### PR TITLE
IL: Adjust Medicaid FPL check for pregnant members

### DIFF
--- a/programs/programs/il/medicaid/aca_adults/calculator.py
+++ b/programs/programs/il/medicaid/aca_adults/calculator.py
@@ -1,10 +1,10 @@
 from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
 from programs.programs.helpers import medicaid_eligible
 import programs.programs.messages as messages
-from programs.programs.mixins import FplIncomeCheckMixin
+from programs.programs.mixins import IlMedicaidFplIncomeCheckMixin
 
 
-class AcaAdults(ProgramCalculator, FplIncomeCheckMixin):
+class AcaAdults(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
     member_amount = 474 * 12  # $474/month
     min_age = 19
     max_age = 64

--- a/programs/programs/il/medicaid/all_kids/calculator.py
+++ b/programs/programs/il/medicaid/all_kids/calculator.py
@@ -1,13 +1,13 @@
 from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
 from programs.programs.helpers import medicaid_eligible
 import programs.programs.messages as messages
-from programs.programs.mixins import FplIncomeCheckMixin
+from programs.programs.mixins import IlMedicaidFplIncomeCheckMixin
 
 
-class AllKids(ProgramCalculator, FplIncomeCheckMixin):
+class AllKids(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
     member_amount = 284 * 12  # $284/month
     max_age = 18  # Under 19
-    dependencies = ["age", "household_size", "income_amount", "income_frequency"]
+    dependencies = ["age", "household_size", "pregnant", "income_amount", "income_frequency"]
 
     def household_eligible(self, e: Eligibility):
         # Check income against 318% FPL

--- a/programs/programs/il/medicaid/family_care/calculator.py
+++ b/programs/programs/il/medicaid/family_care/calculator.py
@@ -1,10 +1,10 @@
 from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility
 from programs.programs.helpers import medicaid_eligible
 import programs.programs.messages as messages
-from programs.programs.mixins import FplIncomeCheckMixin
+from programs.programs.mixins import IlMedicaidFplIncomeCheckMixin
 
 
-class FamilyCare(ProgramCalculator, FplIncomeCheckMixin):
+class FamilyCare(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
     member_amount = 474 * 12
     max_child_age = 18
     fpl_percent = 1.38

--- a/programs/programs/il/medicaid/moms_and_babies/calculator.py
+++ b/programs/programs/il/medicaid/moms_and_babies/calculator.py
@@ -1,10 +1,10 @@
 from programs.programs.calc import MemberEligibility, ProgramCalculator, Eligibility, HouseholdMember
 from programs.programs.helpers import medicaid_eligible
 import programs.programs.messages as messages
-from programs.programs.mixins import FplIncomeCheckMixin
+from programs.programs.mixins import IlMedicaidFplIncomeCheckMixin
 
 
-class MomsAndBabies(ProgramCalculator, FplIncomeCheckMixin):
+class MomsAndBabies(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
     adult_member_amount = 474 * 12  # $474/month for adults
     newborn_member_amount = 284 * 12  # $284/month for newborns
     fpl_percent = 2.13  # 213% FPL

--- a/programs/programs/mixins.py
+++ b/programs/programs/mixins.py
@@ -2,22 +2,27 @@ from programs.programs.calc import Eligibility, MemberEligibility
 import programs.programs.messages as messages
 
 
-class FplIncomeCheckMixin:
+class IlMedicaidFplIncomeCheckMixin:
     """
-    Mixin for programs that check household income against Federal Poverty Level percentages.
+    Mixin for Illinois Medicaid programs that check household income against Federal Poverty Level percentages.
+    Counts pregnant household members as 2 people when calculating household size.
     """
 
     def check_fpl_income(self, e: Eligibility, fpl_percent: float) -> None:
         """
-        Check household income against FPL percentage.
+        Check household income against FPL percentage with pregnancy-adjusted household size.
 
         Args:
             e: Eligibility object for condition checks
             fpl_percent: FPL percentage to check (e.g., 1.38 for 138% FPL)
         """
-        # Calculate income limit
+        # Calculate pregnancy-adjusted household size
+        pregnant_count = self.screen.household_members.filter(pregnant=True).count()
+        adjusted_household_size = self.screen.household_size + pregnant_count
+
+        # Calculate income limit using adjusted household size
         fpl = self.program.year
-        income_limit = int(fpl_percent * fpl.get_limit(self.screen.household_size))
+        income_limit = int(fpl_percent * fpl.get_limit(adjusted_household_size))
 
         # Calculate gross income
         gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

These changes update the FPL check in IL calculators to count pregnant members as 2 people when calculating household size.

- Fixes: https://linear.app/myfriendben/issue/MFB-170/il-add-all-kids

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Adjust `check_fpl_income` function to count pregnant members twice
- Rename `FplIncomeCheckMixin` -> `IlMedicaidFplIncomeCheckMixin`
- Add "pregnant" dependency to All Kids program

**Screen:**

<img width="1010" height="822" alt="Screenshot 2025-09-03 at 10 15 01 AM" src="https://github.com/user-attachments/assets/f79d0578-f715-4b71-96ab-eae5f82ab946" />

**Results:**

<img width="1240" height="144" alt="Screenshot 2025-09-03 at 10 14 14 AM" src="https://github.com/user-attachments/assets/6ed3ffa0-5d16-4b51-b1e7-52ec3956dd9e" />

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps:
    * Create a 2 person HH with the following characteristics:
        - Head of Household
            * Conditions: Pregnant
            * Income: $5,620.00 every month
            * Health Insurance: I don't have or know if I have health insurance
        - Child
            * Health Insurance: They don't have or know if they have health insurance
    * Validate that All Kids program is displayed in eligibility results

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Illinois Moms & Babies eligibility now identifies eligible adults and newborns, with rules for age, relationships, and pregnancy. Newborns receive dedicated benefits.
- Bug Fixes
  - FPL calculations for Illinois Medicaid now count each pregnant person as two in household size, improving accuracy.
- Refactor
  - ACA Adults, All Kids, and FamilyCare in Illinois now use a unified Illinois-specific income eligibility checker for consistency across programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->