### PR TITLE
IL + Central: Add county to IL PE Household

### DIFF
--- a/programs/programs/il/pe/member.py
+++ b/programs/programs/il/pe/member.py
@@ -47,6 +47,7 @@ class IlAca(tax.Aca):
     pe_inputs = [
         *tax.Aca.pe_inputs,
         dependency.IlStateCodeDependency,
+        dependency.IlCountyDependency,
     ]
 
 

--- a/programs/programs/policyengine/calculators/dependencies/household.py
+++ b/programs/programs/policyengine/calculators/dependencies/household.py
@@ -38,7 +38,7 @@ class ZipCodeDependency(Household):
     dependencies = ["zipcode"]
 
     def value(self):
-        return self.screen.zipcode
+        return int(self.screen.zipcode)
 
 
 class IsInPublicHousingDependency(Household):

--- a/programs/programs/policyengine/calculators/dependencies/household.py
+++ b/programs/programs/policyengine/calculators/dependencies/household.py
@@ -26,11 +26,22 @@ class IlStateCodeDependency(StateCode):
     state = "IL"
 
 
-class NcCountyDependency(Household):
+class CountyDependency(Household):
     field = "county_str"
+    dependencies = ["county"]
+    state_dependency_class = None  # Override in subclasses
 
     def value(self):
-        return self.screen.county.replace(" ", "_").upper() + "_NC"
+        state_code = self.state_dependency_class.state
+        return self.screen.county.replace(" ", "_").upper() + f"_{state_code}"
+
+
+class NcCountyDependency(CountyDependency):
+    state_dependency_class = NcStateCodeDependency
+
+
+class IlCountyDependency(CountyDependency):
+    state_dependency_class = IlStateCodeDependency
 
 
 class ZipCodeDependency(Household):
@@ -38,7 +49,7 @@ class ZipCodeDependency(Household):
     dependencies = ["zipcode"]
 
     def value(self):
-        return int(self.screen.zipcode)
+        return self.screen.zipcode
 
 
 class IsInPublicHousingDependency(Household):


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

We are receiving estimated values for ACA in IL that are significantly higher than the estimate with KPP.

  Before vs After

  | Metric          | Before (Bug) | After (Fixed) | KFF    |
  |-----------------|--------------|---------------|--------|
  | Annual PTC      | $7,072       | $4,332        | $4,332 |
  | Monthly PTC     | $589         | $361          | $361   |
  | SLCSP (implied) | ~$714        | ~$345         | ~$345  |

**Root Cause**: PolicyEngine couldn't properly map zip codes to rating areas without explicit county information, causing it to use wrong premium benchmarks.

- Resolves MFB-182
- Related PR: [link if applicable]

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

1. Added county dependency system - Created DRY `CountyDependency` base class that formats county data as "COUNTY_STATE" (e.g., "COOK_IL")
2. Added IL county support - Include `IlCountyDependency` in IL ACA calculator inputs to send explicit county information to PolicyEngine
3. Refactored existing code - Updated `NcCountyDependency` to use the new base class and eliminated code duplication between state county dependencies

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: NA
- Configuration updates needed: NA
- Environment variables/settings to add: NA
- Manual testing steps:

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script:
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:
