### PR TITLE
IL: Add check for existing All Kids benefit

### DIFF
--- a/programs/programs/il/medicaid/all_kids/calculator.py
+++ b/programs/programs/il/medicaid/all_kids/calculator.py
@@ -21,3 +21,6 @@ class AllKids(ProgramCalculator, FplIncomeCheckMixin):
 
         # Must not have Medicaid
         e.condition(not member.has_benefit("medicaid"))
+
+        # Must not already have All Kids (chp)
+        e.condition(not member.has_benefit("chp"))


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: [MFB-195](https://linear.app/myfriendben/issue/MFB-195/il-when-user-selects-all-kids-tile-do-not-show-all-kids-as-a-benefit) (don't see a GH issue attached to this one)

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add check in `AllKids.member_eligible` for All Kids (chp) benefit

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
    1. Create a 2 person household:
        1. HoH - Income: $2500/mo.
        2. Child - Health Insurance: All Kids
    2. View results
    3. Verify that All Kids does not show up as an eligible benefit

**Example HH:**

<img width="1005" height="667" alt="Screenshot 2025-08-27 at 10 10 49 AM" src="https://github.com/user-attachments/assets/105b98b3-69e4-4708-8ae3-17dc7d68c438" />

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: None
- Future considerations: None
