### PR TITLE
feat: Convert UTC dates to user's browser timezone

### DIFF
--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -163,4 +163,4 @@ function initializeAll() {
 }
 
 document.addEventListener("DOMContentLoaded", initializeAll);
-document.body.addEventListener("htmx:afterSwap", initializeAll)
+document.body.addEventListener("htmx:afterSwap", initializeAll);

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -163,7 +163,8 @@ function initializeAll() {
 }
 
 document.addEventListener("DOMContentLoaded", initializeAll);
+
 document.body.addEventListener("htmx:afterSwap", function() {
-  console.log("HTMX content swapped - calling formatDates");
-  setTimeout(formatDates, 0);
+  console.log("HTMX content swapped - reinitializing all");
+  setTimeout(initializeAll, 0); 
 });

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -1,4 +1,3 @@
-
 // Safe table sorting (no crash if no .table)
 function initializeTableSorting() {
   let table = document.querySelector(".table");
@@ -7,9 +6,12 @@ function initializeTableSorting() {
   if (!headers || headers.length === 0) return;
   let currentSortColumn = null;
   let sortDirection = "asc";
+
   headers.forEach(function (header, index) {
-    header.addEventListener("click", function () { sortTable(index); });
-  });
+    header.addEventListener("click", function () { 
+      sortTable(index); });
+    });
+
   function sortTable(columnIndex) {
     let rows = Array.from(table.querySelectorAll("tbody tr"));
     if (columnIndex === currentSortColumn) {
@@ -18,34 +20,49 @@ function initializeTableSorting() {
       currentSortColumn = columnIndex;
       sortDirection = "asc";
     }
+
     rows.sort(function (a, b) {
       let cellA = a.querySelectorAll("td")[columnIndex].textContent.trim();
       let cellB = b.querySelectorAll("td")[columnIndex].textContent.trim();
+
       let valueA = isNaN(cellA) ? cellA.toLowerCase() : parseInt(cellA, 10);
       let valueB = isNaN(cellB) ? cellB.toLowerCase() : parseInt(cellB, 10);
+
       if (valueA < valueB) return sortDirection === "asc" ? -1 : 1;
       if (valueA > valueB) return sortDirection === "asc" ? 1 : -1;
       return 0;
     });
+
     let tbody = table.querySelector("tbody");
-    rows.forEach(function (row) { tbody.appendChild(row); });
+    rows.forEach(function (row) { 
+      tbody.appendChild(row); 
+    });
   }
 }
 
+// For handling the sidebar menu
 function initializeSidebarMenu() {
   let menuItems = document.querySelectorAll(".menu-list .sidebar-item");
   let currentUrl = window.location.href;
+
   menuItems.forEach(function (menuItem) {
     let linkUrl = menuItem.href;
-    if (linkUrl === currentUrl) menuItem.classList.add("is-active");
+
+    if (linkUrl === currentUrl) {
+      menuItem.classList.add("is-active");
+    }
+
     menuItem.addEventListener("click", function (event) {
-      menuItems.forEach(function (item) { item.classList.remove("is-active"); });
+      menuItems.forEach(function (item) { 
+        item.classList.remove("is-active"); 
+      });
+
       event.currentTarget.classList.add("is-active");
     });
   });
 }
 
-// Fix: remove undefined tableId
+// For handling the dropdown menu in the tables 
 function initializeDropdowns() {
   let dropdowns = document.querySelectorAll(".dropdown");
   dropdowns.forEach(function (dropdown) {
@@ -66,6 +83,7 @@ function initializeDropdowns() {
       }
     });
 
+    // Close the dropdown if the user clicks outside of it
     document.addEventListener("click", function (event) {
       let isClickInside = dropdown.contains(event.target);
       if (!isClickInside) {
@@ -75,6 +93,7 @@ function initializeDropdowns() {
       }
     });
 
+    // Close dropdowns when the page is scrolled
     window.addEventListener("scroll", function () {
       dropdown.classList.remove("is-active");
       dropdown.classList.remove("is-top");
@@ -88,6 +107,7 @@ function checkDropdownPosition(dropdown, dropdownContent) {
   let dropdownRect = dropdown.getBoundingClientRect();
   let dropdownContentRect = dropdownContent.getBoundingClientRect();
   let viewportHeight = window.innerHeight;
+
   if (dropdownRect.bottom + dropdownContentRect.height > viewportHeight) {
     dropdown.classList.remove("is-top");
   } else {

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -9,8 +9,9 @@ function initializeTableSorting() {
 
   headers.forEach(function (header, index) {
     header.addEventListener("click", function () { 
-      sortTable(index); });
+      sortTable(index); 
     });
+  });
 
   function sortTable(columnIndex) {
     let rows = Array.from(table.querySelectorAll("tbody tr"));
@@ -34,8 +35,8 @@ function initializeTableSorting() {
     });
 
     let tbody = table.querySelector("tbody");
-    rows.forEach(function (row) { 
-      tbody.appendChild(row); 
+    rows.forEach(function (row) {
+      tbody.appendChild(row);
     });
   }
 }
@@ -53,8 +54,8 @@ function initializeSidebarMenu() {
     }
 
     menuItem.addEventListener("click", function (event) {
-      menuItems.forEach(function (item) { 
-        item.classList.remove("is-active"); 
+      menuItems.forEach(function (item) {
+        item.classList.remove("is-active");
       });
 
       event.currentTarget.classList.add("is-active");
@@ -62,7 +63,7 @@ function initializeSidebarMenu() {
   });
 }
 
-// For handling the dropdown menu in the tables 
+// For handling the dropdown menu in the tables
 function initializeDropdowns() {
   let dropdowns = document.querySelectorAll(".dropdown");
   dropdowns.forEach(function (dropdown) {

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -8,8 +8,8 @@ function initializeTableSorting() {
   let sortDirection = "asc";
 
   headers.forEach(function (header, index) {
-    header.addEventListener("click", function () { 
-      sortTable(index); 
+    header.addEventListener("click", function () {
+      sortTable(index);
     });
   });
 

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -1,4 +1,4 @@
-// Safe table sorting (no crash if no .table)
+// For handling the safe table sorting (no crash if no .table)
 function initializeTableSorting() {
   let table = document.querySelector(".table");
   if (!table) return;

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -1,16 +1,15 @@
-// For handing the sorting of tables
+
+// Safe table sorting (no crash if no .table)
 function initializeTableSorting() {
   let table = document.querySelector(".table");
+  if (!table) return;
   let headers = table.querySelectorAll("th");
+  if (!headers || headers.length === 0) return;
   let currentSortColumn = null;
   let sortDirection = "asc";
-
   headers.forEach(function (header, index) {
-    header.addEventListener("click", function () {
-      sortTable(index);
-    });
+    header.addEventListener("click", function () { sortTable(index); });
   });
-
   function sortTable(columnIndex) {
     let rows = Array.from(table.querySelectorAll("tbody tr"));
     if (columnIndex === currentSortColumn) {
@@ -19,92 +18,76 @@ function initializeTableSorting() {
       currentSortColumn = columnIndex;
       sortDirection = "asc";
     }
-
     rows.sort(function (a, b) {
       let cellA = a.querySelectorAll("td")[columnIndex].textContent.trim();
       let cellB = b.querySelectorAll("td")[columnIndex].textContent.trim();
-
       let valueA = isNaN(cellA) ? cellA.toLowerCase() : parseInt(cellA, 10);
       let valueB = isNaN(cellB) ? cellB.toLowerCase() : parseInt(cellB, 10);
-
       if (valueA < valueB) return sortDirection === "asc" ? -1 : 1;
       if (valueA > valueB) return sortDirection === "asc" ? 1 : -1;
       return 0;
     });
-
     let tbody = table.querySelector("tbody");
-    rows.forEach(function (row) {
-      tbody.appendChild(row);
-    });
+    rows.forEach(function (row) { tbody.appendChild(row); });
   }
 }
 
-// For handling the sidebar menu
 function initializeSidebarMenu() {
   let menuItems = document.querySelectorAll(".menu-list .sidebar-item");
   let currentUrl = window.location.href;
-
   menuItems.forEach(function (menuItem) {
     let linkUrl = menuItem.href;
-
-    if (linkUrl === currentUrl) {
-      menuItem.classList.add("is-active");
-    }
-
+    if (linkUrl === currentUrl) menuItem.classList.add("is-active");
     menuItem.addEventListener("click", function (event) {
-      menuItems.forEach(function (item) {
-        item.classList.remove("is-active");
-      });
-
+      menuItems.forEach(function (item) { item.classList.remove("is-active"); });
       event.currentTarget.classList.add("is-active");
     });
   });
 }
 
-// For handling the dropdown menu in the tables
+// Fix: remove undefined tableId
 function initializeDropdowns() {
-  let dropdowns = document.querySelectorAll("#" + tableId + " .dropdown");
-  dropdowns.forEach(function (dropdown, index) {
+  let dropdowns = document.querySelectorAll(".dropdown");
+  dropdowns.forEach(function (dropdown) {
     let dropdownButton = dropdown.querySelector(".button");
     let dropdownSpan = dropdown.querySelector(".material-symbols-outlined");
     let dropdownContent = dropdown.querySelector(".dropdown-content");
+    if (!dropdownButton) return;
 
     dropdownButton.addEventListener("click", function (event) {
       event.preventDefault();
       dropdown.classList.toggle("is-active");
       if (dropdown.classList.contains("is-active")) {
-        dropdownSpan.textContent = "expand_less";
+        if (dropdownSpan) dropdownSpan.textContent = "expand_less";
         checkDropdownPosition(dropdown, dropdownContent);
       } else {
-        dropdownSpan.textContent = "expand_more";
+        if (dropdownSpan) dropdownSpan.textContent = "expand_more";
         dropdown.classList.remove("is-top");
       }
     });
 
-    // Close the dropdown if the user clicks outside of it
     document.addEventListener("click", function (event) {
       let isClickInside = dropdown.contains(event.target);
       if (!isClickInside) {
         dropdown.classList.remove("is-active");
         dropdown.classList.remove("is-top");
-        dropdownSpan.textContent = "expand_more";
+        if (dropdownSpan) dropdownSpan.textContent = "expand_more";
       }
     });
 
-    // Close dropdowns when the page is scrolled
     window.addEventListener("scroll", function () {
       dropdown.classList.remove("is-active");
       dropdown.classList.remove("is-top");
-      dropdownSpan.textContent = "expand_more";
+      if (dropdownSpan) dropdownSpan.textContent = "expand_more";
     });
   });
 }
 
 function checkDropdownPosition(dropdown, dropdownContent) {
+  if (!dropdownContent) return;
   let dropdownRect = dropdown.getBoundingClientRect();
   let dropdownContentRect = dropdownContent.getBoundingClientRect();
   let viewportHeight = window.innerHeight;
-
   if (dropdownRect.bottom + dropdownContentRect.height > viewportHeight) {
     dropdown.classList.remove("is-top");
   } else {
@@ -112,11 +95,54 @@ function checkDropdownPosition(dropdown, dropdownContent) {
   }
 }
 
-function initializeAll() {
-  initializeTableSorting();
-  initializeSidebarMenu();
-  initializeDropdowns();
+// Convert UTC ISO in data-utc-date to browser timezone
+function formatDates() {  
+  const els = document.querySelectorAll(".utc-date");  
+  
+  if (els.length === 0) {
+    return;
+  }
+  
+  els.forEach(function (el, index) {
+    const iso = el.getAttribute("data-utc-date");    
+    
+    if (!iso || iso === "Never") {
+      return;
+    }
+    
+    try {
+      const d = new Date(iso);
+      if (isNaN(d.getTime())) {
+        return;
+      }
+      
+      const formatted = new Intl.DateTimeFormat(navigator.language, {
+        year: "numeric", 
+        month: "short", 
+        day: "numeric",
+        hour: "numeric", 
+        minute: "numeric", 
+        hour12: true, 
+        timeZoneName: "short"
+      }).format(d);
+      
+      el.textContent = formatted;
+    } catch (e) {
+      console.error("Error formatting date:", e);
+    }
+  });
+}
+window.formatDates = formatDates;
+
+function initializeAll() {  
+  try { initializeTableSorting(); } catch (e) { console.warn("initializeTableSorting error:", e); }
+  try { initializeSidebarMenu(); } catch (e) { console.warn("initializeSidebarMenu error:", e); }
+  try { initializeDropdowns(); } catch (e) { console.warn("initializeDropdowns error:", e); }
+  formatDates();
 }
 
 document.addEventListener("DOMContentLoaded", initializeAll);
-document.body.addEventListener("htmx:afterSwap", initializeAll);
+document.body.addEventListener("htmx:afterSwap", function() {
+  console.log("HTMX content swapped - calling formatDates");
+  setTimeout(formatDates, 0);
+});

--- a/translations/static/js/base.js
+++ b/translations/static/js/base.js
@@ -163,8 +163,4 @@ function initializeAll() {
 }
 
 document.addEventListener("DOMContentLoaded", initializeAll);
-
-document.body.addEventListener("htmx:afterSwap", function() {
-  console.log("HTMX content swapped - reinitializing all");
-  setTimeout(initializeAll, 0); 
-});
+document.body.addEventListener("htmx:afterSwap", initializeAll)

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -5,7 +5,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Translations Admin</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css" />
+    <link 
+      rel="stylesheet" 
+      href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css" 
+    />
     <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
     <link rel="stylesheet" href="{% static 'css/bulma_switch.css' %}" />
     <link
@@ -142,6 +145,7 @@
           </div>
         </div>
       </div>
+    </div>
       <div class="column is-2"></div>
         <div class="column is-10 is-offset-2">
           <div class="container">

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -145,13 +145,14 @@
           </div>
         </div>
       </div>
-    </div>    
-    <div class="column is-2"></div>
-      <div class="column is-10 is-offset-2">
-        <div class="container">
-          <div class="content">{% block content %} {% endblock content %}</div>
+      <div class="column is-2"></div>
+        <div class="column is-10 is-offset-2">
+          <div class="container">
+            <div class="content">{% block content %} {% endblock content %}</div>
+          </div>
         </div>
-      </div>
+    </div>    
+   
     
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
     <script src="{% static 'js/base.js' %}?v=tzfix5"></script>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -154,8 +154,8 @@
     </div>    
    
     
-    <script src="https://unpkg.com/htmx.org@1.9.5"></script>
-    <script src="{% static 'js/base.js' %}?v=tzfix5"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.5"></script>    
+    <script src="{% static 'js/base.js' %}"></script>
     <script src="{% static 'js/theme.js' %}"></script>
   </body>
 </html>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -1,14 +1,12 @@
 {% load static %}
+
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Translations Admin</title>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css"
-    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css" />
     <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
     <link rel="stylesheet" href="{% static 'css/bulma_switch.css' %}" />
     <link
@@ -16,7 +14,6 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"
     />
   </head>
-
   <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}" }'>
     <div class="columns is-gapless">
       <div class="column is-2 sidebar-nav is-flex is-flex-direction-column">
@@ -145,15 +142,16 @@
           </div>
         </div>
       </div>
-      <div class="column is-2"></div>
+     <div class="column is-2"></div>
       <div class="column is-10 is-offset-2">
         <div class="container">
           <div class="content">{% block content %} {% endblock content %}</div>
         </div>
       </div>
     </div>
+    
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
-    <script src="{% static 'js/base.js' %}"></script>
+    <script src="{% static 'js/base.js' %}?v=tzfix5"></script>
     <script src="{% static 'js/theme.js' %}"></script>
   </body>
 </html>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Translations Admin</title>
-    <link 
-      rel="stylesheet" 
+    <link
+      rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css" 
     />
     <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
@@ -146,6 +146,7 @@
         </div>
       </div>
     </div>
+    
       <div class="column is-2"></div>
         <div class="column is-10 is-offset-2">
           <div class="container">

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -152,8 +152,6 @@
           </div>
         </div>
     </div>    
-   
-    
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>    
     <script src="{% static 'js/base.js' %}"></script>
     <script src="{% static 'js/theme.js' %}"></script>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -7,7 +7,7 @@
     <title>Translations Admin</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css" 
+      href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css"
     />
     <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
     <link rel="stylesheet" href="{% static 'css/bulma_switch.css' %}" />

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -145,8 +145,7 @@
           </div>
         </div>
       </div>
-    </div>
-    
+    </div>    
       <div class="column is-2"></div>
         <div class="column is-10 is-offset-2">
           <div class="container">

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -151,8 +151,7 @@
           <div class="container">
             <div class="content">{% block content %} {% endblock content %}</div>
           </div>
-        </div>
-      </div>
+        </div>    
     
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
     <script src="{% static 'js/base.js' %}?v=tzfix5"></script>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -145,9 +145,8 @@
           </div>
         </div>
       </div>
-    </div>    
-      <div class="column is-2"></div>
-        <div class="column is-10 is-offset-2">
+    </div>          
+        <div class="column is-10">
           <div class="container">
             <div class="content">{% block content %} {% endblock content %}</div>
           </div>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -145,8 +145,9 @@
           </div>
         </div>
       </div>
-    </div>          
-        <div class="column is-10">
+    </div>    
+      <div class="column is-2"></div>
+        <div class="column is-10 is-offset-2">
           <div class="container">
             <div class="content">{% block content %} {% endblock content %}</div>
           </div>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -146,12 +146,12 @@
         </div>
       </div>
     </div>    
-      <div class="column is-2"></div>
-        <div class="column is-10 is-offset-2">
-          <div class="container">
-            <div class="content">{% block content %} {% endblock content %}</div>
-          </div>
-        </div>    
+    <div class="column is-2"></div>
+      <div class="column is-10 is-offset-2">
+        <div class="container">
+          <div class="content">{% block content %} {% endblock content %}</div>
+        </div>
+      </div>
     
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
     <script src="{% static 'js/base.js' %}?v=tzfix5"></script>

--- a/translations/templates/base.html
+++ b/translations/templates/base.html
@@ -1,5 +1,4 @@
 {% load static %}
-
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
   <head>
@@ -14,6 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"
     />
   </head>
+
   <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}" }'>
     <div class="columns is-gapless">
       <div class="column is-2 sidebar-nav is-flex is-flex-direction-column">
@@ -142,13 +142,13 @@
           </div>
         </div>
       </div>
-     <div class="column is-2"></div>
-      <div class="column is-10 is-offset-2">
-        <div class="container">
-          <div class="content">{% block content %} {% endblock content %}</div>
+      <div class="column is-2"></div>
+        <div class="column is-10 is-offset-2">
+          <div class="container">
+            <div class="content">{% block content %} {% endblock content %}</div>
+          </div>
         </div>
       </div>
-    </div>
     
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
     <script src="{% static 'js/base.js' %}?v=tzfix5"></script>

--- a/translations/templates/edit/langs.html
+++ b/translations/templates/edit/langs.html
@@ -17,6 +17,14 @@
             </span>
           </label>
         </div>
+        <div class="level-item">
+          <label class="label">Update Type: {% if translation|get_update_type:lang %}
+            Manual
+          {% else %}
+            Auto
+          {% endif %}
+          </label>
+        </div>
       </div>
     </div>
     <form id="{{ lang }}" hx-post="{{ translation.id }}/{{ lang }}" hx-target="#languages" hx-swap="outerHTML">

--- a/translations/templates/edit/langs.html
+++ b/translations/templates/edit/langs.html
@@ -27,7 +27,12 @@
         </div>
       </div>
     </div>
-    <form id="{{ lang }}" hx-post="{{ translation.id }}/{{ lang }}" hx-target="#languages" hx-swap="outerHTML">
+    <form 
+      id="{{ lang }}" 
+      hx-post="{{ translation.id }}/{{ lang }}" 
+      hx-target="#languages" 
+      hx-swap="outerHTML"
+    >
       {% include "./lang_form.html" with lang=lang form=form %}
     </form>
   </div>

--- a/translations/templates/edit/langs.html
+++ b/translations/templates/edit/langs.html
@@ -27,10 +27,10 @@
         </div>
       </div>
     </div>
-    <form 
-      id="{{ lang }}" 
-      hx-post="{{ translation.id }}/{{ lang }}" 
-      hx-target="#languages" 
+    <form
+      id="{{ lang }}"
+      hx-post="{{ translation.id }}/{{ lang }}"
+      hx-target="#languages"
       hx-swap="outerHTML"
     >
       {% include "./lang_form.html" with lang=lang form=form %}

--- a/translations/templates/edit/langs.html
+++ b/translations/templates/edit/langs.html
@@ -10,24 +10,16 @@
       </div>
       <div class="level-right">
         <div class="level-item">
-          <label class="label">Last Updated: {{ updated_dates|get_updated_label:lang }}</label>
-        </div>
-        <div class="level-item">
-          <label class="label">Update Type: {% if translation|get_update_type:lang %}
-            Manual
-          {% else %}
-            Auto
-          {% endif %}
+          <label class="label">
+            Last Updated:
+            <span class="utc-date" data-utc-date="{{ updated_dates|get_updated_label:lang }}">
+              {{ updated_dates|get_updated_label:lang }}
+            </span>
           </label>
         </div>
       </div>
     </div>
-    <form
-      id="{{ lang }}"
-      hx-post="{{ translation.id }}/{{ lang }}"
-      hx-target="#languages"
-      hx-swap="outerHTML"
-    >
+    <form id="{{ lang }}" hx-post="{{ translation.id }}/{{ lang }}" hx-target="#languages" hx-swap="outerHTML">
       {% include "./lang_form.html" with lang=lang form=form %}
     </form>
   </div>

--- a/translations/templates/edit/main.html
+++ b/translations/templates/edit/main.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% load filters %} {% block content %}
+{% extends "base.html" %} {% load filters %} {% block content %} {% load static %}
 <section class="section">
   <h2 class="title">{{ translation.label }}</h2>
 </section>
@@ -50,7 +50,12 @@
             </div>
             <div class="level-right">
               <div class="level-item">
-                <label class="label">Last Updated: {{ updated_dates|get_updated_label:lang }}</label>
+                <label class="label">
+                Last Updated:
+                  <span class="utc-date" data-utc-date="{{ updated_dates|get_updated_label:lang }}">
+                    {{ updated_dates|get_updated_label:lang }}
+                  </span>
+                </label>                
               </div>
               <div class="level-item">
                 <label class="label">Update Type: {% if translation|get_update_type:lang %}
@@ -78,3 +83,6 @@
 
   {% endblock content %}
 </div>
+<script>
+  if (window.formatDates) { window.formatDates(); }
+</script>

--- a/translations/templates/edit/main.html
+++ b/translations/templates/edit/main.html
@@ -83,6 +83,3 @@
 
   {% endblock content %}
 </div>
-<script>
-  if (window.formatDates) { window.formatDates(); }
-</script>

--- a/translations/templatetags/filters.py
+++ b/translations/templatetags/filters.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 register = template.Library()
 
+
 @register.filter
 def get_updated_label(updated_dates, lang_code, default="Never"):
     if not updated_dates:
@@ -12,13 +13,14 @@ def get_updated_label(updated_dates, lang_code, default="Never"):
         return date.isoformat()  # return ISO for JS
     return date or default
 
+
 @register.filter
 def get_update_type(translation, lang_code):
     for record in translation.translations.all():
         if record.language_code == lang_code:
             return record.edited
 
+
 @register.filter
 def get_language_name(lang_code):
     return dict(settings.LANGUAGES).get(lang_code, lang_code)
-

--- a/translations/templatetags/filters.py
+++ b/translations/templatetags/filters.py
@@ -3,11 +3,14 @@ from django.conf import settings
 
 register = template.Library()
 
-
 @register.filter
 def get_updated_label(updated_dates, lang_code, default="Never"):
-    return updated_dates.get(lang_code, default)
-
+    if not updated_dates:
+        return default
+    date = updated_dates.get(lang_code, default)
+    if hasattr(date, "isoformat"):
+        return date.isoformat()  # return ISO for JS
+    return date or default
 
 @register.filter
 def get_update_type(translation, lang_code):
@@ -15,7 +18,7 @@ def get_update_type(translation, lang_code):
         if record.language_code == lang_code:
             return record.edited
 
-
 @register.filter
 def get_language_name(lang_code):
     return dict(settings.LANGUAGES).get(lang_code, lang_code)
+


### PR DESCRIPTION
## Context & Motivation

Add formatDates() function to convert UTC timestamps to user's local timezone
- Fix JavaScript initialization errors in base.js with proper error handling
- Update base.html template structure and script loading
- Implement HTMX afterSwap event handling for dynamic content
- Cache-bust JavaScript files to ensure updated code loads

Resolves timezone display issues where UTC dates were not converting
to user's browser timezone (e.g., PST/PDT).

- Fixes #[MFB-211](https://linear.app/myfriendben/issue/MFB-221/chorebug-translation-historical-records-inaccurate-datetime)
- Related PR: #1054 

## Changes Made

- Added timezone conversion functionality: Implemented formatDates() JavaScript function to convert UTC timestamps to user's browser timezone using Intl.DateTimeFormat()

- Fixed JavaScript initialization errors: Added proper error handling and null checks in initializeTableSorting(), initializeSidebarMenu(), and initializeDropdowns() functions

- Updated [base.html](vscode-file://vscode-app/c:/Users/bedge/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) template: Added proper script loading with cache-busting version parameter (?v=tzfix5) and fixed HTML structure issues

- Enhanced HTMX integration: Added htmx:afterSwap event listener to ensure date formatting runs on dynamically loaded content

- Updated template filters: Modified get_updated_label filter to return ISO format dates for JavaScript processing

Improved template structure: Fixed duplicate content blocks and proper script placement in [base.html](vscode-file://vscode-app/c:/Users/bedge/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- ...

## Testing

- Migrations to run: None required

- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
      Navigate to any translation edit page (e.g., /api/translations/admin/9065)
      Check that UTC timestamps like 2025-09-09T22:06:07.605760+00:00 display as local time (e.g., "Sep 9, 2025, 3:06 PM PDT" for Pacific timezone)
      Test HTMX form submissions to ensure dates convert after dynamic content loads
      Test in different browsers and timezones if possible

## Deployment

- Run script: None required
- Update production config: None required
- Admin updates needed: None required
- Notify team/users of:
      1. Dates will now display in user's local timezone instead of UTC
      2. Users may notice time differences if they were previously interpreting UTC as local time


## Notes for Reviewers

- Known limitations:

    - Requires JavaScript enabled in browser
    - Falls back to showing ISO UTC format if JS fails
    - Timezone detection relies on browser's Intl.DateTimeFormat() support (supported in all modern browsers)

- Future considerations:

    - Consider adding user preference setting to choose between UTC/local time display
    - May want to add timezone indicator in UI for clarity
    - Could extend to other date fields throughout the application

- Review focus areas:

    - JavaScript error handling and browser compatibility
    - Template structure changes in base.html
    - HTMX integration for dynamic content
    - Performance impact of date conversion on pages with many timestamps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dates labeled “Last Updated” now auto-format to your local timezone.
  - Language updates refresh the entire list for a more consistent view.

- Bug Fixes
  - More resilient tables and dropdowns to prevent errors when elements are missing.
  - Safer behavior after dynamic content updates to ensure UI elements stay in sync.
  - Adjusted page layout to correct column/container boundaries.

- Chores
  - Added cache-busting to the main script to ensure the latest assets load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->