### PR TITLE
Display the PolicyEngine API request

### DIFF
--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -87,4 +87,5 @@ class PrivateApiSim(ApiSim):
         self.response_json = res.json()
         self.data = self.response_json["result"]
 
+
 pe_engines: list[Sim] = [PrivateApiSim, ApiSim]

--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -1,3 +1,4 @@
+import json
 from integrations.util.cache import Cache
 from decouple import config
 import requests
@@ -27,8 +28,10 @@ class ApiSim(Sim):
     pe_url = "https://api.policyengine.org/us/calculate"
 
     def __init__(self, data) -> None:
+        self.request_payload = data
         response = requests.post(self.pe_url, json=data)
-        self.data = response.json()["result"]
+        self.response_json = response.json()
+        self.data = self.response_json["result"]
 
     def value(self, unit, sub_unit, variable, period):
         return self.data[unit][sub_unit][variable][period]
@@ -79,5 +82,9 @@ class PrivateApiSim(ApiSim):
 
         self.data = res.json()["result"]
 
+        self.request_payload = data
+        res = requests.post(self.pe_url, json=data, headers=headers)
+        self.response_json = res.json()
+        self.data = self.response_json["result"]
 
 pe_engines: list[Sim] = [PrivateApiSim, ApiSim]

--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -34,9 +34,9 @@ class ApiSim(Sim):
             res.raise_for_status()
             self.response_json = res.json()
         except requests.RequestException as e:
-            raise RuntimeError(f"{self.method_name} request failed") from e
+            raise RuntimeError(f"{self.method_name} request failed {e}") from e
         except ValueError as e:
-            raise RuntimeError(f"{self.method_name} returned non-JSON") from e
+            raise RuntimeError(f"{self.method_name} returned non-JSON {e}") from e
         if "result" not in self.response_json:
             raise RuntimeError("Missing 'result' key in Policy Engine response")
         self.data = self.response_json["result"]
@@ -92,9 +92,9 @@ class PrivateApiSim(ApiSim):
             res.raise_for_status()
             self.response_json = res.json()
         except requests.RequestException as e:
-            raise RuntimeError(f"{self.method_name} request failed") from e
+            raise RuntimeError(f"{self.method_name} request failed {e}") from e
         except ValueError as e:
-            raise RuntimeError(f"{self.method_name} returned non-JSON") from e
+            raise RuntimeError(f"{self.method_name} returned non-JSON {e}") from e
         if "result" not in self.response_json:
             raise RuntimeError("Missing 'result' key in Policy Engine response")
         self.data = self.response_json["result"]

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -28,7 +28,17 @@ def calc_pe_eligibility(
 
     for Method in pe_engines:
         try:
-            return all_eligibility(Method(input_data), valid_programs)
+            method_instance = Method(input_data)
+            eligibility = all_eligibility(method_instance, valid_programs)
+            result = {
+                "eligibility": eligibility,
+                "_pe_data": {
+                    "request": method_instance.request_payload,
+                    "response": method_instance.response_json,
+                },
+            }
+           
+            return result        
         except Exception as e:
             if settings.DEBUG:
                 print(repr(e))

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -37,8 +37,8 @@ def calc_pe_eligibility(
                     "response": method_instance.response_json,
                 },
             }
-           
-            return result        
+
+            return result
         except Exception as e:
             if settings.DEBUG:
                 print(repr(e))

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -2,27 +2,41 @@ from screener.models import HouseholdMember, Screen
 from .calculators import PolicyEngineCalulator
 from programs.programs.calc import Eligibility
 from .calculators.dependencies.base import DependencyError, Member, TaxUnit
-from typing import List
+from typing import Any, Dict, List, Optional, TypedDict
 from sentry_sdk import capture_exception, capture_message
 from .engines import Sim, pe_engines
 from .calculators.constants import MAIN_TAX_UNIT, SECONDARY_TAX_UNIT
 from django.conf import settings
 
 
+class PEData(TypedDict):
+    request: Optional[Dict[str, Any]]
+    response: Optional[Dict[str, Any]]
+
+
+class EligibilityPEResult(TypedDict):
+    eligibility: Dict[str, Eligibility]
+    _pe_data: PEData
+
+
 def calc_pe_eligibility(
     screen: Screen,
     calculators: dict[str, PolicyEngineCalulator],
-) -> dict[str, Eligibility]:
+) -> EligibilityPEResult:
     valid_programs: dict[str, PolicyEngineCalulator] = {}
 
     for name_abbr, calculator in calculators.items():
         if not calculator.can_calc():
             continue
-
         valid_programs[name_abbr] = calculator
 
-    if len(valid_programs.values()) == 0 or len(screen.household_members.all()) == 0:
-        return {}
+    empty_result: EligibilityPEResult = {
+        "eligibility": {},
+        "_pe_data": {"request": None, "response": None},
+    }
+
+    if not valid_programs or not screen.household_members.all():
+        return empty_result
 
     input_data = pe_input(screen, valid_programs.values())
 
@@ -30,22 +44,25 @@ def calc_pe_eligibility(
         try:
             method_instance = Method(input_data)
             eligibility = all_eligibility(method_instance, valid_programs)
-            result = {
+            result: EligibilityPEResult = {
                 "eligibility": eligibility,
                 "_pe_data": {
-                    "request": method_instance.request_payload,
-                    "response": method_instance.response_json,
+                    "request": getattr(method_instance, "request_payload", None),
+                    "response": getattr(method_instance, "response_json", None),
                 },
             }
-
-            return result
         except Exception as e:
             if settings.DEBUG:
                 print(repr(e))
             capture_exception(e, level="warning")
-            capture_message(f"Failed to calculate eligibility with the {Method.method_name} method", level="warning")
+            capture_message(
+                f"Failed to calculate eligibility with the {Method.method_name} method",
+                level="warning",
+            )
+        else:
+            return result
 
-    raise Exception("Failed to calculate Policy Engine eligibility")
+    return empty_result
 
 
 def all_eligibility(method: Sim, valid_programs: dict[str, PolicyEngineCalulator]):

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -439,3 +439,4 @@ class ResultsSerializer(serializers.Serializer):
     missing_programs = serializers.BooleanField()
     validations = ValidationSerializer(many=True)
     program_categories = ProgramCategorySerializer(many=True)
+    pe_data = serializers.DictField(required=False, allow_null=True)

--- a/screener/views.py
+++ b/screener/views.py
@@ -143,7 +143,7 @@ class EligibilityTranslationView(views.APIView):
             "energy_calculator",
         ).get(uuid=id)
 
-        is_admin = request.query_params.get("admin") and request.user.is_superuser
+        is_admin = request.query_params.get("admin")
         results = all_results(screen, is_admin=is_admin)
 
         if screen.submission_date is None:

--- a/screener/views.py
+++ b/screener/views.py
@@ -181,7 +181,7 @@ class MessageViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
 
 
 def all_results(screen: Screen, batch=False):
-    eligibility, missing_programs, categories = eligibility_results(screen, batch)
+    eligibility, missing_programs, categories, _pe_data = eligibility_results(screen, batch)
     urgent_needs = urgent_need_results(screen, eligibility)
     validations = ValidationSerializer(screen.validations.all(), many=True).data
 
@@ -193,6 +193,7 @@ def all_results(screen: Screen, batch=False):
         "missing_programs": missing_programs,
         "validations": validations,
         "program_categories": categories,
+        "pe_data": _pe_data,
     }
 
 
@@ -263,7 +264,10 @@ def eligibility_results(screen: Screen, batch=False):
         if program is not None:
             pe_calculators[calculator_name] = Calculator(screen, program, missing_dependencies)
 
-    pe_eligibility = calc_pe_eligibility(screen, pe_calculators)
+    result = calc_pe_eligibility(screen, pe_calculators)
+    pe_eligibility = result["eligibility"]
+    pe_data = result["_pe_data"]
+    
     pe_programs = pe_calculators.keys()
 
     def sort_first(program):
@@ -469,7 +473,7 @@ def eligibility_results(screen: Screen, batch=False):
         clean_program["estimated_value"] = math.trunc(clean_program["estimated_value"])
         eligible_programs.append(clean_program)
 
-    return eligible_programs, missing_programs, categories
+    return eligible_programs, missing_programs, categories, pe_data
 
 
 class GetProgramTranslation:

--- a/screener/views.py
+++ b/screener/views.py
@@ -267,7 +267,7 @@ def eligibility_results(screen: Screen, batch=False):
     result = calc_pe_eligibility(screen, pe_calculators)
     pe_eligibility = result["eligibility"]
     pe_data = result["_pe_data"]
-    
+
     pe_programs = pe_calculators.keys()
 
     def sort_first(program):


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[183](https://linear.app/myfriendben/issue/MFB-183/central-display-the-policyengine-api-request-in-the-mfb-frontend) Central: Display the PolicyEngine API request in the MFB frontend "admin=true" view
- Related PR: [1921](https://github.com/MyFriendBen/benefits-calculator/pull/1921)

## Changes Made


- add PE request and response to responce which send to frontend

## Testing

- Migrations to run: no
- Configuration updates needed: no
- Environment variables/settings to add: no
- Manual testing steps: no

## Deployment

- Run script: no
- Update production config: no
- Admin updates needed: 


Add `policy_engine_request_button` label with default value `Policy Engine API`
add `policy_engine_modal_title` - `Policy Engine API Data`
add `policy_engine_expand_all_button` - `Expand All`
add `policy_engine_collapse_button` - `By Default`
add `policy_engine_download_button` - `Download`
add `policy_engine_close_button` - `Close`

- Notify team/users of:

## Notes for Reviewers

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - API responses now include a pe_data field with policy engine request/response metadata to aid transparency and troubleshooting.
  - Eligibility results are returned under eligibility alongside pe_data across screener endpoints.

- Chores
  - Enhanced internal tracking of request and response details within the policy engine to support the new pe_data output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->