### PR TITLE
IL: Remove Greater Chicago Food Depository referrer

### DIFF
--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -167,10 +167,6 @@ class IlConfigurationData(ConfigurationData):
     }
 
     referral_options = {
-        "socialServices": {
-            "_label": "referralOptions.gcfd.il",
-            "_default_message": "Greater Chicago Food Depository",
-        },
         "searchEngine": {
             "_label": "referralOptions.searchEngine",
             "_default_message": "Google or other search engine",


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: https://linear.app/myfriendben/issue/MFB-235/il-remove-the-greater-chicago-food-depository-from-referrer-list-in

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Remove Greater Chicago Food Depository from the white label configuration

<img width="548" height="608" alt="Screenshot 2025-09-09 at 4 07 51 PM" src="https://github.com/user-attachments/assets/21eddba3-1fd0-4137-adf0-1da1bc996c8d" />

## Testing

<!-- Steps needed to test this PR locally -->

- Configuration updates needed: `python manage.py add_config il`
- Manual testing steps:
    * Visit step 10 of the screener
    * Verify that Greater Chicago Food Depository is not an option in the dropdown

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Update production config: `python manage.py add_config il`