### PR TITLE
IL: Add Illinois Housing Development Authority Foreclosure Prevention Counseling

### DIFF
--- a/programs/programs/urgent_needs/il/__init__.py
+++ b/programs/programs/urgent_needs/il/__init__.py
@@ -1,10 +1,14 @@
 from .il_early_intervention import IlEarlyIntervention
 from .il_cook_foreclosure import IlCookForeclosure
 from .rentervention import Rentervention
+from .housing_development_authority_foreclosure_prevention_counseling import (
+    HousingDevelopmentAuthorityForeclosurePreventionCounseling,
+)
 from ..base import UrgentNeedFunction
 
 il_urgent_need_functions: dict[str, type[UrgentNeedFunction]] = {
     "il_early_interv": IlEarlyIntervention,
     "il_cook_foreclosure": IlCookForeclosure,
     "il_rentervention": Rentervention,
+    "il_save_home": HousingDevelopmentAuthorityForeclosurePreventionCounseling,
 }

--- a/programs/programs/urgent_needs/il/housing_development_authority_foreclosure_prevention_counseling.py
+++ b/programs/programs/urgent_needs/il/housing_development_authority_foreclosure_prevention_counseling.py
@@ -1,0 +1,14 @@
+from ..base import UrgentNeedFunction
+
+
+class HousingDevelopmentAuthorityForeclosurePreventionCounseling(UrgentNeedFunction):
+
+    def eligible(self):
+        """
+        Return True if the household marks need for housing/utilities resource and household has a mortgage expense
+        """
+
+        needs_housing_help = self.screen.needs_housing_help
+        has_mortgage = self.screen.has_expense(["mortgage"])
+
+        return needs_housing_help and has_mortgage


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-197](https://linear.app/myfriendben/issue/MFB-197/il-additional-resources-illinois-housing-development-authority)

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add Illinois Housing Development Authority Foreclosure Prevention Counseling to Illinois Additional Resources programs (housing) 

- Use this external name: il_save_home

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run:
- Configuration updates needed:
- Environment variables/settings to add:
- Manual testing steps:
  - In the Illinois screener, create a household with zip code 60006 (Cook county) with one adult. On step 6 the expenses question, add "Mortage" $1000/month. On step 9 with the needs tiles, select "Help with managing your mortgage, rent, or utilities". On the results page in the "Additional Resources" tab you should see the Illinois Housing Development Authority Foreclosure Prevention Counseling.

<img width="800" height="400" alt="Screenshot 2025-08-27 at 10 21 09 AM" src="https://github.com/user-attachments/assets/0548d62b-f016-4ada-9ab1-aa092ca782c1" />


## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script:
- Update production config:
- Admin updates needed:
  - Add Illinois Housing Development Authority Foreclosure Prevention Counseling program
- Notify team/users of:
