### PR TITLE
IL: Add ACA Adults Program

### DIFF
--- a/programs/programs/il/__init__.py
+++ b/programs/programs/il/__init__.py
@@ -1,8 +1,10 @@
 from .medicaid.family_care.calculator import FamilyCare
 from .medicaid.moms_and_babies.calculator import MomsAndBabies
+from .medicaid.aca_adults.calculator import AcaAdults
 from ..calc import ProgramCalculator
 
 il_calculators: dict[str, type[ProgramCalculator]] = {
     "il_family_care": FamilyCare,
     "il_moms_and_babies": MomsAndBabies,
+    "il_aca_adults": AcaAdults,
 }

--- a/programs/programs/il/medicaid/aca_adults/calculator.py
+++ b/programs/programs/il/medicaid/aca_adults/calculator.py
@@ -1,0 +1,51 @@
+from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
+from programs.programs.helpers import medicaid_eligible
+import programs.programs.messages as messages
+from programs.programs.mixins import FplIncomeCheckMixin
+
+
+class AcaAdults(ProgramCalculator, FplIncomeCheckMixin):
+    member_amount = 474 * 12  # $474/month
+    min_age = 19
+    max_age = 64
+    caretaker_roles = [
+        "headOfHousehold",
+        "spouse",
+        "domesticPartner",
+        "parent",
+        "fosterParent",
+    ]
+    dependencies = ["age", "household_size", "relationship", "pregnant", "income_amount", "income_frequency"]
+
+    def household_eligible(self, e: Eligibility):
+        # Must have base Medicaid eligibility
+        e.condition(medicaid_eligible(self.data), messages.must_have_benefit("Medicaid"))
+
+        # Check income against 138% FPL (includes 5% disregard)
+        self.check_fpl_income(e, 1.38)
+
+        # Must NOT be eligible for FamilyCare
+        family_care_eligible = "il_family_care" in self.data and self.data["il_family_care"].eligible
+        e.condition(not family_care_eligible, messages.must_not_have_benefit("FamilyCare"))
+
+        # Must NOT be eligible for Moms & Babies
+        moms_and_babies_eligible = "il_moms_and_babies" in self.data and self.data["il_moms_and_babies"].eligible
+        e.condition(not moms_and_babies_eligible, messages.must_not_have_benefit("Moms & Babies"))
+
+    def member_eligible(self, e: MemberEligibility):
+        member = e.member
+
+        # Must be age 19-64
+        e.condition(member.age >= self.min_age and member.age <= self.max_age)
+
+        # Must NOT be pregnant
+        e.condition(not member.pregnant)
+
+        # Must NOT be a parent/caretaker of children
+        is_caretaker = member.relationship in self.caretaker_roles
+        has_children = (
+            self.screen.num_children(age_max=18, child_relationship=["child", "fosterChild", "stepChild", "grandChild"])
+            > 0
+        )
+
+        e.condition(not (is_caretaker and has_children))

--- a/programs/programs/il/medicaid/family_care/calculator.py
+++ b/programs/programs/il/medicaid/family_care/calculator.py
@@ -1,9 +1,10 @@
 from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
 from programs.programs.helpers import medicaid_eligible
 import programs.programs.messages as messages
+from programs.programs.mixins import FplIncomeCheckMixin
 
 
-class FamilyCare(ProgramCalculator):
+class FamilyCare(ProgramCalculator, FplIncomeCheckMixin):
     member_amount = 474 * 12
     max_child_age = 18
     fpl_percent = 1.38
@@ -15,12 +16,8 @@ class FamilyCare(ProgramCalculator):
         # Must have base Medicaid eligibility
         e.condition(medicaid_eligible(self.data), messages.must_have_benefit("Medicaid"))
 
-        # Income must be at or below 138% FPL
-        fpl = self.program.year
-        income_limit = int(self.fpl_percent * fpl.get_limit(self.screen.household_size))
-        gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
-
-        e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+        # Check income against 138% FPL (includes 5% disregard)
+        self.check_fpl_income(e, self.fpl_percent)
 
     def member_eligible(self, e: MemberEligibility):
         member = e.member

--- a/programs/programs/il/medicaid/moms_and_babies/calculator.py
+++ b/programs/programs/il/medicaid/moms_and_babies/calculator.py
@@ -1,9 +1,10 @@
 from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility, HouseholdMember
 from programs.programs.helpers import medicaid_eligible
 import programs.programs.messages as messages
+from programs.programs.mixins import FplIncomeCheckMixin
 
 
-class MomsAndBabies(ProgramCalculator):
+class MomsAndBabies(ProgramCalculator, FplIncomeCheckMixin):
     adult_member_amount = 474 * 12  # $474/month for adults
     newborn_member_amount = 284 * 12  # $284/month for newborns
     fpl_percent = 2.13  # 213% FPL
@@ -33,11 +34,7 @@ class MomsAndBabies(ProgramCalculator):
         e.condition(not family_care_eligible, messages.must_not_have_benefit("FamilyCare"))
 
         # Income must be at or below 213% FPL
-        fpl = self.program.year
-        income_limit = int(self.fpl_percent * fpl.get_limit(self.screen.household_size))
-        gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
-
-        e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+        self.check_fpl_income(e, self.fpl_percent)
 
         # Must have eligible adult
         e.condition(self._has_eligible_adult(self.screen.household_members.all()))

--- a/programs/programs/mixins.py
+++ b/programs/programs/mixins.py
@@ -1,0 +1,26 @@
+from programs.programs.calc import Eligibility
+import programs.programs.messages as messages
+
+
+class FplIncomeCheckMixin:
+    """
+    Mixin for programs that check household income against Federal Poverty Level percentages.
+    """
+
+    def check_fpl_income(self, e: Eligibility, fpl_percent: float) -> None:
+        """
+        Check household income against FPL percentage.
+
+        Args:
+            e: Eligibility object for condition checks
+            fpl_percent: FPL percentage to check (e.g., 1.38 for 138% FPL)
+        """
+        # Calculate income limit
+        fpl = self.program.year
+        income_limit = int(fpl_percent * fpl.get_limit(self.screen.household_size))
+
+        # Calculate gross income
+        gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
+
+        # Add eligibility condition
+        e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))


### PR DESCRIPTION
## Context & Motivation
<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->
Implements ACA Adults as separate calculator with base Medicaid eligibility check. Provides Medicaid coverage for childless adults aged 19-64 at or below 138% FPL who don't qualify for FamilyCare or Moms and Babies programs.

[benefits-api#1083](https://app.zenhub.com/workspaces/myfriendben-652eb93b7dc40e0935103f4c/issues/gh/myfriendben/benefits-api/1083)

## Changes Made
<!-- Required: What specifically changed? Be concrete and specific -->
- Create `AcaAdults` calculator with age, pregnancy, and caretaker exclusion checks
- Add `FplIncomeCheckMixin` for reusable FPL income checking logic across programs
- Register `il_aca_adults` in IL calculators with dependencies on FamilyCare and Moms & Babies
- Refactor existing IL Medicaid programs to use shared FPL mixin

<img width="939" height="181" alt="Screenshot 2025-08-14 at 3 47 26 PM" src="https://github.com/user-attachments/assets/ba5f5d71-c32d-4759-a520-eb15a9feff74" />

## Testing
<!-- Steps needed to test this PR locally -->
- **Migrations to run**: None
- **Configuration updates needed**: None
- **Environment variables/settings to add**: None
- **Manual testing steps**:
    * Add program mentioned in **Deployment** steps via the admin console

## Deployment
<!-- Steps needed AFTER merging to get this live -->
- **Run script**: None
- **Update production config**: None
- **Admin updates needed**:
    * Add IL ACA Adults program
- **Notify team/users of**: New Illinois ACA Adults program now available for childless adults in the calculator