### PR TITLE
Updated ma config file to change text for child development title in step 9.

### DIFF
--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -67,8 +67,8 @@ class MaConfigurationData(ConfigurationData):
         "childDevelopment": {
             "icon": {"_icon": "Child_development", "_classname": "option-card-icon"},
             "text": {
-                "_label": "acuteConditionOptions.childDevelopment",
-                "_default_message": "Concern about your child's development",
+                "_label": "acuteConditionOptions.childDevelopment_ma",
+                "_default_message": "Concern about your child's development (ages 0 - 21)",
             },
         },
         "familyPlanning": {


### PR DESCRIPTION


## Context & Motivation

Step 9 (Additional Resources) has a tile for "concern about your child's development". The MA department of public health want to show programs that are available for children through age 21. To accommodate these programs:

- Change text in tile to read "concern about your child's development (ages 0 - 21)" 
- Change icon to show something like a school-age child (full body)(FE PR)

- Fixes #MFB-99
- Related PR: [link if applicable]

## Changes Made

Updated ma config file to change text for child development title in step 9 to "concern about your child's development (ages 0 - 21)" 

## Testing

- Migrations to run:NA
- Configuration updates needed: YES 
 use command `python manage.py add_config ma`
- Environment variables/settings to add: YES
-Create a new translation with name "acuteConditionOptions.childDevelopment_ma" in translation admin with description  "concern about your child's development (ages 0 - 21)"
- Manual testing steps: Go to the screener on step-9 and check whether changes reflected or not in child development component (icon and text)

## Deployment

<!-- Steps needed AFTER merging to get this live -->
## Post-Deployment Commands

- Create a new translation with name "acuteConditionOptions.childDevelopment_ma" in translation admin with description "concern about your child's development (ages 0 - 21)"
- `python manage.py add_config ma`

- Run script:
- Update production config: `python manage.py add_config ma`
- Admin updates needed: Create a new translation with name "acuteConditionOptions.childDevelopment_ma" in translation admin with description "concern about your child's development (ages 0 - 21)
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:
