### PR TITLE
Added lang support for Portuguese and Haitian Creole

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -222,7 +222,7 @@ LANGUAGES = (
     ("pl", _("Polish")),
     ("tl", _("Tagalog")),
     ("ko", _("Korean")),
-    ("ur", _("Urdu")),    
+    ("ur", _("Urdu")),
     ("pt", _("Portuguese")),
     ("ht", _("Haitian Creole")),
 )
@@ -252,7 +252,7 @@ PARLER_LANGUAGES = {
         {"code": "pl"},
         {"code": "tl"},
         {"code": "ko"},
-        {"code": "ur"},        
+        {"code": "ur"},
         {"code": "pt"},
         {"code": "ht"},
     ),

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -222,7 +222,9 @@ LANGUAGES = (
     ("pl", _("Polish")),
     ("tl", _("Tagalog")),
     ("ko", _("Korean")),
-    ("ur", _("Urdu")),
+    ("ur", _("Urdu")),    
+    ("pt", _("Portuguese")),
+    ("ht", _("Haitian Creole")),
 )
 
 TIME_ZONE = "UTC"
@@ -250,7 +252,9 @@ PARLER_LANGUAGES = {
         {"code": "pl"},
         {"code": "tl"},
         {"code": "ko"},
-        {"code": "ur"},
+        {"code": "ur"},        
+        {"code": "pt"},
+        {"code": "ht"},
     ),
     "default": {
         "fallbacks": ["en-us"],  # defaults to PARLER_DEFAULT_LANGUAGE_CODE

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -223,7 +223,7 @@ LANGUAGES = (
     ("tl", _("Tagalog")),
     ("ko", _("Korean")),
     ("ur", _("Urdu")),
-    ("pt-br", _("Brazilian Portuguese")),
+    ("pt-BR", _("Brazilian Portuguese")),
     ("ht", _("Haitian Creole")),
 )
 
@@ -253,7 +253,7 @@ PARLER_LANGUAGES = {
         {"code": "tl"},
         {"code": "ko"},
         {"code": "ur"},
-        {"code": "pt-br"},
+        {"code": "pt-BR"},
         {"code": "ht"},
     ),
     "default": {

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -39,7 +39,7 @@ EXTRA_LANG_INFO = {
         "code": "ht",
         "name": "Haitian Creole",
         "name_local": "Kreyòl ayisyen",
-    }
+    },
 }
 
 DJANGO_LANG_INFO.update(EXTRA_LANG_INFO)

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -223,7 +223,7 @@ LANGUAGES = (
     ("tl", _("Tagalog")),
     ("ko", _("Korean")),
     ("ur", _("Urdu")),
-    ("pt", _("Portuguese")),
+    ("pt-br", _("Brazilian Portuguese")),
     ("ht", _("Haitian Creole")),
 )
 
@@ -253,7 +253,7 @@ PARLER_LANGUAGES = {
         {"code": "tl"},
         {"code": "ko"},
         {"code": "ur"},
-        {"code": "pt"},
+        {"code": "pt-br"},
         {"code": "ht"},
     ),
     "default": {

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -223,7 +223,7 @@ LANGUAGES = (
     ("tl", _("Tagalog")),
     ("ko", _("Korean")),
     ("ur", _("Urdu")),
-    ("pt-BR", _("Brazilian Portuguese")),
+    ("pt-br", _("Brazilian Portuguese")),
     ("ht", _("Haitian Creole")),
 )
 
@@ -253,7 +253,7 @@ PARLER_LANGUAGES = {
         {"code": "tl"},
         {"code": "ko"},
         {"code": "ur"},
-        {"code": "pt-BR"},
+        {"code": "pt-br"},
         {"code": "ht"},
     ),
     "default": {

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -34,6 +34,12 @@ EXTRA_LANG_INFO = {
         "name": "Somali",
         "name_local": "Soomaali",
     },
+    "ht": {
+        "bidi": False,
+        "code": "ht",
+        "name": "Haitian Creole",
+        "name_local": "Kreyòl ayisyen",
+    }
 }
 
 DJANGO_LANG_INFO.update(EXTRA_LANG_INFO)

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -72,7 +72,7 @@ class DefaultConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt": "português",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -72,7 +72,7 @@ class DefaultConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-br": "Português Brasileiro",
+        "pt-BR": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -72,7 +72,7 @@ class DefaultConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-BR": "Português Brasileiro",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -72,6 +72,8 @@ class DefaultConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
+        "pt": "português",
+        "ht": "Kreyòl",
     }
 
     feedback_links = {

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -132,7 +132,7 @@ class ConfigurationData:
         "pl": "Polski",
         "tl": "Tagalog",
         "ko": "한국어",
-        "pt-br": "Português Brasileiro",
+        "pt-BR": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -132,6 +132,8 @@ class ConfigurationData:
         "pl": "Polski",
         "tl": "Tagalog",
         "ko": "한국어",
+        "pt": "português",
+        "ht": "Kreyòl",
     }
 
     income_options = {

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -132,7 +132,7 @@ class ConfigurationData:
         "pl": "Polski",
         "tl": "Tagalog",
         "ko": "한국어",
-        "pt-BR": "Português Brasileiro",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -132,7 +132,7 @@ class ConfigurationData:
         "pl": "Polski",
         "tl": "Tagalog",
         "ko": "한국어",
-        "pt": "português",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -207,7 +207,7 @@ class CoConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-BR": "Português Brasileiro",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -207,7 +207,7 @@ class CoConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt": "português",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -207,6 +207,8 @@ class CoConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
+        "pt": "português",
+        "ht": "Kreyòl",
     }
 
     income_options = {

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -207,7 +207,7 @@ class CoConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-br": "Português Brasileiro",
+        "pt-BR": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -203,7 +203,7 @@ class IlConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt": "português",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -203,7 +203,7 @@ class IlConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-br": "Português Brasileiro",
+        "pt-BR": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -203,7 +203,7 @@ class IlConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-BR": "Português Brasileiro",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -203,6 +203,8 @@ class IlConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
+        "pt": "português",
+        "ht": "Kreyòl",
     }
 
     income_options = {

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -173,6 +173,8 @@ class MaConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
+        "pt": "português",
+        "ht": "Kreyòl",
     }
 
     income_options = {

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -173,7 +173,7 @@ class MaConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-BR": "Português Brasileiro",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -173,7 +173,7 @@ class MaConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-br": "Português Brasileiro",
+        "pt-BR": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -173,7 +173,7 @@ class MaConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt": "português",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -308,7 +308,7 @@ class NcConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-BR": "Português Brasileiro",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -308,7 +308,7 @@ class NcConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt-br": "Português Brasileiro",
+        "pt-BR": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -308,7 +308,7 @@ class NcConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
-        "pt": "português",
+        "pt-br": "Português Brasileiro",
         "ht": "Kreyòl",
     }
 

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -308,6 +308,8 @@ class NcConfigurationData(ConfigurationData):
         "tl": "Tagalog",
         "ko": "한국어",
         "ur": "اردو",
+        "pt": "português",
+        "ht": "Kreyòl",
     }
 
     income_options = {

--- a/integrations/services/google_translate/integration.py
+++ b/integrations/services/google_translate/integration.py
@@ -60,6 +60,14 @@ class Translate:
         result = self.bulk_translate([lang], [text])
         return result[text][lang]
 
+    LANGUAGE_CODE_MAPPING = {       
+        'pt-BR': 'pt',  # Map pt-br to pt for Google Translate
+        'en-us': 'en',    
+    }
+
+    def _map_language_code(self, lang_code):
+        return self.LANGUAGE_CODE_MAPPING.get(lang_code, lang_code)
+
     def bulk_translate(self, langs: list[str], texts: list[str]):
         """
         Translates all of the texts to the target langs, preserving paragraph structure for each text.
@@ -73,13 +81,16 @@ class Translate:
             if lang not in Translate.languages:
                 raise Exception(f"{lang} is not configured in settings, or is the default language")
 
+            # Use mapped code for Google Translate
+            google_lang = self._map_language_code(lang)
+
             # For each text, split into paragraphs, translate, and rejoin
             for text in texts:
                 paragraphs = self.split_paragraphs(text)
 
                 try:
                     results = self.client.translate(
-                        paragraphs, target_language=lang, source_language=Translate.main_language
+                        paragraphs, target_language=google_lang, source_language=self._map_language_code(Translate.main_language)
                     )
                 except Exception as e:
                     capture_exception(e, level="error")


### PR DESCRIPTION
## Context & Motivation
To serve MA users, partners have requested that MFB be available in Portuguese (Brazilian) and Haitian Creole language.
<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [#MFB-86](https://linear.app/myfriendben/issue/MFB-86/ma-add-brazilian-portuguese-and-haitian-creole-as-languages)
- Related FE PR: [#1932](https://github.com/MyFriendBen/benefits-calculator/pull/1932)

## Changes Made

Added language configs to all white labels 

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: NA
- Configuration updates needed:
- Environment variables/settings to add:
- Manual testing steps:

## Deployment

<!-- Steps needed AFTER merging to get this live -->

## Post-Deployment Commands
After deploying these language changes to production, run the following commands in order:

#Required Commands:

```
# 1. Apply any pending database migrations
python manage.py migrate

# 2. Update all white label configurations with new languages
python manage.py add_config --all

# 3. Create and translate records for new languages using bulk_translate 'python manage.py bulk_translate --lang=pt-br --all=true'
# The command will show you how many translations need each language:
# Example output for 'pt-br' lang:

#  Total translations: 4878
#  Total en-us translations: 4878
#  With English text: 3855
#  Auto translation allowed: 3319
#  Missing pt-BR record: 3319
#  Translations needing pt-BR translation: 3319
#  Processing 49 batches for language pt-br
#  Bulk translate completed successfully for pt-br
#  Total records created/updated: 4081

# For most efficient processing, use --all flag to process all eligible translations at once
# The command automatically creates missing translation records and translates them
# Only translations with English source text and auto-translation enabled will be translated
# The count for translations created will be higher because some records (eg URLs) don't have a translation so they retain their original text in all languages

python manage.py bulk_translate --lang=pt-br --all=true
python manage.py bulk_translate --lang=ht --all=true  


# Alternative: Process in smaller batches if you encounter timeouts
# python manage.py bulk_translate --lang=pt-br --limit=500
# python manage.py bulk_translate --lang=ht --limit=500

# Note: Each command only needs to be run once per language. 
# The command will only process translations that don't already have the target language record.

# 4. Clear and refresh all translation caches (comprehensive)
python manage.py shell -c "
from translations.models import Translation
from django.core.cache import cache

# Clear Django's default cache
cache.clear()

# Clear and reset the translation cache
Translation.objects.translation_cache.invalid = True
Translation.objects.translation_cache.data = Translation.objects.translation_cache.default
Translation.objects.translation_cache.update()

print('All caches cleared and translation cache updated')
print('Available languages:', list(Translation.objects.translation_cache.data.keys()) if Translation.objects.translation_cache.data else 'Empty cache')
"

# 5. Verify all white labels have new languages
python manage.py health_check ma  # Test ma specifically
python manage.py health_check co  # Test other white labels as needed
```

## Optional Verification Commands
```
# Check that all white labels have the new languages in their config
python manage.py shell -c "
from configuration.models import Configuration
from screener.models import WhiteLabel
for wl_code in ['co', 'nc', 'ma', 'il']:
    wl = WhiteLabel.objects.get(code=wl_code)
    config = Configuration.objects.filter(white_label=wl, name='language_options').first()
    if config and all(lang in str(config.data) for lang in ['pt-BR', 'ht']):
        print(f'{wl_code}: ✓ All 2 new languages present')
    else:
        print(f'{wl_code}: ✗ Missing new languages')
"

# Test a sample translation across all new languages
python manage.py shell -c "
from translations.models import Translation
trans = Translation.objects.first()
if trans:
    print(f'Testing translation: {trans.label}')
    for lang in ['pt-BR', 'ht']:
        trans.set_current_language(lang)
        status = '✓' if trans.text and trans.text.strip() else '✗'
        print(f'  {lang}: {status}')
"
```

- Run script:
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:
