### PR TITLE
IL: Remove BAP presumptive eligibility

### DIFF
--- a/programs/programs/il/bap/calculator.py
+++ b/programs/programs/il/bap/calculator.py
@@ -13,12 +13,10 @@ class IlBenefitAccess(IlTransportationMixin, ProgramCalculator):
     def household_eligible(self, e: Eligibility):
         e.condition(not self.screen.has_benefit("il_bap"))
 
-        presumptive_eligible = self.check_presumptive_eligibility()
-
         household_size = self.screen.household_size
         gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
 
         income_limit = self.income_limit_by_household_size[min(household_size, 3)]
         income_eligible = gross_income <= income_limit
 
-        e.condition((household_size <= 3) and (presumptive_eligible or income_eligible))
+        e.condition((household_size <= 3) and income_eligible)


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

After additional research, the team found that there is no presumptive eligibility for BAP.

- Fixes: https://linear.app/myfriendben/issue/MFB-189/il-add-benefit-access-program

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Remove presumptive eligibility check from `BenefitAccess` calculator

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps:
    * Create a screen for a HH with very high income but receiving Medicare
    * Verify that you do not see Benefits Access eligibility

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A