### PR TITLE
IL: Add current benefit functionality to SNAP

### DIFF
--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -2282,7 +2282,7 @@ class IlConfigurationData(ConfigurationData):
     category_benefits = {
         "foodAndNutrition": {
             "benefits": {
-                "il_snap": {
+                "snap": {
                     "name": {
                         "_label": "foodAndNutritionBenefits.snap",
                         "_default_message": "Supplemental Nutrition Assistance Program (SNAP): ",

--- a/screener/models.py
+++ b/screener/models.py
@@ -338,6 +338,7 @@ class Screen(models.Model):
             "sunbucks": self.has_sunbucks,
             "co_snap": self.has_snap,
             "nc_snap": self.has_snap,
+            "il_snap": self.has_snap,
             "lifeline": self.has_lifeline,
             "acp": self.has_acp,
             "eitc": self.has_eitc,


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

These changes reuse the `has_snap` field on the Screen model to track whether a household already has the SNAP benefit. This is in line with what we're doing in CO and NC.

- Fixes: https://linear.app/myfriendben/issue/MFB-77/il-snap
- Related PR: [link if applicable]

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Update IL configuration to use "snap" instead of "il_snap"
- Update `has_benefit` function to map "il_snap" to existing `has_snap` field

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: N/A
- Configuration updates needed: Yes
- Environment variables/settings to add: N/A
- Manual testing steps:
    * Create a SNAP eligible HH
    * Verify that you see SNAP eligibility in the results
    * Go back and edit the screen to select SNAP as a current benefit
    * Verify that you no longer see SNAP eligibility in the results

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: N/A
- Update production config: Yes
- Admin updates needed: N/A