### PR TITLE
1086 il add lifeline

### DIFF
--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -2304,6 +2304,21 @@ class IlConfigurationData(ConfigurationData):
                 "_default_message": "Food and Nutrition",
             },
         },
+        "housingAndUtilities": {
+            "benefits": {
+                "lifeline": {
+                    "name": {"_label": "housingAndUtilities.lifeline", "_default_message": "Lifeline: "},
+                    "description": {
+                        "_label": "housingAndUtilities.lifeline_desc",
+                        "_default_message": "Phone or internet discount",
+                    },
+                },
+            },
+            "category_name": {
+                "_label": "housing",
+                "_default_message": "Housing and Utilities",
+            },
+        },
     }
 
     consent_to_contact = {


### PR DESCRIPTION
## Context & Motivation
Implements Lifeline for Illinois.
<img width="1281" height="137" alt="image" src="https://github.com/user-attachments/assets/ee05dadc-3fe7-48d9-b0ef-b8e569d1d992" />

[benefits-api#1086](https://github.com/MyFriendBen/benefits-api/issues/1086)

## Changes Made
Add "lifeline" to Illinois white-label

## Testing
Manual testing steps:
Add program mentioned in Deployment steps via the admin console


## Deployment
1. Update production config: `python manage.py add_config il`
2. Add `il_housing `category in Translation Admin
3.  Run script: `python manage.py transfer il lifeline` ("Transfer programs from one white label to another")
4. Update programs in Admin site (External name - il_lifeline), select year 2025 and `il_housing ` category


