### PR TITLE
IL: Early Intervention Urgent Need

### DIFF
--- a/programs/programs/urgent_needs/__init__.py
+++ b/programs/programs/urgent_needs/__init__.py
@@ -1,9 +1,11 @@
 from .base import UrgentNeedFunction
 from .co import co_urgent_need_functions
 from .ma import ma_urgent_need_functions
+from .il import il_urgent_need_functions
 
 
 urgent_need_functions: dict[str, type[UrgentNeedFunction]] = {
     **co_urgent_need_functions,
     **ma_urgent_need_functions,
+    **il_urgent_need_functions,
 }

--- a/programs/programs/urgent_needs/il/__init__.py
+++ b/programs/programs/urgent_needs/il/__init__.py
@@ -1,3 +1,4 @@
+from .il_early_intervention import IlEarlyIntervention
 from ..base import UrgentNeedFunction
 
-il_urgent_need_functions: dict[str, type[UrgentNeedFunction]] = {}
+il_urgent_need_functions: dict[str, type[UrgentNeedFunction]] = {"il_early_interv": IlEarlyIntervention}

--- a/programs/programs/urgent_needs/il/il_early_intervention.py
+++ b/programs/programs/urgent_needs/il/il_early_intervention.py
@@ -1,0 +1,12 @@
+from ..base import UrgentNeedFunction
+
+
+class IlEarlyIntervention(UrgentNeedFunction):
+    dependencies = ["age"]
+    max_age = 2
+
+    def eligible(self):
+        """
+        Has child age 0-2
+        """
+        return self.screen.num_children(age_max=self.max_age) > 0


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-204](https://linear.app/myfriendben/issue/MFB-204/il-additional-resources-illinois-early-intervention)

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Sets lllinois up to have urgent need functions
- Adds new urgent need function `il_early_interv` for Illinois Early Intervention, requiring the household to have at least one child age 2 or under.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: See deployment steps below.

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: Lots: 
- TODO
- Notify team/users of: Someone will need to add all of the translations fields after adding the urgent need.
