### PR TITLE
Bug: fix broken urgent need type link

### DIFF
--- a/translations/templates/urgent_needs/list.html
+++ b/translations/templates/urgent_needs/list.html
@@ -53,11 +53,13 @@
                   class="dropdown-item"
                   >Link</a
                 >
+                {% if urgent_need.category_type %}
                 <a
-                  href="/api/translations/admin/{{ urgent_need.type.id }}"
+                  href="/api/translations/admin/{{ urgent_need.category_type.name.id }}"
                   class="dropdown-item"
                   >Type</a
                 >
+                {% endif %}
                 <a
                   href="/api/translations/admin/{{ urgent_need.warning.id }}"
                   class="dropdown-item"


### PR DESCRIPTION
## Context & Motivation

The admin panel has a broken link for Urgent Need translation `type`. More details in [Linear](https://linear.app/myfriendben/issue/MFB-191/admin-fix-urgent-need-type-edit-404).

- Fixes #MFB-191

## Changes Made

The template was referencing the old `type` field that was removed in migration 0112. The field was renamed to `category_type`, which is a `ForeignKey` to `UrgentNeedType`. The fix updates the template to:
  1. Use `urgent_need.category_type` instead of `urgent_need.type`
  2. Access the name's `id` through `category_type.name.id` since `UrgentNeedType` has a name field that's a `ForeignKey` to `Translation`
  3. Add a conditional check since `category_type`` can be null

- ...

## Testing

1. Visit https://api.myfriendben.org/api/translations/admin/urgent_needs
2. Click `Go To` for any of the rows
3. Click `Type`

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps: See above

## Deployment

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A
- Notify team/users of: N/A

## Notes for Reviewers

 N/A
