### PR TITLE
IL: Limit LTRF to specific counties

### DIFF
--- a/programs/programs/il/bap/calculator.py
+++ b/programs/programs/il/bap/calculator.py
@@ -1,75 +1,26 @@
-from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
+from programs.programs.calc import ProgramCalculator, Eligibility
+from programs.programs.mixins import IlTransportationMixin
 import programs.programs.messages as messages
 
 
-class IlBenefitAccess(ProgramCalculator):
-    dependencies = [
-        "age",
-        "household_size",
-        "income_amount",
-        "income_frequency",
-        "visually_impaired",
-        "disabled",
-    ]
-
-    presumptive_eligibility_programs = ["ssi", "ssdi"]
-
-    presumptive_eligibility_insurances = ["medicare"]
-
-    minimum_age = 65
-
-    minimum_age_with_disability = 16
-
-    income_by_household_size = {
+class IlBenefitAccess(IlTransportationMixin, ProgramCalculator):
+    income_limit_by_household_size = {
         1: 33_562,
         2: 44_533,
         3: 55_500,
     }
 
-    county_benefit_amounts = {
-        # Chicago Area counties - $75/month ($900/year)
-        "cook": 900,
-        "dupage": 900,
-        "kane": 900,
-        "lake": 900,
-        "mchenry": 900,
-        "will": 900,
-        # $40/month counties ($480/year)
-        "madison": 480,
-        "peoria": 480,
-        "sangamon": 480,
-        # Jackson county - $25/month ($300/year)
-        "jackson": 300,
-    }
-
     def household_eligible(self, e: Eligibility):
-        presumptive_eligible = self.screen.has_benefit_from_list(
-            self.presumptive_eligibility_programs
-        ) or self.screen.has_insurance_types(self.presumptive_eligibility_insurances)
+        presumptive_eligible = self.check_presumptive_eligibility()
 
         household_size = self.screen.household_size
-        income_limit = self.income_by_household_size.get(min(household_size, 3), self.income_by_household_size[3])
         gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
 
+        income_limit = self.income_limit_by_household_size.get(
+            min(household_size, 3), self.income_limit_by_household_size[3]
+        )
         income_eligible = gross_income <= income_limit
+
         household_eligible = household_size <= 3
 
         e.condition(presumptive_eligible or (income_eligible and household_eligible))
-
-    def member_eligible(self, e: MemberEligibility):
-        member = e.member
-
-        # Check age eligibility
-        age_eligible = member.age >= self.minimum_age
-
-        disability_eligible = member.age >= self.minimum_age_with_disability and (
-            member.visually_impaired or member.disabled
-        )
-
-        e.condition(age_eligible or disability_eligible)
-
-    def member_value(self, member):
-        county = self.screen.county.lower() if self.screen.county else ""
-
-        # Default to positive value to enable manual "Varies" override, since county_benefit_amounts are not comprehensive
-        return self.county_benefit_amounts.get(county, 1)

--- a/programs/programs/il/transit_reduced_fare/calculator.py
+++ b/programs/programs/il/transit_reduced_fare/calculator.py
@@ -1,36 +1,22 @@
 from programs.programs.il.bap.calculator import IlBenefitAccess
-from programs.programs.calc import Eligibility
+from programs.programs.calc import ProgramCalculator, Eligibility
+from programs.programs.mixins import IlTransportationMixin
 
 
-class IlTransitReducedFare(IlBenefitAccess):
-    county_benefit_amounts = {
-        # Chicago Area counties - $40/month ($480/year)
-        "cook": 480,
-        "dupage": 480,
-        "kane": 480,
-        "lake": 480,
-        "mchenry": 480,
-        "will": 480,
-        # Other counties
-        "madison": 240,
-        "peoria": 240,
-        "sangamon": 228,
-        "jackson": 120,
-    }
+class IlTransitReducedFare(IlTransportationMixin, ProgramCalculator):
+    eligible_counties = ["cook", "dupage", "kane", "lake", "mchenry", "will"]
 
     def household_eligible(self, e: Eligibility):
-        # Check presumptive eligibility
-        presumptive_eligible = self.screen.has_benefit_from_list(
-            self.presumptive_eligibility_programs
-        ) or self.screen.has_insurance_types(self.presumptive_eligibility_insurances)
+        presumptive_eligible = self.check_presumptive_eligibility()
 
-        # Check income eligibility
         household_size = self.screen.household_size
-        income_limit = self.income_by_household_size.get(min(household_size, 3), self.income_by_household_size[3])
-
         gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
+        bap_income_limit = IlBenefitAccess.income_limit_by_household_size.get(
+            min(household_size, 3), IlBenefitAccess.income_limit_by_household_size[3]
+        )
+        income_eligible = gross_income > bap_income_limit
 
-        # Income must be above the Benefit Access limit
-        income_eligible = gross_income > income_limit
+        county = (self.screen.county or "").lower()
+        county_eligible = county in self.eligible_counties
 
-        e.condition(presumptive_eligible or income_eligible)
+        e.condition(presumptive_eligible or (income_eligible and county_eligible))

--- a/programs/programs/mixins.py
+++ b/programs/programs/mixins.py
@@ -1,4 +1,4 @@
-from programs.programs.calc import Eligibility
+from programs.programs.calc import Eligibility, MemberEligibility
 import programs.programs.messages as messages
 
 
@@ -24,3 +24,38 @@ class FplIncomeCheckMixin:
 
         # Add eligibility condition
         e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+
+
+class IlTransportationMixin:
+    dependencies = [
+        "age",
+        "household_size",
+        "income_amount",
+        "income_frequency",
+        "visually_impaired",
+        "disabled",
+    ]
+    presumptive_eligibility_programs = ["ssi", "ssdi"]
+    presumptive_eligibility_insurances = ["medicare"]
+    minimum_age = 65
+    minimum_age_with_disability = 16
+
+    def check_presumptive_eligibility(self):
+        has_presumptive_program = self.screen.has_benefit_from_list(self.presumptive_eligibility_programs)
+        has_presumptive_insurance = self.screen.has_insurance_types(self.presumptive_eligibility_insurances)
+        return has_presumptive_program or has_presumptive_insurance
+
+    def member_eligible(self, e: MemberEligibility):
+        member = e.member
+
+        age_eligible = member.age >= self.minimum_age
+
+        has_minimum_age_with_disability = member.age >= self.minimum_age_with_disability
+        has_eligible_disability = member.visually_impaired or member.disabled
+        disability_eligible = has_minimum_age_with_disability and has_eligible_disability
+
+        e.condition(age_eligible or disability_eligible)
+
+    def member_value(self, member):
+        # Default to positive value to enable manual "Varies" override
+        return 1


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: https://linear.app/myfriendben/issue/MFB-190/il-add-local-transit-reduced-fare

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add eligible county check to LTRF calculator
- Extract a mixin out of BAP and LTRF calculators

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: None

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: Ensure that both BAP and LTRF programs' estimated value is overridden with `Varies`
- Notify team/users of: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: None
- Future considerations: None
