### PR TITLE
IL: Limit BAP eligibility to HH of 3 or fewer

### DIFF
--- a/programs/programs/il/bap/calculator.py
+++ b/programs/programs/il/bap/calculator.py
@@ -1,75 +1,22 @@
-from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
+from programs.programs.calc import ProgramCalculator, Eligibility
+from programs.programs.mixins import IlTransportationMixin
 import programs.programs.messages as messages
 
 
-class IlBenefitAccess(ProgramCalculator):
-    dependencies = [
-        "age",
-        "household_size",
-        "income_amount",
-        "income_frequency",
-        "visually_impaired",
-        "disabled",
-    ]
-
-    presumptive_eligibility_programs = ["ssi", "ssdi"]
-
-    presumptive_eligibility_insurances = ["medicare"]
-
-    minimum_age = 65
-
-    minimum_age_with_disability = 16
-
-    income_by_household_size = {
+class IlBenefitAccess(IlTransportationMixin, ProgramCalculator):
+    income_limit_by_household_size = {
         1: 33_562,
         2: 44_533,
         3: 55_500,
     }
 
-    county_benefit_amounts = {
-        # Chicago Area counties - $75/month ($900/year)
-        "cook": 900,
-        "dupage": 900,
-        "kane": 900,
-        "lake": 900,
-        "mchenry": 900,
-        "will": 900,
-        # $40/month counties ($480/year)
-        "madison": 480,
-        "peoria": 480,
-        "sangamon": 480,
-        # Jackson county - $25/month ($300/year)
-        "jackson": 300,
-    }
-
     def household_eligible(self, e: Eligibility):
-        presumptive_eligible = self.screen.has_benefit_from_list(
-            self.presumptive_eligibility_programs
-        ) or self.screen.has_insurance_types(self.presumptive_eligibility_insurances)
+        presumptive_eligible = self.check_presumptive_eligibility()
 
         household_size = self.screen.household_size
-        income_limit = self.income_by_household_size.get(min(household_size, 3), self.income_by_household_size[3])
         gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
 
+        income_limit = self.income_limit_by_household_size[min(household_size, 3)]
         income_eligible = gross_income <= income_limit
-        household_eligible = household_size <= 3
 
-        e.condition(presumptive_eligible or (income_eligible and household_eligible))
-
-    def member_eligible(self, e: MemberEligibility):
-        member = e.member
-
-        # Check age eligibility
-        age_eligible = member.age >= self.minimum_age
-
-        disability_eligible = member.age >= self.minimum_age_with_disability and (
-            member.visually_impaired or member.disabled
-        )
-
-        e.condition(age_eligible or disability_eligible)
-
-    def member_value(self, member):
-        county = self.screen.county.lower() if self.screen.county else ""
-
-        # Default to positive value to enable manual "Varies" override, since county_benefit_amounts are not comprehensive
-        return self.county_benefit_amounts.get(county, 1)
+        e.condition((household_size <= 3) and (presumptive_eligible or income_eligible))

--- a/programs/programs/il/bap/calculator.py
+++ b/programs/programs/il/bap/calculator.py
@@ -43,20 +43,18 @@ class IlBenefitAccess(ProgramCalculator):
     }
 
     def household_eligible(self, e: Eligibility):
-        # Check presumptive eligibility
         presumptive_eligible = self.screen.has_benefit_from_list(
             self.presumptive_eligibility_programs
         ) or self.screen.has_insurance_types(self.presumptive_eligibility_insurances)
 
-        # Check income eligibility
         household_size = self.screen.household_size
         income_limit = self.income_by_household_size.get(min(household_size, 3), self.income_by_household_size[3])
-
         gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
 
         income_eligible = gross_income <= income_limit
+        household_eligible = household_size <= 3
 
-        e.condition(presumptive_eligible or income_eligible)
+        e.condition(presumptive_eligible or (income_eligible and household_eligible))
 
     def member_eligible(self, e: MemberEligibility):
         member = e.member

--- a/programs/programs/mixins.py
+++ b/programs/programs/mixins.py
@@ -1,4 +1,4 @@
-from programs.programs.calc import Eligibility
+from programs.programs.calc import Eligibility, MemberEligibility
 import programs.programs.messages as messages
 
 
@@ -24,3 +24,38 @@ class FplIncomeCheckMixin:
 
         # Add eligibility condition
         e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+
+
+class IlTransportationMixin:
+    dependencies = [
+        "age",
+        "household_size",
+        "income_amount",
+        "income_frequency",
+        "visually_impaired",
+        "disabled",
+    ]
+    presumptive_eligibility_programs = ["ssi", "ssdi"]
+    presumptive_eligibility_insurances = ["medicare"]
+    minimum_age = 65
+    minimum_age_with_disability = 16
+
+    def check_presumptive_eligibility(self):
+        has_presumptive_program = self.screen.has_benefit_from_list(self.presumptive_eligibility_programs)
+        has_presumptive_insurance = self.screen.has_insurance_types(self.presumptive_eligibility_insurances)
+        return has_presumptive_program or has_presumptive_insurance
+
+    def member_eligible(self, e: MemberEligibility):
+        member = e.member
+
+        age_eligible = member.age >= self.minimum_age
+
+        has_minimum_age_with_disability = member.age >= self.minimum_age_with_disability
+        has_eligible_disability = member.visually_impaired or member.disabled
+        disability_eligible = has_minimum_age_with_disability and has_eligible_disability
+
+        e.condition(age_eligible or disability_eligible)
+
+    def member_value(self, member):
+        # Default to positive value to enable manual "Varies" override
+        return 1


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: https://linear.app/myfriendben/issue/MFB-189/il-add-benefit-access-program

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add household size check to calculator
- Cleaned up some (unnecessary, IMO) comments

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
    1. Create a household with 3 people, where HoH is 65+ or blind/disabled, with an income <$33k/year
    2. Verify that HH is eligible
    3. Add a 4th HH member
    4. Verify that HH is no longer eligible

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: None
- Future considerations: None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated IL Benefit Access eligibility rules: income-based eligibility applies only to households of 3 or fewer; households with 4+ members qualify only through presumptive criteria. No changes to income limits themselves; calculation continues to cap at 3 household members. This clarifies outcomes for larger households and aligns determinations with policy. No user interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->