### PR TITLE
Add data_referrer_codes to view refresh

### DIFF
--- a/configuration/management/commands/refresh_views.py
+++ b/configuration/management/commands/refresh_views.py
@@ -5,6 +5,7 @@ from django.db.utils import ProgrammingError
 
 
 VIEWS = [
+    "data_referrer_codes",
     "data",
     "data_current_benefits",
     "data_householdmembers",


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

I forgot to add `data_referrer_codes` to the Linear ticket but found it while QA'ing the fix in #1162 

- Fixes #MFB-110
- Related PR: https://linear.app/myfriendben/issue/MFB-110/central-move-materialized-view-refresh-to-managepy

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add `data_referrer_codes`

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run:
- Configuration updates needed:
- Environment variables/settings to add:
- Manual testing steps:

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script:
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:
