### PR TITLE
Central: Move Materialized View Refresh to manage.py

### DIFF
--- a/configuration/management/commands/refresh_views.py
+++ b/configuration/management/commands/refresh_views.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+VIEWS = [
+    "data",
+    "data_current_benefits",
+    "data_householdmembers",
+    "data_immediate_needs",
+    "data_previous_benefits",
+    "data_programs",
+]
+
+
+class Command(BaseCommand):
+    help = "Refresh all materialized views"
+
+    def handle(self, *args, **kwargs):
+        with connection.cursor() as cursor:
+            for view in VIEWS:
+
+                try:
+                    self.stdout.write(f"Refreshing {view}...")
+                    cursor.execute(f"REFRESH MATERIALIZED VIEW {view};")
+
+                except Exception as e:
+                    self.stdout.write(self.style.ERROR(f"Failed to refresh {view}: {e}\n"))
+        self.stdout.write(self.style.SUCCESS("All materialized views refreshed!"))


### PR DESCRIPTION
## Context & Motivation

The current process for refreshing materialized views is handled through Heroku Scheduler. We want to manage all MVs in one command and allow devs to adjust and test locally a little easier by extracting all the materialized view refresh commands to `refresh_views` command. 

- Fixes https://linear.app/myfriendben/issue/MFB-110/central-move-materialized-view-refresh-to-managepy

## Changes Made

Add command `refresh_views`

## Testing

- Manual testing steps:
    -  (Optional) Query total records in `screener_householdmember` table to establish a baseline. `SELECT COUNT(*) FROM screener_householdmember;`
    -  Query total records in `data_householdmembers` materialized view. `SELECT COUNT(*) FROM public.data_householdmembers;`
    -  In Screener, create a new result with at least one new household member.
    -  (Optional) Re-check `screener_householdmember` count, it should increase by 1.
    -  Re-check `data_householdmembers` count, it should not change yet.
    -  Run the new added refresh command: `python manage.py refresh_views`. Verify logs show no errors.
    -  Re-check `data_householdmembers` count, it should increase by 1 and include the new member data.


## Notes for Reviewers

- We're not doing "concurrently" for the refresh for now
- Please let me know if I’ve missed or misunderstood anything.
