### PR TITLE
IL: Add HubSpot Configuration

### DIFF
--- a/integrations/services/cms_integration.py
+++ b/integrations/services/cms_integration.py
@@ -138,10 +138,16 @@ class MaHubSpotIntegration(HubSpotIntegration):
     OWNER_ID = "79223440"
 
 
+class IlHubSpotIntegration(HubSpotIntegration):
+    STATE = "IL"
+    OWNER_ID = "80630223"
+
+
 CMS_INTEGRATIONS = {
     "co_hubspot": CoHubSpotIntegration,
     "nc_hubspot": NcHubSpotIntegration,
     "ma_hubspot": MaHubSpotIntegration,
+    "il_hubspot": IlHubSpotIntegration,
 }
 
 


### PR DESCRIPTION
## Context & Motivation

  Adding Illinois (IL) HubSpot configuration to enable CRM integration for IL users. This follows the existing pattern used by CO, NC, and MA white labels to
  track user contacts in HubSpot with state-specific owner assignment.

  ## Changes Made

  - Added `IlHubSpotIntegration` class in `/benefits-be/integrations/services/cms_integration.py`
    - Inherits from `HubSpotIntegration` base class
    - Sets `STATE = "IL"` for HubSpot contact field
    - Sets `OWNER_ID = "80630223"` (same as CO per request)
  - Updated `CMS_INTEGRATIONS` registry to include `"il_hubspot": IlHubSpotIntegration`
  - Follows exact same pattern as existing state integrations (CO, NC, MA)

  ## Testing

  - Migrations to run: None
  - Configuration updates needed: Set `cms_method = "il_hubspot"` for IL via Django admin
  - Environment variables/settings to add: None (uses existing HUBSPOT_CENTRAL token)
  - Manual testing steps:
    1. Set IL WhiteLabel cms_method in Django admin
    2. Run `python manage.py health_check il` to verify no cms_method errors
    3. Test IL user sign-up creates HubSpot contact with STATE="IL" and correct owner

  ## Deployment

  - Run script: None
  - Update production config: None
  - Admin updates needed: Set `cms_method = "il_hubspot"` for Illinois WhiteLabel in Django admin
  - Notify team/users of: IL users will now be automatically added to HubSpot CRM

  ## Notes for Reviewers

  - Implementation follows identical pattern to existing state integrations
  - No new dependencies or environment variables required
  - Uses same HubSpot owner ID as Colorado (80630223 which is Josh)
  - Future considerations: Who do we want to assign MA, IL, and CO contacts to?