### PR TITLE
NC: Fix NC TANF household size issue

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -108,6 +108,9 @@ class Medicaid(Member):
 class Ssi(Member):
     field = "ssi"
 
+    def value(self):
+        return self.member.calc_gross_income("yearly", ["sSI"])
+
 
 class IsDisabledDependency(Member):
     field = "is_disabled"


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes https://github.com/MyFriendBen/benefits-calculator/issues/1813
- Related PR: Created a [PR](https://github.com/PolicyEngine/policyengine-us/pull/6424) on the PolicyEngine side at the same time to resolve the issue.

## Changes Made

Include member SSI value in PE input data

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: 
  1. Use the two households data listed in [this issue](https://github.com/MyFriendBen/benefits-calculator/issues/1813), 
  2. Verify the SSI value of each member in pe input data is same as user input

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations: I assume the "ssi" key isn’t currently in use. Let me know if we should reserve it for future use.
