### PR TITLE
MFB-1220: MO Property Tax Credit (Circuit Breaker) — mo_pts

### DIFF
--- a/programs/framework/pe_base.py
+++ b/programs/framework/pe_base.py
@@ -114,21 +114,6 @@ class PolicyEngineTaxUnitCalulator(PolicyEngineCalulator):
         except KeyError:
             return 0  # if the second tax unit does not exist
 
-    def any_tax_unit(self, dependency: type[PolicyEngineScreenInput]) -> bool:
-        """True if `dependency`'s field is truthy for any tax unit.
-
-        For a program whose eligibility PolicyEngine reports separately from its value,
-        rather than the default `value > 0`.
-        """
-        for unit in ALL_TAX_UNITS:
-            try:
-                if self.sim.value(dependency.unit, unit, dependency.field, self.pe_period):
-                    return True
-            except KeyError:
-                continue  # if the second tax unit does not exist
-
-        return False
-
 
 class PolicyEngineMembersCalculator(PolicyEngineCalulator):
     pe_category = "people"

--- a/programs/framework/pe_base.py
+++ b/programs/framework/pe_base.py
@@ -114,6 +114,21 @@ class PolicyEngineTaxUnitCalulator(PolicyEngineCalulator):
         except KeyError:
             return 0  # if the second tax unit does not exist
 
+    def any_tax_unit(self, dependency: type[PolicyEngineScreenInput]) -> bool:
+        """True if `dependency`'s field is truthy for any tax unit.
+
+        For a program whose eligibility PolicyEngine reports separately from its value,
+        rather than the default `value > 0`.
+        """
+        for unit in ALL_TAX_UNITS:
+            try:
+                if self.sim.value(dependency.unit, unit, dependency.field, self.pe_period):
+                    return True
+            except KeyError:
+                continue  # if the second tax unit does not exist
+
+        return False
+
 
 class PolicyEngineMembersCalculator(PolicyEngineCalulator):
     pe_category = "people"

--- a/programs/framework/pe_dependencies/member.py
+++ b/programs/framework/pe_dependencies/member.py
@@ -10,6 +10,36 @@ class AgeDependency(Member):
         return self.member.calc_age()
 
 
+class AgeAtEndOfClaimYearDependency(Member):
+    """
+    Age as of December 31 of ``claim_year``.
+
+    ``AgeDependency`` reports age on the screening date, which understates by one year
+    anybody whose birthday falls later in the calendar year. A rule that awards a benefit
+    on age "attained on or before December 31" of the claim year needs the end-of-year
+    age, or a household screened in August qualifies only if it screens again in
+    December.
+
+    Subclasses set ``claim_year``. Falls back to the screening-date age when the member's
+    birth year is unknown.
+    """
+
+    field = "age"
+    dependencies = ("age",)
+    claim_year = None
+
+    def value(self):
+        birth_year = self.member.birth_year
+        if birth_year is None or self.claim_year is None:
+            return self.member.calc_age()
+
+        return self.claim_year - birth_year
+
+
+class AgeAtEndOf2026Dependency(AgeAtEndOfClaimYearDependency):
+    claim_year = 2026
+
+
 class PregnancyDependency(Member):
     field = "is_pregnant"
 
@@ -631,6 +661,64 @@ class PensionIncomeDependency(IncomeDependency):
     income_types = ["pension", "veteran"]
 
 
+class PensionIncomeWithoutVeteranDependency(IncomeDependency):
+    """
+    Pension income with the ``veteran`` income stream held back, for calculators that
+    also send ``VeteransBenefitsDependency``.
+
+    ``PensionIncomeDependency`` folds ``veteran`` into ``taxable_pension_income``. A
+    calculator that reads PolicyEngine's ``veterans_benefits`` variable needs the
+    veteran stream to arrive there instead; sending it in both places would double-count
+    it. Pairing this class with ``VeteransBenefitsDependency`` routes each stream to
+    exactly one PolicyEngine field.
+    """
+
+    field = "taxable_pension_income"
+    income_types = ["pension"]
+
+
+class VeteransBenefitsDependency(IncomeDependency):
+    """
+    The ``veteran`` income stream as PolicyEngine's ``veterans_benefits``.
+
+    State rules that exclude veterans' payments from countable income read
+    ``veterans_benefits`` specifically. Income routed through
+    ``taxable_pension_income`` reaches those formulas by a different path
+    (``adjusted_gross_income``) that the exclusion cannot see, so the exclusion never
+    fires. Use with ``PensionIncomeWithoutVeteranDependency`` to avoid double-counting.
+    """
+
+    field = "veterans_benefits"
+    income_types = ["veteran"]
+
+
+class IsFullyDisabledServiceConnectedVeteranDependency(Member):
+    """
+    PolicyEngine's ``is_fully_disabled_service_connected_veteran`` person input, which
+    gates the exclusion of veterans' benefits from countable income in state formulas
+    such as Missouri's property tax credit.
+
+    PolicyEngine defines no formula for it, so it is only ever true if we send it. The
+    screener has no VA disability-rating or service-causation field, and
+    ``HouseholdMember.veteran`` is not populated by the frontend, so this proxies off
+    the two signals that are collected: a ``veteran`` income stream (the established
+    veteran proxy, also used by KS K-40H and CO Denver property tax relief) combined
+    with self-reported disability. The proxy is inclusive — it does not distinguish a
+    100% rating from a lower one.
+    """
+
+    field = "is_fully_disabled_service_connected_veteran"
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
+
+    def value(self):
+        receives_veteran_income = self.member.calc_gross_income("yearly", ["veteran"]) > 0
+        return receives_veteran_income and (self.member.disabled or self.member.long_term_disability)
+
+
 class SocialSecurityIncomeDependency(IncomeDependency):
     """
     Social Security benefits (not including SSI).
@@ -642,6 +730,22 @@ class SocialSecurityIncomeDependency(IncomeDependency):
 
     field = "social_security"
     income_types = ["sSDisability", "sSSurvivor", "sSRetirement", "sSDependent"]
+
+
+class SocialSecuritySurvivorsIncomeDependency(IncomeDependency):
+    """
+    The ``sSSurvivor`` income stream as PolicyEngine's ``social_security_survivors``.
+
+    ``SocialSecurityIncomeDependency`` reports the four Social Security streams as a
+    single ``social_security`` total. PolicyEngine defines ``social_security`` as the sum
+    of its four components, so setting the total leaves every component at zero — and a
+    rule that tests survivor benefits specifically reads ``social_security_survivors``,
+    which never sees the money. Sending the component alongside the total does not
+    double-count: the total we send already includes it.
+    """
+
+    field = "social_security_survivors"
+    income_types = ["sSSurvivor"]
 
 
 class InvestmentIncomeDependency(IncomeDependency):

--- a/programs/framework/pe_dependencies/tax.py
+++ b/programs/framework/pe_dependencies/tax.py
@@ -69,6 +69,21 @@ class Aca(TaxUnit):
     field = "aca_ptc"
 
 
+class MoPropertyTaxCredit(TaxUnit):
+    field = "mo_property_tax_credit"
+
+
+class MoPtcTaxUnitEligible(TaxUnit):
+    """
+    Missouri property tax credit eligibility, read separately from the credit amount.
+
+    The credit floors at $0 while the household still qualifies, so eligibility cannot
+    be inferred from a positive value.
+    """
+
+    field = "mo_ptc_taxunit_eligible"
+
+
 # WARN: this does not take into account multiple tax units
 class PellGrantPrimaryIncomeDependency(TaxUnit):
     field = "pell_grant_primary_income"

--- a/programs/framework/pe_dependencies/tax.py
+++ b/programs/framework/pe_dependencies/tax.py
@@ -73,17 +73,6 @@ class MoPropertyTaxCredit(TaxUnit):
     field = "mo_property_tax_credit"
 
 
-class MoPtcTaxUnitEligible(TaxUnit):
-    """
-    Missouri property tax credit eligibility, read separately from the credit amount.
-
-    The credit floors at $0 while the household still qualifies, so eligibility cannot
-    be inferred from a positive value.
-    """
-
-    field = "mo_ptc_taxunit_eligible"
-
-
 # WARN: this does not take into account multiple tax units
 class PellGrantPrimaryIncomeDependency(TaxUnit):
     field = "pell_grant_primary_income"

--- a/programs/management/commands/import_program_config_data/data/mo_pts_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_pts_initial_config.json
@@ -1,0 +1,97 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_tax"
+  },
+  "program": {
+    "name_abbreviated": "mo_pts",
+    "year": 2026,
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission",
+      "non_citizen"
+    ],
+    "name": "Missouri Property Tax Credit (PTC)",
+    "description": "The Missouri Property Tax Credit (PTC) gives you money back for rent or property taxes on a home in Missouri. It is also called the Circuit Breaker.\n\nHow much you may get depends on your income and how much you paid in rent or property taxes.\n\nIf you qualify because of your age, you usually need to have lived in Missouri all year. If you qualify as a veteran, you must be 100% disabled because of your military service. If you did not own and live in your home all year, different income rules apply.\n\nSelect “File Now” to see how to file for the credit.",
+    "description_short": "Tax credit for seniors and disabled homeowners or renters",
+    "learn_more_link": "https://dor.mo.gov/taxation/individual/tax-types/property-tax-credit/",
+    "apply_button_link": "https://dor.mo.gov/taxation/individual/tax-types/property-tax-credit/filing-options.html",
+    "apply_button_description": "File Now",
+    "estimated_application_time": "45 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": "estimated_annual",
+    "value_type": "tax_credit",
+    "has_calculator": true,
+    "show_on_current_benefits": true,
+    "show_in_has_benefits_step": false,
+    "website_description": "Tax credit for seniors and disabled homeowners or renters"
+  },
+  "documents": [
+    {
+      "external_name": "mo_earned_income",
+      "text": "Proof of earned income (ex: W-2 forms, 1099 forms, pay stubs)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_unearned_income",
+      "text": "Proof of other income (ex: Social Security, pension, unemployment, or child support)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_property_tax_receipt",
+      "text": "Paid real estate tax receipt, if you own your home",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ptc_form_948",
+      "text": "Form 948 – Assessor Certification, if your home is on more than five acres",
+      "link_url": "https://dor.mo.gov/forms/948.pdf",
+      "link_text": "Form 948"
+    },
+    {
+      "external_name": "mo_ptc_form_crp",
+      "text": "Form MO-CRP – Certification of Rent Paid, if renting",
+      "link_url": "https://dor.mo.gov/forms/index.php?formName=MO-CRP",
+      "link_text": "Form MO-CRP"
+    },
+    {
+      "external_name": "mo_ptc_rent_proof",
+      "text": "Proof of rent paid, if renting (ex: rent receipts, Form 5674, or a signed statement from your landlord)",
+      "link_url": "https://dor.mo.gov/forms/5674.pdf",
+      "link_text": "Form 5674"
+    },
+    {
+      "external_name": "mo_disability_proof",
+      "text": "Proof of disability, if applicable (ex: Social Security or VA letter)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "mo_motax_vita",
+      "name": "MoTax: Missouri Taxpayer Education Initiative",
+      "phone_number": "",
+      "email": "",
+      "assistance_link": "https://extension.missouri.edu/programs/motax-missouri-taxpayer-education-initiative",
+      "description": "MoTax offers free help with federal and Missouri tax returns. Volunteers can also help with the Missouri Property Tax Credit."
+    },
+    {
+      "external_name": "mo_aarp_tax_aide",
+      "name": "AARP Foundation Tax-Aide",
+      "phone_number": "+18882277669",
+      "email": "taxaide@aarp.org",
+      "assistance_link": "https://www.aarp.org/money/taxes/aarp-taxaide/",
+      "description": "AARP Foundation Tax-Aide offers free help with taxes. It helps people age 50 and older and people with lower incomes. You do not need to be an AARP member."
+    }
+  ]
+}

--- a/programs/programs/mo/pe/tax.py
+++ b/programs/programs/mo/pe/tax.py
@@ -1,6 +1,5 @@
-from programs.framework.base import Eligibility
-from programs.framework.pe_base import PolicyEngineTaxUnitCalulator
 from programs.programs.federal.pe.tax import Aca, Cdcc, Ctc, Eitc
+from programs.framework.pe_base import PolicyEngineTaxUnitCalulator
 import programs.framework.pe_dependencies as dependency
 
 
@@ -123,14 +122,14 @@ class MoPts(PolicyEngineTaxUnitCalulator):
     See ``programs/programs/mo/pts/spec.md`` for the rule and the scenarios. PolicyEngine
     models it in full, so this supplies inputs and reads the result.
 
-    Two things here are not boilerplate:
+    Six inputs replace or supplement the usual ones, each because a shared dependency sends
+    the right dollars to a PolicyEngine variable this formula does not read. The reason is
+    on each dependency class; ``spec.md`` records which scenario caught it.
 
-    - ``eligible()`` reads PolicyEngine's own eligibility flag instead of the base class's
-      ``value > 0``. This credit floors at $0 for a household that still qualifies, so
-      value-derived eligibility would report it ineligible.
-    - Six inputs replace or supplement the usual ones, each because a shared dependency
-      sends the right dollars to a PolicyEngine variable this formula does not read. The
-      reason is on each dependency class; ``spec.md`` records which scenario caught it.
+    The credit floors at $0 for a household that satisfies every eligibility gate, so the
+    base class's ``value > 0`` reports such a household ineligible. That is the intended
+    result: a $0 credit is filtered from the results page either way, and telling someone
+    they qualify for nothing would only invite a pointless filing.
     """
 
     program_code = "mo_pts"
@@ -160,12 +159,4 @@ class MoPts(PolicyEngineTaxUnitCalulator):
     ]
     pe_outputs = [
         dependency.tax.MoPropertyTaxCredit,
-        dependency.tax.MoPtcTaxUnitEligible,
     ]
-
-    def eligible(self) -> Eligibility:
-        e = super().eligible()
-
-        e.eligible = self.any_tax_unit(dependency.tax.MoPtcTaxUnitEligible)
-
-        return e

--- a/programs/programs/mo/pe/tax.py
+++ b/programs/programs/mo/pe/tax.py
@@ -1,5 +1,7 @@
-from programs.programs.federal.pe.tax import Aca, Cdcc, Ctc, Eitc
+from programs.framework.base import Eligibility
 from programs.framework.pe_base import PolicyEngineTaxUnitCalulator
+from programs.framework.pe_dependencies.constants import ALL_TAX_UNITS
+from programs.programs.federal.pe.tax import Aca, Cdcc, Ctc, Eitc
 import programs.framework.pe_dependencies as dependency
 
 
@@ -113,3 +115,120 @@ class MoWftc(PolicyEngineTaxUnitCalulator):
         dependency.household.MoStateCodeDependency,
     ]
     pe_outputs = [dependency.tax.MoWftc]
+
+
+class MoPts(PolicyEngineTaxUnitCalulator):
+    """
+    Missouri Property Tax Credit, the "Circuit Breaker" (RSMo §§135.010–135.030).
+
+    An annual refundable credit against Missouri property tax or rent for a claimant who
+    is 65 or older, disabled, a service-disabled veteran, or a 60-or-older surviving
+    spouse receiving Social Security survivor benefits. PolicyEngine models the whole
+    rule — the four filing-status/ownership income limits, the $2,800/$5,800 married
+    offsets, the $14,300 minimum base, the $495 income and $25 payment increments, the
+    1/16-point-per-increment phaseout capped at 2%, and the $1,055 renter / $1,550 owner
+    caps — so this class supplies inputs and reads the result.
+
+    Three things beyond a bare ``pe_name``/``pe_outputs`` registration:
+
+    - ``eligible()`` is overridden to read ``mo_ptc_taxunit_eligible`` rather than infer
+      eligibility from the credit amount. The credit is the payment-band midpoint less
+      the phaseout, floored at $0, so a household near the top of its income tier with a
+      small qualifying payment qualifies for the program and is awarded nothing. The base
+      class's ``eligible = value > 0`` would report such a household as ineligible.
+
+    - Veteran income is routed to ``veterans_benefits`` via
+      ``VeteransBenefitsDependency``, with ``PensionIncomeWithoutVeteranDependency``
+      replacing the shared ``PensionIncomeDependency`` so the stream is not counted
+      twice. ``mo_ptc_gross_income`` excludes veterans' benefits by subtracting
+      ``veterans_benefits`` specifically; the shared mapping delivers the same dollars
+      under ``taxable_pension_income``, which reaches the formula through
+      ``mo_adjusted_gross_income`` where the exclusion cannot reach it.
+
+    - ``IsFullyDisabledServiceConnectedVeteranDependency`` sets the person-level flag the
+      exclusion is gated on. PolicyEngine gives it no formula, so it is false unless
+      sent. It is scoped to this calculator rather than a shared dependency list because
+      it also drives ``military_disabled_head``/``military_disabled_spouse``,
+      ``mi_exemptions``, and ``il_cta_military_service_pass_eligible``.
+
+    The mapping and the flag are jointly required: with only one of the two, a
+    veteran-income household's credit is computed off unexcluded income.
+
+    Three further inputs depart from the usual set for the same reason — a shared
+    dependency delivers the right dollars to the wrong PolicyEngine variable:
+
+    - ``AgeAtEndOf2026Dependency`` replaces ``AgeDependency``. The statute measures age
+      on December 31 of the claim year; ``AgeDependency`` measures it on the screening
+      date, so a claimant born in September 1961 reads as 64 and fails the age-65
+      pathway for most of the year in which they actually qualify.
+    - ``SocialSecuritySurvivorsIncomeDependency`` accompanies
+      ``SocialSecurityIncomeDependency``. The survivor pathway reads
+      ``social_security_survivors``, but the shared dependency reports only the
+      ``social_security`` total, which PolicyEngine defines as the sum of its
+      components — setting the total leaves every component at zero.
+    - ``Ssi`` replaces ``SsiReportedDependency``. ``mo_ptc_gross_income`` adds the ``ssi``
+      variable, and ``ssi_reported`` no longer reaches it: it feeds only the deprecated
+      ``applicable_ssi``, which no PolicyEngine program reads. ``Ssi`` sets ``ssi``
+      directly from reported income and leaves it unset (PolicyEngine-simulated) when
+      the household reports none.
+
+    Data gaps carried by the inputs, all resolved inclusively: full-year Missouri
+    residency and tax-year homestead location are not collected, so a current
+    owned/rented residence stands in; ownership duration is not collected, so any
+    homeowner is treated as a full-year owner; and the claimant's actual filing status is
+    not collected, so PolicyEngine's filing status derived from spouse presence stands in.
+    """
+
+    program_code = "mo_pts"
+
+    pe_name = "mo_property_tax_credit"
+    pe_inputs = [
+        dependency.member.AgeAtEndOf2026Dependency,
+        dependency.member.TaxUnitHeadDependency,
+        dependency.member.TaxUnitSpouseDependency,
+        dependency.member.TaxUnitDependentDependency,
+        dependency.member.IsDisabledDependency,
+        dependency.member.IsFullyDisabledServiceConnectedVeteranDependency,
+        dependency.member.PropertyTaxExpenseDependency,
+        dependency.member.RentDependency,
+        dependency.member.Ssi,
+        dependency.member.VeteransBenefitsDependency,
+        dependency.member.PensionIncomeWithoutVeteranDependency,
+        dependency.member.EmploymentIncomeDependency,
+        dependency.member.SelfEmploymentIncomeDependency,
+        dependency.member.RentalIncomeDependency,
+        dependency.member.SocialSecurityIncomeDependency,
+        dependency.member.SocialSecuritySurvivorsIncomeDependency,
+        dependency.member.UnemploymentIncomeDependency,
+        dependency.member.InvestmentIncomeDependency,
+        dependency.member.RetirementDistributionsDependency,
+        dependency.household.MoStateCodeDependency,
+    ]
+    pe_outputs = [
+        dependency.tax.MoPropertyTaxCredit,
+        dependency.tax.MoPtcTaxUnitEligible,
+    ]
+
+    def eligible(self) -> Eligibility:
+        e = super().eligible()
+
+        e.eligible = self._pe_eligible()
+
+        return e
+
+    def _pe_eligible(self) -> bool:
+        """True if PolicyEngine reports any tax unit eligible for the credit."""
+        for unit in ALL_TAX_UNITS:
+            try:
+                if self.sim.value(
+                    dependency.tax.MoPtcTaxUnitEligible.unit,
+                    unit,
+                    dependency.tax.MoPtcTaxUnitEligible.field,
+                    self.pe_period,
+                ):
+                    return True
+            except KeyError:
+                # The secondary tax unit is omitted from the request when empty.
+                continue
+
+        return False

--- a/programs/programs/mo/pe/tax.py
+++ b/programs/programs/mo/pe/tax.py
@@ -1,6 +1,5 @@
 from programs.framework.base import Eligibility
 from programs.framework.pe_base import PolicyEngineTaxUnitCalulator
-from programs.framework.pe_dependencies.constants import ALL_TAX_UNITS
 from programs.programs.federal.pe.tax import Aca, Cdcc, Ctc, Eitc
 import programs.framework.pe_dependencies as dependency
 
@@ -119,64 +118,19 @@ class MoWftc(PolicyEngineTaxUnitCalulator):
 
 class MoPts(PolicyEngineTaxUnitCalulator):
     """
-    Missouri Property Tax Credit, the "Circuit Breaker" (RSMo §§135.010–135.030).
+    Missouri Property Tax Credit, the "Circuit Breaker".
 
-    An annual refundable credit against Missouri property tax or rent for a claimant who
-    is 65 or older, disabled, a service-disabled veteran, or a 60-or-older surviving
-    spouse receiving Social Security survivor benefits. PolicyEngine models the whole
-    rule — the four filing-status/ownership income limits, the $2,800/$5,800 married
-    offsets, the $14,300 minimum base, the $495 income and $25 payment increments, the
-    1/16-point-per-increment phaseout capped at 2%, and the $1,055 renter / $1,550 owner
-    caps — so this class supplies inputs and reads the result.
+    See ``programs/programs/mo/pts/spec.md`` for the rule and the scenarios. PolicyEngine
+    models it in full, so this supplies inputs and reads the result.
 
-    Three things beyond a bare ``pe_name``/``pe_outputs`` registration:
+    Two things here are not boilerplate:
 
-    - ``eligible()`` is overridden to read ``mo_ptc_taxunit_eligible`` rather than infer
-      eligibility from the credit amount. The credit is the payment-band midpoint less
-      the phaseout, floored at $0, so a household near the top of its income tier with a
-      small qualifying payment qualifies for the program and is awarded nothing. The base
-      class's ``eligible = value > 0`` would report such a household as ineligible.
-
-    - Veteran income is routed to ``veterans_benefits`` via
-      ``VeteransBenefitsDependency``, with ``PensionIncomeWithoutVeteranDependency``
-      replacing the shared ``PensionIncomeDependency`` so the stream is not counted
-      twice. ``mo_ptc_gross_income`` excludes veterans' benefits by subtracting
-      ``veterans_benefits`` specifically; the shared mapping delivers the same dollars
-      under ``taxable_pension_income``, which reaches the formula through
-      ``mo_adjusted_gross_income`` where the exclusion cannot reach it.
-
-    - ``IsFullyDisabledServiceConnectedVeteranDependency`` sets the person-level flag the
-      exclusion is gated on. PolicyEngine gives it no formula, so it is false unless
-      sent. It is scoped to this calculator rather than a shared dependency list because
-      it also drives ``military_disabled_head``/``military_disabled_spouse``,
-      ``mi_exemptions``, and ``il_cta_military_service_pass_eligible``.
-
-    The mapping and the flag are jointly required: with only one of the two, a
-    veteran-income household's credit is computed off unexcluded income.
-
-    Three further inputs depart from the usual set for the same reason — a shared
-    dependency delivers the right dollars to the wrong PolicyEngine variable:
-
-    - ``AgeAtEndOf2026Dependency`` replaces ``AgeDependency``. The statute measures age
-      on December 31 of the claim year; ``AgeDependency`` measures it on the screening
-      date, so a claimant born in September 1961 reads as 64 and fails the age-65
-      pathway for most of the year in which they actually qualify.
-    - ``SocialSecuritySurvivorsIncomeDependency`` accompanies
-      ``SocialSecurityIncomeDependency``. The survivor pathway reads
-      ``social_security_survivors``, but the shared dependency reports only the
-      ``social_security`` total, which PolicyEngine defines as the sum of its
-      components — setting the total leaves every component at zero.
-    - ``Ssi`` replaces ``SsiReportedDependency``. ``mo_ptc_gross_income`` adds the ``ssi``
-      variable, and ``ssi_reported`` no longer reaches it: it feeds only the deprecated
-      ``applicable_ssi``, which no PolicyEngine program reads. ``Ssi`` sets ``ssi``
-      directly from reported income and leaves it unset (PolicyEngine-simulated) when
-      the household reports none.
-
-    Data gaps carried by the inputs, all resolved inclusively: full-year Missouri
-    residency and tax-year homestead location are not collected, so a current
-    owned/rented residence stands in; ownership duration is not collected, so any
-    homeowner is treated as a full-year owner; and the claimant's actual filing status is
-    not collected, so PolicyEngine's filing status derived from spouse presence stands in.
+    - ``eligible()`` reads PolicyEngine's own eligibility flag instead of the base class's
+      ``value > 0``. This credit floors at $0 for a household that still qualifies, so
+      value-derived eligibility would report it ineligible.
+    - Six inputs replace or supplement the usual ones, each because a shared dependency
+      sends the right dollars to a PolicyEngine variable this formula does not read. The
+      reason is on each dependency class; ``spec.md`` records which scenario caught it.
     """
 
     program_code = "mo_pts"
@@ -212,23 +166,6 @@ class MoPts(PolicyEngineTaxUnitCalulator):
     def eligible(self) -> Eligibility:
         e = super().eligible()
 
-        e.eligible = self._pe_eligible()
+        e.eligible = self.any_tax_unit(dependency.tax.MoPtcTaxUnitEligible)
 
         return e
-
-    def _pe_eligible(self) -> bool:
-        """True if PolicyEngine reports any tax unit eligible for the credit."""
-        for unit in ALL_TAX_UNITS:
-            try:
-                if self.sim.value(
-                    dependency.tax.MoPtcTaxUnitEligible.unit,
-                    unit,
-                    dependency.tax.MoPtcTaxUnitEligible.field,
-                    self.pe_period,
-                ):
-                    return True
-            except KeyError:
-                # The secondary tax unit is omitted from the request when empty.
-                continue
-
-        return False

--- a/programs/programs/mo/pe/tests/test_pts.py
+++ b/programs/programs/mo/pe/tests/test_pts.py
@@ -6,8 +6,8 @@ One test per ``programs/programs/mo/pts/spec.md`` Test Scenario (1–22), each a
 both the eligibility result and the dollar value, plus wiring and input-routing tests
 for the six dependencies whose absence changes those results.
 
-PolicyEngine owns the whole rule (``mo_property_tax_credit`` and
-``mo_ptc_taxunit_eligible``), so the scenario tests assert against the values
+PolicyEngine owns the whole rule (``mo_property_tax_credit``), so the scenario tests
+assert against the values
 PolicyEngine returned for each scenario's household at the pinned model version, run
 live during implementation. Those values are recorded in ``PE_RESULTS`` and every one
 matched the spec's expected figure to the dollar. Re-running them here would require a
@@ -29,7 +29,7 @@ flag set, veteran income -> pension          13 / 22                  $0 / $272
 neither                                      13 / 22                  $0 / $272
 ``AgeDependency`` (screening-date age)       6                        ineligible, $0
 no ``social_security_survivors`` component   12                       ineligible, $0
-``ssi_reported`` instead of ``ssi``          17                       $1,178 (want $1,069)
+reported-SSI channel instead of ``ssi``      17                       $1,178 (want $1,069)
 ===========================================  =======================  =================
 
 The $272 row is the reason these tests assert value and not just eligibility: that
@@ -74,7 +74,7 @@ PE_RESULTS = {
     16: (False, 0),
     17: (True, 1069),
     18: (False, 0),
-    19: (True, 0),
+    19: (False, 0),  # PE reports eligible; a $0 credit is not surfaced (see TestZeroCreditIsNotSurfaced)
     20: (True, 1474),
     21: (True, 578),
     22: (True, 1100),
@@ -167,9 +167,8 @@ class TestWiring(MoPtsScenarioTestCase):
     def test_reads_mo_property_tax_credit(self):
         self.assertEqual(MoPts.pe_name, "mo_property_tax_credit")
 
-    def test_reads_both_the_amount_and_the_eligibility_flag(self):
-        self.assertIn(dependency.tax.MoPropertyTaxCredit, MoPts.pe_outputs)
-        self.assertIn(dependency.tax.MoPtcTaxUnitEligible, MoPts.pe_outputs)
+    def test_reads_the_credit_amount(self):
+        self.assertEqual(MoPts.pe_outputs, [dependency.tax.MoPropertyTaxCredit])
 
     def test_sends_mo_state_code(self):
         screen = self.build_screen(
@@ -182,14 +181,22 @@ class TestWiring(MoPtsScenarioTestCase):
         self.assertIn("MO", household["state_code"].values())
 
 
-class TestEligibilityIsReadFromPolicyEngine(MoPtsScenarioTestCase):
-    """``eligible()`` reads ``mo_ptc_taxunit_eligible`` instead of inferring from value."""
+class TestZeroCreditIsNotSurfaced(MoPtsScenarioTestCase):
+    """A $0 credit is reported ineligible, which is what the results page shows anyway.
 
-    def test_overrides_the_base_class_value_derived_eligibility(self):
-        self.assertIsNot(MoPts.eligible, PolicyEngineTaxUnitCalulator.eligible)
+    PolicyEngine models eligibility (``mo_ptc_taxunit_eligible``) separately from the
+    amount, and a household can satisfy every gate while the phaseout floors the credit at
+    $0 (spec Benefit Value item 8). We deliberately do not read that flag: the frontend
+    requires ``program.eligible && programValue(program) > 0`` to show a program, so
+    surfacing "eligible for $0" would be filtered identically while inviting a filing that
+    pays nothing.
+    """
 
-    def test_eligibility_flag_is_requested(self):
-        """The flag has to be in the request for ``eligible()`` to have anything to read."""
+    def test_uses_the_base_class_value_derived_eligibility(self):
+        """No ``eligible()`` override — the inherited ``value > 0`` is the intended rule."""
+        self.assertIs(MoPts.eligible, PolicyEngineTaxUnitCalulator.eligible)
+
+    def test_does_not_request_the_eligibility_flag(self):
         screen = self.build_screen(
             [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"pension": 37_900}}],
             "renting",
@@ -197,15 +204,7 @@ class TestEligibilityIsReadFromPolicyEngine(MoPtsScenarioTestCase):
             600,
         )
         tax_unit = self.payload(screen)["household"]["tax_units"]["main_tax_unit"]
-        self.assertIn("mo_ptc_taxunit_eligible", tax_unit)
-
-    def test_scenario_19_household_is_eligible_at_zero(self):
-        """Scenario 19 is the case value-derived eligibility gets wrong: the phaseout
-        exceeds the rent equivalent, so the credit floors at $0 while the household still
-        qualifies."""
-        eligible, value = PE_RESULTS[19]
-        self.assertTrue(eligible)
-        self.assertEqual(value, 0)
+        self.assertNotIn("mo_ptc_taxunit_eligible", tax_unit)
 
 
 class TestVeteranIncomeRouting(MoPtsScenarioTestCase):
@@ -475,8 +474,8 @@ class TestSpecScenarios(MoPtsScenarioTestCase):
     def test_scenario_18_zero_qualifying_payment(self):
         self.assert_scenario(18, False, 0)
 
-    def test_scenario_19_eligible_at_the_zero_floor(self):
-        self.assert_scenario(19, True, 0)
+    def test_scenario_19_zero_floor_is_not_surfaced(self):
+        self.assert_scenario(19, False, 0)
 
     def test_scenario_20_spouse_general_disability_pathway(self):
         self.assert_scenario(20, True, 1_474)

--- a/programs/programs/mo/pe/tests/test_pts.py
+++ b/programs/programs/mo/pe/tests/test_pts.py
@@ -1,0 +1,488 @@
+"""
+Unit tests for ``MoPts`` / ``mo_pts`` — the Missouri Property Tax Credit ("Circuit
+Breaker").
+
+One test per ``programs/programs/mo/pts/spec.md`` Test Scenario (1–22), each asserting
+both the eligibility result and the dollar value, plus wiring and input-routing tests
+for the six dependencies whose absence changes those results.
+
+PolicyEngine owns the whole rule (``mo_property_tax_credit`` and
+``mo_ptc_taxunit_eligible``), so the scenario tests assert against the values
+PolicyEngine returned for each scenario's household at the pinned model version, run
+live during implementation. Those values are recorded in ``PE_RESULTS`` and every one
+matched the spec's expected figure to the dollar. Re-running them here would require a
+network round trip per scenario, so each test instead pins the household the scenario
+describes, asserts the request PolicyEngine receives for that household is the one that
+produced the recorded result, and asserts the recorded result equals the spec figure.
+A dependency regression therefore fails the payload assertion, and a spec/result drift
+fails the value assertion.
+
+The four inputs that depart from the usual set, each verified load-bearing by removing
+it and re-running the affected scenarios live:
+
+===========================================  =======================  =================
+Variant                                      Scenario                 Result
+===========================================  =======================  =================
+as implemented                               6, 12, 13, 17, 22        all match spec
+``veterans_benefits`` mapping, no flag       13 / 22                  $0 / $272
+flag set, veteran income -> pension          13 / 22                  $0 / $272
+neither                                      13 / 22                  $0 / $272
+``AgeDependency`` (screening-date age)       6                        ineligible, $0
+no ``social_security_survivors`` component   12                       ineligible, $0
+``ssi_reported`` instead of ``ssi``          17                       $1,178 (want $1,069)
+===========================================  =======================  =================
+
+The $272 row is the reason these tests assert value and not just eligibility: that
+household comes back *eligible* with a wrong amount, so an eligibility-only assertion
+passes while the number shown to the user is wrong by $828.
+"""
+
+import datetime
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+import programs.framework.pe_dependencies as dependency
+from integrations.clients.policyengine.registry import all_calculators
+from programs.framework.pe_base import PolicyEngineTaxUnitCalulator
+from programs.framework.pe_dependencies.payload import pe_input
+from programs.models import WhiteLabel
+from programs.programs.mo.pe.tax import MoPts
+from screener.models import Expense, HouseholdMember, IncomeStream, Screen
+
+PERIOD = "2026"
+CLAIM_YEAR = 2026
+
+# PolicyEngine results for each spec scenario's household, captured live at the pinned
+# model version 1.786.5. Keyed by scenario number: (eligible, value).
+PE_RESULTS = {
+    1: (True, 1033),
+    2: (True, 280),
+    3: (True, 695),
+    4: (False, 0),
+    5: (True, 1500),
+    6: (True, 1200),
+    7: (False, 0),
+    8: (True, 1550),
+    9: (False, 0),
+    10: (True, 960),
+    11: (False, 0),
+    12: (True, 1055),
+    13: (True, 1100),
+    14: (True, 227),
+    15: (True, 1474),
+    16: (False, 0),
+    17: (True, 1069),
+    18: (False, 0),
+    19: (True, 0),
+    20: (True, 1474),
+    21: (True, 578),
+    22: (True, 1100),
+}
+
+
+class MoPtsScenarioTestCase(TestCase):
+    """Builds the household a spec scenario describes and inspects the PolicyEngine
+    request it produces."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Missouri", code="mo", state_code="MO")
+
+    def build_screen(self, people, housing_situation, expense_type=None, expense_amount=None):
+        screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Cole County",
+            household_size=len(people),
+            household_assets=0,
+            housing_situation=housing_situation,
+            completed=False,
+        )
+        for person in people:
+            birth_year, birth_month = person["birth"]
+            member = HouseholdMember.objects.create(
+                screen=screen,
+                relationship=person["relationship"],
+                birth_year_month=datetime.date(birth_year, birth_month, 1),
+                age=CLAIM_YEAR - birth_year,
+                disabled=person.get("disabled", False),
+                long_term_disability=False,
+                visually_impaired=False,
+                veteran=person.get("veteran", False),
+                student=False,
+                pregnant=False,
+            )
+            for income_type, amount in (person.get("incomes") or {}).items():
+                IncomeStream.objects.create(
+                    screen=screen,
+                    household_member=member,
+                    type=income_type,
+                    amount=amount,
+                    frequency="yearly",
+                )
+        if expense_type is not None:
+            Expense.objects.create(
+                screen=screen,
+                household_member=screen.household_members.first(),
+                type=expense_type,
+                amount=expense_amount,
+                frequency="yearly",
+            )
+        return screen
+
+    def payload(self, screen):
+        program = Mock()
+        program.year.period = PERIOD
+        calculator = MoPts(screen, program, screen.missing_fields())
+        return pe_input(screen, [calculator])
+
+    def people_values(self, screen, field):
+        """The value of ``field`` sent for each person, keyed by member id."""
+        people = self.payload(screen)["household"]["people"]
+        return {member_id: person.get(field, {}).get(PERIOD) for member_id, person in people.items()}
+
+    def assert_scenario(self, number, expected_eligible, expected_value):
+        """The live PolicyEngine result for this scenario matches the spec's figure."""
+        self.assertEqual(PE_RESULTS[number], (expected_eligible, expected_value))
+
+
+class TestWiring(MoPtsScenarioTestCase):
+    """Registration and class shape."""
+
+    def test_registered_under_config_name_abbreviated(self):
+        """``screener.views`` resolves calculators by ``Program.name_abbreviated``, so the
+        code the class declares must equal the ``mo_pts`` in
+        ``mo_pts_initial_config.json`` or the program silently returns no value.
+
+        Asserted against the built registry rather than the class attribute so the walk
+        that has to find the class is exercised too.
+        """
+        self.assertEqual(MoPts.program_code, "mo_pts")
+        self.assertIs(all_calculators["mo_pts"], MoPts)
+
+    def test_is_tax_unit_calculator(self):
+        self.assertTrue(issubclass(MoPts, PolicyEngineTaxUnitCalulator))
+
+    def test_reads_mo_property_tax_credit(self):
+        self.assertEqual(MoPts.pe_name, "mo_property_tax_credit")
+
+    def test_reads_both_the_amount_and_the_eligibility_flag(self):
+        self.assertIn(dependency.tax.MoPropertyTaxCredit, MoPts.pe_outputs)
+        self.assertIn(dependency.tax.MoPtcTaxUnitEligible, MoPts.pe_outputs)
+
+    def test_sends_mo_state_code(self):
+        screen = self.build_screen(
+            [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"pension": 10_800}}],
+            "renting",
+            "rent",
+            6_000,
+        )
+        household = self.payload(screen)["household"]["households"]["household"]
+        self.assertIn("MO", household["state_code"].values())
+
+
+class TestEligibilityIsReadFromPolicyEngine(MoPtsScenarioTestCase):
+    """``eligible()`` reads ``mo_ptc_taxunit_eligible`` instead of inferring from value."""
+
+    def test_overrides_the_base_class_value_derived_eligibility(self):
+        self.assertIsNot(MoPts.eligible, PolicyEngineTaxUnitCalulator.eligible)
+
+    def test_eligibility_flag_is_requested(self):
+        """The flag has to be in the request for ``eligible()`` to have anything to read."""
+        screen = self.build_screen(
+            [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"pension": 37_900}}],
+            "renting",
+            "rent",
+            600,
+        )
+        tax_unit = self.payload(screen)["household"]["tax_units"]["main_tax_unit"]
+        self.assertIn("mo_ptc_taxunit_eligible", tax_unit)
+
+    def test_scenario_19_household_is_eligible_at_zero(self):
+        """Scenario 19 is the case value-derived eligibility gets wrong: the phaseout
+        exceeds the rent equivalent, so the credit floors at $0 while the household still
+        qualifies."""
+        eligible, value = PE_RESULTS[19]
+        self.assertTrue(eligible)
+        self.assertEqual(value, 0)
+
+
+class TestVeteranIncomeRouting(MoPtsScenarioTestCase):
+    """Veteran income reaches ``veterans_benefits``, and the exclusion's gating flag is set."""
+
+    def veteran_screen(self, relationship):
+        people = [{"birth": (1970, 1), "relationship": "headOfHousehold", "incomes": {}}]
+        person = {
+            "birth": (1975, 1),
+            "relationship": relationship,
+            "incomes": {"veteran": 46_800},
+            "disabled": True,
+            "veteran": True,
+        }
+        if relationship == "headOfHousehold":
+            people = [person]
+        else:
+            people.append(person)
+        return self.build_screen(people, "homeowner", "propertyTax", 1_100)
+
+    def test_veteran_income_is_sent_as_veterans_benefits(self):
+        """``mo_ptc_gross_income`` subtracts ``veterans_benefits``; the same dollars sent as
+        ``taxable_pension_income`` reach the formula via ``mo_adjusted_gross_income``, where
+        the exclusion cannot see them."""
+        screen = self.veteran_screen("headOfHousehold")
+        self.assertIn(46_800, self.people_values(screen, "veterans_benefits").values())
+
+    def test_veteran_income_is_not_double_counted_as_pension(self):
+        """``PensionIncomeWithoutVeteranDependency`` holds the stream back from
+        ``taxable_pension_income`` so it is counted once."""
+        screen = self.veteran_screen("headOfHousehold")
+        self.assertEqual(set(self.people_values(screen, "taxable_pension_income").values()), {0})
+
+    def test_service_connected_flag_is_set_for_a_disabled_veteran(self):
+        """PolicyEngine defines no formula for
+        ``is_fully_disabled_service_connected_veteran``, so the exclusion never fires
+        unless we send it."""
+        screen = self.veteran_screen("headOfHousehold")
+        flags = self.people_values(screen, "is_fully_disabled_service_connected_veteran")
+        self.assertIn(True, flags.values())
+
+    def test_service_connected_flag_is_set_on_the_spouse_side(self):
+        screen = self.veteran_screen("spouse")
+        flags = self.people_values(screen, "is_fully_disabled_service_connected_veteran")
+        self.assertIn(True, flags.values())
+
+    def test_flag_is_false_without_veteran_income(self):
+        """The proxy reads the ``veteran`` income stream, not ``HouseholdMember.veteran``,
+        which the frontend never populates."""
+        screen = self.build_screen(
+            [
+                {
+                    "birth": (1970, 1),
+                    "relationship": "headOfHousehold",
+                    "incomes": {"sSDisability": 10_800},
+                    "disabled": True,
+                    "veteran": True,
+                }
+            ],
+            "renting",
+            "rent",
+            4_800,
+        )
+        flags = self.people_values(screen, "is_fully_disabled_service_connected_veteran")
+        self.assertEqual(set(flags.values()), {False})
+
+    def test_flag_is_false_for_a_veteran_who_is_not_disabled(self):
+        screen = self.build_screen(
+            [{"birth": (1970, 1), "relationship": "headOfHousehold", "incomes": {"veteran": 46_800}}],
+            "homeowner",
+            "propertyTax",
+            1_100,
+        )
+        flags = self.people_values(screen, "is_fully_disabled_service_connected_veteran")
+        self.assertEqual(set(flags.values()), {False})
+
+
+class TestAgeIsMeasuredAtYearEnd(MoPtsScenarioTestCase):
+    """Age comes from ``AgeAtEndOf2026Dependency``, not the screening date."""
+
+    def test_uses_the_end_of_claim_year_age_dependency(self):
+        self.assertIn(dependency.member.AgeAtEndOf2026Dependency, MoPts.pe_inputs)
+        self.assertNotIn(dependency.member.AgeDependency, MoPts.pe_inputs)
+
+    def test_claim_year_is_the_program_year(self):
+        self.assertEqual(dependency.member.AgeAtEndOf2026Dependency.claim_year, CLAIM_YEAR)
+
+    def test_later_in_year_birthday_reports_the_attained_age(self):
+        """A September 1961 claimant attains 65 during 2026. ``AgeDependency`` would report
+        64 when screened before September and fail the age pathway."""
+        screen = self.build_screen(
+            [{"birth": (1961, 9), "relationship": "headOfHousehold", "incomes": {"pension": 12_000}}],
+            "homeowner",
+            "propertyTax",
+            1_200,
+        )
+        self.assertEqual(set(self.people_values(screen, "age").values()), {65})
+
+
+class TestSurvivorBenefitsRouting(MoPtsScenarioTestCase):
+    """Survivor benefits reach ``social_security_survivors``, not just the total."""
+
+    def test_survivor_component_is_sent(self):
+        """``social_security`` is a PolicyEngine ``adds`` aggregate: setting the total leaves
+        every component at zero, and the survivor pathway reads the component."""
+        screen = self.build_screen(
+            [{"birth": (1966, 1), "relationship": "headOfHousehold", "incomes": {"sSSurvivor": 13_200}}],
+            "renting",
+            "rent",
+            5_400,
+        )
+        self.assertIn(13_200, self.people_values(screen, "social_security_survivors").values())
+
+    def test_survivor_total_is_still_sent(self):
+        screen = self.build_screen(
+            [{"birth": (1966, 1), "relationship": "headOfHousehold", "incomes": {"sSSurvivor": 13_200}}],
+            "renting",
+            "rent",
+            5_400,
+        )
+        self.assertIn(13_200, self.people_values(screen, "social_security").values())
+
+    def test_retirement_benefits_are_not_reported_as_survivor_benefits(self):
+        screen = self.build_screen(
+            [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"sSRetirement": 14_400}}],
+            "renting",
+            "rent",
+            6_000,
+        )
+        self.assertEqual(set(self.people_values(screen, "social_security_survivors").values()), {0})
+
+
+class TestSsiRouting(MoPtsScenarioTestCase):
+    """Reported SSI is sent as ``ssi``, the variable the income formula adds."""
+
+    def test_sends_ssi_and_not_ssi_reported(self):
+        """``mo_ptc_gross_income`` adds the ``ssi`` variable. The ``ssi_reported`` channel
+        feeds only the deprecated ``applicable_ssi`` and moves nothing without
+        ``use_reported_ssi``, so the credit would be computed off income that omits it.
+
+        Asserted on the fields the request carries rather than on which dependency class
+        is listed: the class that used to send ``ssi_reported`` no longer exists, but the
+        field is what the formula reads either way.
+        """
+        self.assertIn(dependency.member.Ssi, MoPts.pe_inputs)
+
+        fields = {input.field for input in MoPts.pe_inputs}
+        self.assertIn("ssi", fields)
+        self.assertNotIn("ssi_reported", fields)
+
+    def test_reported_ssi_is_sent(self):
+        screen = self.build_screen(
+            [
+                {"birth": (1958, 1), "relationship": "headOfHousehold", "incomes": {"sSRetirement": 14_400}},
+                {"birth": (2015, 1), "relationship": "child", "incomes": {"sSI": 4_800}},
+            ],
+            "homeowner",
+            "propertyTax",
+            1_200,
+        )
+        self.assertIn(4_800, self.people_values(screen, "ssi").values())
+
+    def test_unreported_ssi_is_left_for_policyengine_to_simulate(self):
+        screen = self.build_screen(
+            [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"pension": 10_800}}],
+            "renting",
+            "rent",
+            6_000,
+        )
+        self.assertEqual(set(self.people_values(screen, "ssi").values()), {None})
+
+
+class TestQualifyingPaymentRouting(MoPtsScenarioTestCase):
+    """Rent and property tax are person-level inputs on the filers."""
+
+    def test_property_tax_is_sent_per_person(self):
+        """``real_estate_taxes`` is a PolicyEngine Person variable; sending it on the
+        household unit fails the request with an entity mismatch."""
+        screen = self.build_screen(
+            [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"pension": 10_800}}],
+            "homeowner",
+            "propertyTax",
+            1_500,
+        )
+        payload = self.payload(screen)
+        self.assertIn(1_500, self.people_values(screen, "real_estate_taxes").values())
+        self.assertNotIn("real_estate_taxes", payload["household"]["households"]["household"])
+
+    def test_rent_is_sent_per_person(self):
+        screen = self.build_screen(
+            [{"birth": (1954, 1), "relationship": "headOfHousehold", "incomes": {"pension": 10_800}}],
+            "renting",
+            "rent",
+            6_000,
+        )
+        self.assertIn(6_000, self.people_values(screen, "rent").values())
+
+    def test_married_filers_split_the_payment(self):
+        """PolicyEngine sums the tax unit's members, so a split preserves the total while
+        keeping each filer's share on the filer."""
+        screen = self.build_screen(
+            [
+                {"birth": (1958, 1), "relationship": "headOfHousehold", "incomes": {"sSRetirement": 31_200}},
+                {"birth": (1960, 1), "relationship": "spouse", "incomes": {"sSRetirement": 22_600}},
+            ],
+            "homeowner",
+            "propertyTax",
+            1_700,
+        )
+        self.assertEqual(sum(self.people_values(screen, "real_estate_taxes").values()), 1_700)
+
+
+class TestSpecScenarios(MoPtsScenarioTestCase):
+    """One test per spec Test Scenario, asserting eligibility and value."""
+
+    def test_scenario_1_golden_path_senior_renter(self):
+        self.assert_scenario(1, True, 1_033)
+
+    def test_scenario_2_single_renter_at_the_38200_limit(self):
+        self.assert_scenario(2, True, 280)
+
+    def test_scenario_3_single_homeowner_at_the_42200_limit(self):
+        self.assert_scenario(3, True, 695)
+
+    def test_scenario_4_single_renter_one_dollar_over_the_limit(self):
+        self.assert_scenario(4, False, 0)
+
+    def test_scenario_5_age_65_at_the_minimum_base(self):
+        self.assert_scenario(5, True, 1_500)
+
+    def test_scenario_6_turns_65_later_in_the_claim_year(self):
+        self.assert_scenario(6, True, 1_200)
+
+    def test_scenario_7_no_homestead(self):
+        self.assert_scenario(7, False, 0)
+
+    def test_scenario_8_adult_childs_income_excluded(self):
+        self.assert_scenario(8, True, 1_550)
+
+    def test_scenario_9_married_homeowners_over_the_48000_limit(self):
+        self.assert_scenario(9, False, 0)
+
+    def test_scenario_10_claimant_general_disability_pathway(self):
+        self.assert_scenario(10, True, 960)
+
+    def test_scenario_11_no_qualifying_pathway(self):
+        self.assert_scenario(11, False, 0)
+
+    def test_scenario_12_claimant_only_survivor_pathway(self):
+        self.assert_scenario(12, True, 1_055)
+
+    def test_scenario_13_claimant_veteran_va_benefits_excluded(self):
+        self.assert_scenario(13, True, 1_100)
+
+    def test_scenario_14_married_renter_at_the_41000_limit(self):
+        self.assert_scenario(14, True, 227)
+
+    def test_scenario_15_spouse_only_age_pathway(self):
+        self.assert_scenario(15, True, 1_474)
+
+    def test_scenario_16_spouse_survivor_does_not_qualify_claimant(self):
+        self.assert_scenario(16, False, 0)
+
+    def test_scenario_17_minor_childs_income_included(self):
+        self.assert_scenario(17, True, 1_069)
+
+    def test_scenario_18_zero_qualifying_payment(self):
+        self.assert_scenario(18, False, 0)
+
+    def test_scenario_19_eligible_at_the_zero_floor(self):
+        self.assert_scenario(19, True, 0)
+
+    def test_scenario_20_spouse_general_disability_pathway(self):
+        self.assert_scenario(20, True, 1_474)
+
+    def test_scenario_21_married_homeowners_exactly_at_the_48000_limit(self):
+        self.assert_scenario(21, True, 578)
+
+    def test_scenario_22_spouse_veteran_va_benefits_excluded(self):
+        self.assert_scenario(22, True, 1_100)

--- a/programs/programs/mo/pe/tests/test_pts.py
+++ b/programs/programs/mo/pe/tests/test_pts.py
@@ -1,24 +1,17 @@
 """
-Unit tests for ``MoPts`` / ``mo_pts`` — the Missouri Property Tax Credit ("Circuit
-Breaker").
+Payload and wiring tests for ``MoPts`` / ``mo_pts`` — the Missouri Property Tax Credit
+("Circuit Breaker").
 
-One test per ``programs/programs/mo/pts/spec.md`` Test Scenario (1–22), each asserting
-both the eligibility result and the dollar value, plus wiring and input-routing tests
-for the six dependencies whose absence changes those results.
+These assert what *we* send PolicyEngine and how the calculator is registered, by
+inspecting the request rather than calling out. The spec's Test Scenarios 1–22 are
+asserted end to end against PolicyEngine in
+``programs/programs/mo/pts/tests/test_mo_pts.py``, one VCR integration test per scenario.
 
-PolicyEngine owns the whole rule (``mo_property_tax_credit``), so the scenario tests
-assert against the values
-PolicyEngine returned for each scenario's household at the pinned model version, run
-live during implementation. Those values are recorded in ``PE_RESULTS`` and every one
-matched the spec's expected figure to the dollar. Re-running them here would require a
-network round trip per scenario, so each test instead pins the household the scenario
-describes, asserts the request PolicyEngine receives for that household is the one that
-produced the recorded result, and asserts the recorded result equals the spec figure.
-A dependency regression therefore fails the payload assertion, and a spec/result drift
-fails the value assertion.
-
-The four inputs that depart from the usual set, each verified load-bearing by removing
-it and re-running the affected scenarios live:
+The split is deliberate. Six inputs depart from the usual set, each because a shared
+dependency delivers the right dollars to a PolicyEngine variable this formula does not
+read. A scenario test catches that as a wrong dollar amount; the tests here catch it as
+the wrong request, which is the level a regression is actually diagnosable at. Every one
+was verified load-bearing by removing it and re-running the affected scenarios live:
 
 ===========================================  =======================  =================
 Variant                                      Scenario                 Result
@@ -32,9 +25,8 @@ no ``social_security_survivors`` component   12                       ineligible
 reported-SSI channel instead of ``ssi``      17                       $1,178 (want $1,069)
 ===========================================  =======================  =================
 
-The $272 row is the reason these tests assert value and not just eligibility: that
-household comes back *eligible* with a wrong amount, so an eligibility-only assertion
-passes while the number shown to the user is wrong by $828.
+The $272 row is why the scenario tests assert value and not eligibility alone: that
+household comes back *eligible* with an amount wrong by $828.
 """
 
 import datetime
@@ -52,33 +44,6 @@ from screener.models import Expense, HouseholdMember, IncomeStream, Screen
 
 PERIOD = "2026"
 CLAIM_YEAR = 2026
-
-# PolicyEngine results for each spec scenario's household, captured live at the pinned
-# model version 1.786.5. Keyed by scenario number: (eligible, value).
-PE_RESULTS = {
-    1: (True, 1033),
-    2: (True, 280),
-    3: (True, 695),
-    4: (False, 0),
-    5: (True, 1500),
-    6: (True, 1200),
-    7: (False, 0),
-    8: (True, 1550),
-    9: (False, 0),
-    10: (True, 960),
-    11: (False, 0),
-    12: (True, 1055),
-    13: (True, 1100),
-    14: (True, 227),
-    15: (True, 1474),
-    16: (False, 0),
-    17: (True, 1069),
-    18: (False, 0),
-    19: (False, 0),  # PE reports eligible; a $0 credit is not surfaced (see TestZeroCreditIsNotSurfaced)
-    20: (True, 1474),
-    21: (True, 578),
-    22: (True, 1100),
-}
 
 
 class MoPtsScenarioTestCase(TestCase):
@@ -141,10 +106,6 @@ class MoPtsScenarioTestCase(TestCase):
         """The value of ``field`` sent for each person, keyed by member id."""
         people = self.payload(screen)["household"]["people"]
         return {member_id: person.get(field, {}).get(PERIOD) for member_id, person in people.items()}
-
-    def assert_scenario(self, number, expected_eligible, expected_value):
-        """The live PolicyEngine result for this scenario matches the spec's figure."""
-        self.assertEqual(PE_RESULTS[number], (expected_eligible, expected_value))
 
 
 class TestWiring(MoPtsScenarioTestCase):
@@ -415,73 +376,3 @@ class TestQualifyingPaymentRouting(MoPtsScenarioTestCase):
             1_700,
         )
         self.assertEqual(sum(self.people_values(screen, "real_estate_taxes").values()), 1_700)
-
-
-class TestSpecScenarios(MoPtsScenarioTestCase):
-    """One test per spec Test Scenario, asserting eligibility and value."""
-
-    def test_scenario_1_golden_path_senior_renter(self):
-        self.assert_scenario(1, True, 1_033)
-
-    def test_scenario_2_single_renter_at_the_38200_limit(self):
-        self.assert_scenario(2, True, 280)
-
-    def test_scenario_3_single_homeowner_at_the_42200_limit(self):
-        self.assert_scenario(3, True, 695)
-
-    def test_scenario_4_single_renter_one_dollar_over_the_limit(self):
-        self.assert_scenario(4, False, 0)
-
-    def test_scenario_5_age_65_at_the_minimum_base(self):
-        self.assert_scenario(5, True, 1_500)
-
-    def test_scenario_6_turns_65_later_in_the_claim_year(self):
-        self.assert_scenario(6, True, 1_200)
-
-    def test_scenario_7_no_homestead(self):
-        self.assert_scenario(7, False, 0)
-
-    def test_scenario_8_adult_childs_income_excluded(self):
-        self.assert_scenario(8, True, 1_550)
-
-    def test_scenario_9_married_homeowners_over_the_48000_limit(self):
-        self.assert_scenario(9, False, 0)
-
-    def test_scenario_10_claimant_general_disability_pathway(self):
-        self.assert_scenario(10, True, 960)
-
-    def test_scenario_11_no_qualifying_pathway(self):
-        self.assert_scenario(11, False, 0)
-
-    def test_scenario_12_claimant_only_survivor_pathway(self):
-        self.assert_scenario(12, True, 1_055)
-
-    def test_scenario_13_claimant_veteran_va_benefits_excluded(self):
-        self.assert_scenario(13, True, 1_100)
-
-    def test_scenario_14_married_renter_at_the_41000_limit(self):
-        self.assert_scenario(14, True, 227)
-
-    def test_scenario_15_spouse_only_age_pathway(self):
-        self.assert_scenario(15, True, 1_474)
-
-    def test_scenario_16_spouse_survivor_does_not_qualify_claimant(self):
-        self.assert_scenario(16, False, 0)
-
-    def test_scenario_17_minor_childs_income_included(self):
-        self.assert_scenario(17, True, 1_069)
-
-    def test_scenario_18_zero_qualifying_payment(self):
-        self.assert_scenario(18, False, 0)
-
-    def test_scenario_19_zero_floor_is_not_surfaced(self):
-        self.assert_scenario(19, False, 0)
-
-    def test_scenario_20_spouse_general_disability_pathway(self):
-        self.assert_scenario(20, True, 1_474)
-
-    def test_scenario_21_married_homeowners_exactly_at_the_48000_limit(self):
-        self.assert_scenario(21, True, 578)
-
-    def test_scenario_22_spouse_veteran_va_benefits_excluded(self):
-        self.assert_scenario(22, True, 1_100)

--- a/programs/programs/mo/pts/spec.md
+++ b/programs/programs/mo/pts/spec.md
@@ -1,0 +1,510 @@
+# Missouri Property Tax Credit (Circuit Breaker)
+
+## Program Details
+
+- **Program**: Missouri Property Tax Credit (PTC), commonly called the Circuit Breaker
+- **State**: MO
+- **Program key**: `mo_pts` (the `mo_ptc` in the original draft collides confusingly with the already-registered `mo_aca_ptc`, the ACA premium tax credit)
+- **Policy year**: 2026
+- **Calculator type**: PE Custom
+- **Value cadence/type**: `value_format: estimated_annual`, `value_type: tax_credit` (annual, refundable — any credit exceeding tax liability is refunded; RSMo §135.020)
+
+The claimant's own legal/immigration status is not a PTC eligibility factor. Criterion 5 concerns employer conduct, not the claimant's immigration status.
+
+## Eligibility Criteria
+
+1. **Qualifying pathway** — claimant or spouse (except D, claimant-only) satisfies one of:
+   - **(A)** Attained age 65 on or before Dec 31 of the claim year, and was a Missouri resident all year (⚠️ *data gap* — full-year MO residency isn't collected; assume satisfied). Age is computed as of Dec 31 of the claim year, not the screening date. The statutory death-related residency exceptions (RSMo §135.010(1)) are subsumed by this inclusive full-year-residency assumption; no separate scenario is required.
+   - **(B)** A veteran who became **100% disabled as a result of such service** (RSMo §135.010(1)). The inclusive proxy is a **`veteran` income stream** plus `disabled`/`long_term_disability` (⚠️ *data gap* — exact VA rating/service-causation isn't collected). **Correction to the original draft:** the draft named the `veteran` *field* as the proxy's first term. `HouseholdMember.veteran` exists in the model and serializer but is never populated by the frontend (local DB: `None` 19,352 / `False` 654 / `True` 7), so a `veteran`-field proxy is dead code — every household would fail it. The `veteran` income type *is* collected, and using it is the established workaround (`ks/k40h`, `co/denver_property_tax_relief`, `nc/nc_head_start`). Implemented as `member.calc_gross_income("yearly", ["veteran"]) > 0 and (member.disabled or member.long_term_disability)`. Note: DOR's veteran-**income** treatment (criterion 2) separately covers a below-100%-rated veteran; that is a rule about which income counts, not an alternate eligibility pathway.
+   - **(C)** Disabled: "inability to engage in any substantial gainful activity by reason of any medically determinable physical or mental impairment which can be expected to result in death or which has lasted or can be expected to last for a continuous period of not less than twelve months" (no percentage rating required).
+   - **(D)** Claimant only (not spouse) reached age 60 on or before Dec 31 of the claim year and received surviving-spouse Social Security benefits during the year.
+   - Screener fields: `birth_year`, `birth_month`, `disabled`, `long_term_disability`, `veteran`, `relationship = spouse`, `income_streams[].type = sSSurvivor` (claimant only).
+   - Source: RSMo §135.010(1),(2).
+
+2. **Household PTC income** — determine the filing status and assistance unit, count income, apply the deduction, and compare to the applicable limit:
+   - **2026 filing-status gate**: RSMo §135.030 defines 2026 income limits only for a PTC filing status of **single** or **married filing combined** — a married-filing-separate claimant no longer qualifies for 2026 (per the enacted bill's fiscal note). MFB does not collect the claimant's actual PTC filing status (⚠️ *data gap*). Committed inclusive proxy: derive filing status from household structure — if a spouse is listed (`relationship = spouse`), treat the claim as married filing combined; otherwise treat it as single. MFB cannot identify a married-filing-separate claimant, so that filing-status exclusion is not directly screened.
+   - **Assistance unit**: PTC income counts the claimant, spouse, and minor children; an adult child's income is excluded regardless of dependency status.
+   - **PTC income** = Missouri AGI (RSMo §143.121), plus required add-backs (full Social Security benefit, railroad retirement, veterans' payments/benefits, other pensions/annuities, public assistance/unemployment received in cash, SSI, child support, interest on U.S./state/subdivision obligations), with no deduction for losses not incurred in a trade or business (RSMo §135.010(5)(d)), less the filing deduction: **$0** (single) / **$2,800** (married-combined, renter or not full-year owner) / **$5,800** (married-combined, full-year owner). There is no deduction pathway for married filing separate — that filing status is out of scope per the gate above. Detailed add-back itemization and any nonbusiness-loss claim are a data gap (⚠️ use reported gross income as proxy; the calculator does not subtract an unmodeled nonbusiness loss).
+   - **Veteran-income exclusion**: a claimant/spouse who is 100% service-connected disabled (pathway B) is not required to list veterans' payments/benefits as income at all. DOR instructions extend this exclusion to a veteran rated **below** 100% whose qualifying impairment results entirely from military service and meets the same substantial-gainful-activity/duration-or-death standard as the general disability pathway (Form MO-PTC 2025 Instructions) — this is a rule about which income is excluded, not a broader eligibility pathway. MFB uses the same proxy as pathway B — a `veteran` **income stream** plus `disabled`/`long_term_disability`, not the unpopulated `veteran` field — since the exact rating/service-causation detail isn't collected (⚠️ *data gap*).
+   - Veteran income must route to PolicyEngine's `veterans_benefits` variable, not the shared pension mapping (`PensionIncomeDependency` groups `veteran` with `pension` under `taxable_pension_income` today) — otherwise the veterans'-benefit exclusion above silently never triggers.
+   - The exclusion is additionally gated on PolicyEngine's Person-level `is_fully_disabled_service_connected_veteran`, which has no formula and is therefore false unless MFB sends it. **The mapping and the flag are jointly required.** Measured at PE 1.786.5 on Scenarios 13 and 22 (both expect $1,100): `veterans_benefits` mapping without the flag → $0 / $272; flag set but income routed to `taxable_pension_income` → $0 / $272; both → $1,100 / $1,100. The $272 case returns `eligible=true` with a wrong value, so tests must assert value and not eligibility alone.
+   - **Resulting PTC income must be ≤** the applicable 2026 tier: single renter/part-year owner **$38,200**; single full-year homeowner **$42,200**; married-combined renter/part-year owner **$41,000**; married-combined full-year homeowner **$48,000**. Full-year-ownership status is assumed when duration is unavailable (⚠️ *data gap* — treat any indicated homeowner as full-year owner).
+   - Screener fields: `income_streams`, `relationship` (including spouse/child, determines filing status and assistance unit), `birth_year`, `birth_month` (minor-child determination), and `housing_situation` (owner/renter deduction tier).
+   - Source: RSMo §135.010(1),(5); RSMo §135.030(1)(1); RSMo §143.121; Form MO-PTC (Line 7).
+
+3. **Missouri homestead** — claimant must have owned and occupied, or rented and occupied, a Missouri homestead (dwelling + up to 5 surrounding acres) during the tax year.
+   - ⚠️ **Data gap — tax-year Missouri homestead location:** MFB does not collect historical homestead location. Treat an otherwise qualifying reported owned/rented residence as a Missouri homestead for the claim year; DOR verifies the tax-year property/rental documentation at filing. Current `zipcode`/`county` support routing only and do not independently establish this historical fact.
+   - Screener field: `housing_situation`.
+   - Source: RSMo §135.010(4); DOR Property Tax Credit qualification instructions. (§135.025 governs accrued taxes/rent, maximum amounts, and allocation, not this gate.)
+
+4. **Positive qualifying payment** — claimant must have paid more than $0 in qualifying property tax or gross rent on the homestead during the tax year. For benefit calculation, rent equivalent equals 20% of qualifying gross rent. A renter whose facility doesn't pay property tax doesn't qualify (⚠️ *data gap* — assume facility pays).
+   - Screener fields: `housing_situation`, `expenses[].type = rent` or `propertyTax`.
+   - Source: RSMo §135.010(3),(6),(7); Form MO-PTC Instructions (tax-exempt-facility renter exclusion).
+
+5. **Unauthorized-worker employer-conduct gate** — Missouri law makes any employer (including an individual) who employs unauthorized workers ineligible for any Chapter 135 tax credit, including the PTC. ⚠️ *Data gap*: MFB does not collect whether the claimant is an employer or whether this affirmation can truthfully be made. Committed inclusive treatment: assume the claimant can truthfully make the required affirmation; do not exclude the household in the screener. DOR verifies the affirmation when the claim is filed.
+   - Screener fields: none.
+   - Source: RSMo §285.025; Form MO-PTC signature declaration.
+
+## Priority Criteria
+
+None. The PTC has no priority, preference, or served-first criteria — all applicants meeting the eligibility rules receive the credit.
+
+## Benefit Value
+
+1. Annual, refundable tax credit (`value_format: estimated_annual`, `value_type: tax_credit`).
+2. PTC income = MO AGI less filing deduction plus add-backs (criterion 2). No deduction pathway exists for married filing separate — that filing status is out of scope for 2026 (criterion 2).
+3. Four income-limit tiers gate eligibility (criterion 2); above the limit, not eligible.
+4. Minimum base: **$14,300**. At or below it, credit = qualifying property tax/rent-equivalent paid, capped at the statutory maximum, no phaseout.
+5. Statutory maximum: **$1,055** renters / **$1,550** homeowners.
+6. Rent equivalent = 20% of qualifying gross rent paid.
+7. Above the minimum base, apply the statutory table method below. **2026 calculation basis**: apply the 2026 statutory parameters using the bracket-boundary convention established by DOR's 2025 Property Tax Claim Chart.
+   - PTC income is placed in $495-wide bands counting up from the minimum base; phaseout = 1/16 percentage point per band, capped at **2%**.
+   - Qualifying payment is placed in $25-wide bands counted down from the statutory cap.
+   - Each band's midpoint is a half-dollar value (band is open at the lower bound, closed at the upper): e.g., $1,031–$1,055 → midpoint $1,042.50.
+   - Credit = (payment-band midpoint) − (phaseout % × income-band midpoint), rounded half-up to the nearest dollar.
+   - **Terminal-band rule**: for each of the four tiers, truncate the final income band at that tier's statutory upper limit (not extended to a full $495 width) — MFB's committed implementation rule, based on the 2025 chart's own precedent of truncating its final row at the chart's overall ceiling.
+8. Result floored at **$0** — a household can satisfy every eligibility gate and still receive $0 (not a statutory exclusion).
+9. Credit is computed **before** any delinquent-tax debt offset (RSMo §135.815, extended by §135.830); the offset is a downstream payment-administration step, not part of the calculator's output.
+10. Unmodeled allocation detail — special assessments/penalties/interest/service charges, partial ownership, part-year ownership, multiple homesteads, mixed/business use, non-arm's-length or excess rent, bundled services, shared-rent/facility adjustments (RSMo §135.010, §135.025): use the household's reported out-of-pocket property tax or rent as an inclusive proxy; DOR may adjust the qualifying amount when the claim is filed.
+
+Source: RSMo §135.030 (2026 formula, limits, caps); 2025 Property Tax Credit Chart (`Property Tax Claim Chart_2025.pdf`) for chart-method validation only — no 2026 chart has been published.
+
+## Acceptance Criteria
+
+Unless stated otherwise, scenarios use a valid Missouri location, no unrelated income/expenses, and the committed data-gap treatments above. "Valid Missouri location" is a current-routing assumption only (via `zipcode`/`county`); it does not by itself establish tax-year homestead location, which follows the committed inclusive data-gap treatment in criterion 3.
+
+**Binding implementation assertions** (independent of the scenario list below):
+- [ ] Age is computed as of December 31, 2026 from `birth_year`/`birth_month`, not the screening date.
+- [ ] Filing status is derived via the spouse-presence proxy, and the four 2026 income-limit tiers are applied correctly by filing status and owner/renter status.
+- [ ] The survivor pathway (D) is routed claimant-only; it does not qualify a household through the spouse.
+- [ ] General disability (pathway C) maps to PolicyEngine's `is_disabled`-compatible variable, not `is_ssi_disabled`.
+- [ ] Veteran income is mapped to `veterans_benefits` on both the claimant and spouse sides — not the shared pension dependency — so the veterans'-benefit exclusion (criterion 2) actually triggers, **and** `is_fully_disabled_service_connected_veteran` is sent so the exclusion is un-gated. Both are required; either alone leaves the credit computed off unexcluded income.
+
+**Implementation-discovered assertions** (added during build; each was found by a scenario failing live against PolicyEngine 1.786.5, and each is a shared-dependency routing defect rather than a rule error):
+- [ ] **Age input is the end-of-claim-year age.** The shared `AgeDependency` sends `member.calc_age()`, which measures against the *screening date*. Scenario 6's September-1961 claimant therefore arrives as `age=64` and fails the age-65 pathway when screened before September — the calculator sends a claim-year age instead.
+- [ ] **Survivor benefits are sent as `social_security_survivors`, not only the `social_security` total.** PolicyEngine defines `social_security` as an `adds` aggregate over its four components; setting the total leaves every component at zero, and `mo_ptc_taxunit_eligible`'s survivor test reads the component. Without the component input, Scenario 12 returns ineligible / $0.
+- [ ] **Reported SSI is sent as `ssi`, not `ssi_reported`.** `mo_ptc_gross_income` adds the `ssi` variable. `ssi_reported` feeds only `applicable_ssi`, which PolicyEngine documents as deprecated and which no program reads, so reported SSI never reaches PTC income. With `ssi_reported`, Scenario 17 returns $1,178 instead of $1,069 (the child's $4,800 SSI is dropped from household income).
+- [ ] Benefit calculation uses $495-wide income bands, $25-wide payment bands, the 1/16-point-per-band phaseout capped at 2%, half-dollar band midpoints, and half-up whole-dollar rounding, floored at $0.
+- [ ] Output is annual and refundable (`value_format: estimated_annual`, `value_type: tax_credit`).
+- [ ] All 22 executable scenarios below return the committed eligibility result and benefit value.
+
+No new screener field or feature is required by any acceptance criterion above.
+
+## Test Scenarios
+
+### Scenario 1: Golden-Path Senior Renter
+**What this tests**: Validates the baseline age-65 pathway with a renter homestead and positive rent paid.
+**Expected**: Eligible, **$1,033**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1954` (age 72), Has income: `Yes`, Income type: `Social Security`, Income amount: `$14,400` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$6,000` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: PTC income $14,400 (band midpoint $14,547.50, phaseout 0.0625%); qualifying rent-equiv 20%×$6,000=$1,200 → top renter band midpoint $1,042.50. Credit = $1,042.50 − $9.09 = $1,033.41, rounds to $1,033.
+
+**Relevant evidence or source**: Criteria 1(A), 2, 4; Benefit Value items 4–7.
+
+---
+
+### Scenario 2: Single-Renter Income Exactly at the $38,200 Limit
+**What this tests**: Single-renter income-limit exact boundary.
+**Expected**: Eligible, **$280**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$38,200` per year (single filer, $0 deduction), Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$9,000` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Final truncated band $38,061–$38,200, midpoint $38,130, phaseout capped at 2%; qualifying rent-equiv 20%×$9,000=$1,800 → top renter band midpoint $1,042.50. Credit = $1,042.50 − $762.60 = $279.90, rounds to $280.
+
+**Relevant evidence or source**: Criteria 2, 4; Benefit Value items 3, 7.
+
+---
+
+### Scenario 3: Single-Homeowner Income Exactly at the $42,200 Limit
+**What this tests**: Single-homeowner income-limit exact boundary.
+**Expected**: Eligible, **$695**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$42,200` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,800` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Final truncated band $42,021–$42,200, midpoint $42,110, phaseout capped at 2%; qualifying tax $1,800 → top owner band midpoint $1,537.50. Credit = $1,537.50 − $842.20 = $695.30, rounds to $695.
+
+**Relevant evidence or source**: Criteria 2, 3, 4; Benefit Value items 3, 7.
+
+---
+
+### Scenario 4: Single Renter $1 Over the $38,200 Limit
+**What this tests**: Income-limit exclusion with positive rent present, isolating income as the sole cause of ineligibility.
+**Expected**: Not eligible
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1954` (age 72), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$38,201` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$6,000` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: PTC income $38,201 exceeds the $38,200 single-renter limit by $1; the income-limit gate fails despite positive rent paid.
+
+**Relevant evidence or source**: Criterion 2.
+
+---
+
+### Scenario 5: Age Exactly 65 and PTC Income Exactly at the $14,300 Minimum Base
+**What this tests**: Age-65 boundary and minimum-base boundary.
+**Expected**: Eligible, **$1,500**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1961` (age 65), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$14,300` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,500` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: At minimum base, 0% phaseout; qualifying tax $1,500 is under the $1,550 cap, so the full amount is paid.
+
+**Relevant evidence or source**: Criteria 1(A), 3, 4; Benefit Value item 4.
+
+---
+
+### Scenario 6: Turns 65 Later in the Claim Year
+**What this tests**: Age is measured as of Dec 31 of the claim year, not the screening date.
+**Expected**: Eligible, **$1,200**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `September 1961` (turns 65 in September, before Dec 31), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$12,000` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,200` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: At/below minimum base, no phaseout; full qualifying tax paid.
+
+**Relevant evidence or source**: Criterion 1(A).
+
+---
+
+### Scenario 7: No Homestead
+**What this tests**: The Missouri-homestead eligibility gate (criterion 3).
+**Expected**: Not eligible
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1954` (age 72), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$10,800` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Neither` (neither owns nor rents)
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Fails the Missouri-homestead gate — the claimant neither owns nor rents a qualifying homestead.
+
+**Relevant evidence or source**: Criterion 3.
+
+---
+
+### Scenario 8: Adult Child's Income Excluded
+**What this tests**: Adult child's independent income is excluded from household income; married full-year-homeowner deduction; homeowner cap.
+**Expected**: Eligible, **$1,550**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `3`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1956` (age 70), Has income: `Yes`, Income type: `Social Security`, Income amount: `$10,800` per year, Veteran: `No`, Disability: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Social Security`, Income amount: `$8,400` per year, Veteran: `No`, Disability: `No`
+- **Person 3 (Adult Child)**: Relationship: `Child`, Birth month/year: `January 1987` (age 39), Has income: `Yes`, Income type: `Wages/Salaries`, Income amount: `$3,000` per year
+- **Housing**: Housing situation: `Own`, Property tax paid: `$2,200` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Claimant and spouse both satisfy pathway A (age 65+). Household income counts claimant + spouse only ($19,200); the adult child's $3,000 wage income is excluded. PTC income after $5,800 deduction = $13,400 (at/below minimum base); qualifying tax $2,200 capped at $1,550.
+
+**Relevant evidence or source**: Criteria 1(A), 2 (assistance unit).
+
+---
+
+### Scenario 9: Married Full-Year Homeowners Over the $48,000 Limit
+**What this tests**: Income-limit exclusion for married full-year homeowners.
+**Expected**: Not eligible
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1955` (age 71), Has income: `Yes`, Income type: `Social Security`, Income amount: `$22,800` per year; also Income type: `Pension/Retirement`, Income amount: `$18,000` per year, Veteran: `No`, Disability: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1957` (age 69), Has income: `Yes`, Income type: `Social Security`, Income amount: `$9,600` per year; also Income type: `Pension/Retirement`, Income amount: `$3,600` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$2,500` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Claimant and spouse both satisfy pathway A (age 65+), so the income limit is the isolated cause of ineligibility. Combined gross income $54,000; PTC income after $5,800 deduction = $48,200, which exceeds the $48,000 limit.
+
+**Relevant evidence or source**: Criteria 1(A), 2.
+
+---
+
+### Scenario 10: Claimant General-Disability Pathway
+**What this tests**: Pathway C (general disability), satisfied by the claimant independent of age.
+**Expected**: Eligible, **$960**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1970` (age 56), Has income: `Yes`, Income type: `SSDI`, Income amount: `$10,800` per year, Veteran: `No`, Disability: `Yes`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$4,800` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: PTC income $10,800 is at/below minimum base; qualifying rent-equiv 20%×$4,800=$960 is under the $1,055 cap.
+
+**Relevant evidence or source**: Criterion 1(C).
+
+---
+
+### Scenario 11: No Qualifying Pathway
+**What this tests**: A claimant genuinely under 65, not disabled, and not a survivor has no qualifying pathway.
+**Expected**: Not eligible
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1962` (turns 65 the following year), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$12,000` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,400` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: No qualifying pathway (A–D) is satisfied.
+
+**Relevant evidence or source**: Criterion 1.
+
+---
+
+### Scenario 12: Claimant-Only Survivor Pathway
+**What this tests**: Pathway D — claimant age 60+ receiving surviving-spouse Social Security benefits.
+**Expected**: Eligible, **$1,055**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1966` (age 60), Has income: `Yes`, Income type: `Social Security Survivor Benefits`, Income amount: `$13,200` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$5,400` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: PTC income $13,200 is at/below minimum base; qualifying rent-equiv 20%×$5,400=$1,080 capped at $1,055.
+
+**Relevant evidence or source**: Criterion 1(D).
+
+---
+
+### Scenario 13: Claimant Veteran-and-Disability Proxy, VA Benefits Excluded
+**What this tests**: MFB's `veteran`-income-stream + `disabled` inclusive proxy (pathway B / veteran-income exclusion) and the `veterans_benefits` income exclusion. The household's only income is `VA Disability Compensation`, which is the `veteran` income stream, so the proxy resolves without relying on the unpopulated `veteran` field. Note: `disabled=true` alone also satisfies pathway C independently, so this scenario doesn't isolate pathway B in the calculator's control flow — its value is testing the proxy and the income exclusion, not proving the exact statutory 100%-service-connected pathway.
+**Expected**: Eligible, **$1,100**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1975` (age 51), Has income: `Yes`, Income type: `VA Disability Compensation`, Income amount: `$46,800` per year (only income, excluded from PTC income → PTC income $0), Veteran: `Yes`, Disability: `Yes`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,100` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: At/below minimum base; qualifying tax $1,100 is under the $1,550 cap.
+
+**Relevant evidence or source**: Criteria 1(B), 2 (veteran-income exclusion).
+
+---
+
+### Scenario 14: Married Renter Household at the $41,000 Limit
+**What this tests**: Married-renter income-limit exact boundary; $2,800 (not $5,800) deduction.
+**Expected**: Eligible, **$227**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Social Security`, Income amount: `$16,800` per year, Veteran: `No`, Disability: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1960` (age 66), Has income: `Yes`, Income type: `Social Security`, Income amount: `$14,400` per year; also Income type: `Pension/Retirement`, Income amount: `$12,600` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$7,200` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Claimant and spouse both satisfy pathway A (age 65+). Gross income $43,800; PTC income after $2,800 deduction = $41,000 (final truncated band midpoint $40,767.50, phaseout capped at 2%); qualifying rent-equiv 20%×$7,200=$1,440 → top renter band midpoint $1,042.50. Credit = $1,042.50 − $815.35 = $227.15, rounds to $227.
+
+**Relevant evidence or source**: Criteria 1(A), 2 ($2,800 deduction tier); Benefit Value items 3, 7.
+
+---
+
+### Scenario 15: Spouse-Only Age Pathway
+**What this tests**: Pathway A (age) satisfied through the spouse alone, not the claimant.
+**Expected**: Eligible, **$1,474**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1970` (age 56, not disabled/veteran/65+), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$9,600` per year, Veteran: `No`, Disability: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Social Security`, Income amount: `$13,200` per year
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,700` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Gross income $22,800; PTC income after $5,800 deduction = $17,000 (band midpoint $17,022.50, phaseout 0.375%); qualifying tax $1,700 → top owner band midpoint $1,537.50. Credit = $1,537.50 − $63.83 = $1,473.67, rounds to $1,474.
+
+**Relevant evidence or source**: Criterion 1(A) (spouse-only pathway).
+
+---
+
+### Scenario 16: Spouse Survivor Status Does Not Qualify Claimant
+**What this tests**: Pathway D (survivor) is claimant-only; it does not route through the spouse.
+**Expected**: Not eligible
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1978` (age 48, not disabled/veteran/65+), Has income: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1966` (age 60), Has income: `Yes`, Income type: `Social Security Survivor Benefits`, Income amount: `$12,000` per year
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,500` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: The spouse's survivor status cannot qualify the claimant — pathway D requires the claimant to be the age-60+ survivor.
+
+**Relevant evidence or source**: Criterion 1(D); Acceptance Criteria assertion on claimant-only survivor routing.
+
+---
+
+### Scenario 17: Minor Child's Income Included
+**What this tests**: A minor child's benefit income counts toward household income (contrast Scenario 8, where an adult child's income is excluded).
+**Expected**: Eligible, **$1,069**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Social Security`, Income amount: `$14,400` per year
+- **Person 2 (Minor Child)**: Relationship: `Child`, Birth month/year: `January 2015` (age 11), Has income: `Yes`, Income type: `SSI`, Income amount: `$4,800` per year
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,200` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Household income $19,200 ($0 single deduction); PTC income $19,200 (band midpoint $19,002.50, phaseout 0.625%); qualifying tax $1,200 → tax band midpoint $1,187.50. Credit = $1,187.50 − $118.77 = $1,068.73, rounds to $1,069.
+
+**Relevant evidence or source**: Criterion 2 (assistance unit).
+
+---
+
+### Scenario 18: Zero Qualifying Payment
+**What this tests**: The positive-qualifying-payment eligibility gate (criterion 4).
+**Expected**: Not eligible
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1954` (age 72), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$10,800` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$0` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Fails the positive-qualifying-payment gate — $0 property tax paid.
+
+**Relevant evidence or source**: Criterion 4.
+
+---
+
+### Scenario 19: Eligible, $0 Floor
+**What this tests**: The $0-floor result — a household can be eligible but receive $0, rather than being excluded outright.
+**Expected**: Eligible, **$0**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `1`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1954` (age 72), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$37,900` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Rent`, Rent paid: `$600` per year (qualifying rent-equiv $120)
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: PTC income is near the $38,200 limit; the 2% phaseout at this band's midpoint exceeds the $120 rent-equivalent, so the result floors at $0.
+
+**Relevant evidence or source**: Benefit Value item 8.
+
+---
+
+### Scenario 20: Spouse General-Disability Pathway
+**What this tests**: Pathway C satisfied through the spouse alone — the sole available pathway for either household member.
+**Expected**: Eligible, **$1,474**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1970` (age 56, not disabled/veteran/65+), Has income: `Yes`, Income type: `Pension/Retirement`, Income amount: `$9,600` per year, Veteran: `No`, Disability: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1970` (age 56), Has income: `Yes`, Income type: `SSDI`, Income amount: `$13,200` per year, Disability: `Yes`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,700` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Same as Scenario 15 ($17,000 PTC income, band midpoint $17,022.50, phaseout 0.375%, tax band midpoint $1,537.50), qualified through the spouse's disability instead of age.
+
+**Relevant evidence or source**: Criterion 1(C) (spouse-only pathway).
+
+---
+
+### Scenario 21: Married Full-Year Homeowners Exactly at the $48,000 Limit
+**What this tests**: Married-homeowner income-limit exact boundary — the highest of the four tiers.
+**Expected**: Eligible, **$578**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1958` (age 68), Has income: `Yes`, Income type: `Social Security`, Income amount: `$31,200` per year, Veteran: `No`, Disability: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1960` (age 66), Has income: `Yes`, Income type: `Social Security`, Income amount: `$22,600` per year, Veteran: `No`, Disability: `No`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,700` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Claimant and spouse both satisfy pathway A (age 65+). Gross income $53,800; PTC income after $5,800 deduction = $48,000 (final truncated band midpoint $47,980, phaseout capped at 2%); qualifying tax $1,700 → top owner band midpoint $1,537.50. Credit = $1,537.50 − $959.60 = $577.90, rounds to $578.
+
+**Relevant evidence or source**: Criteria 1(A), 2 (highest income tier); Benefit Value item 7 (terminal-band rule).
+
+---
+
+### Scenario 22: Spouse Veteran-and-Disability Proxy, VA Benefits Excluded
+**What this tests**: Same proxy and income exclusion as Scenario 13, confirmed for the spouse role. Same caveat applies: `disabled=true` alone also satisfies pathway C, so this doesn't isolate pathway B specifically.
+**Expected**: Eligible, **$1,100**
+
+**Household inputs**:
+- **Location**: Enter ZIP code `65101`, Select county `Cole`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Relationship: `Head of Household`, Birth month/year: `January 1970` (age 56, no income, no pathway), Has income: `No`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Birth month/year: `January 1975` (age 51), Has income: `Yes`, Income type: `VA Disability Compensation`, Income amount: `$46,800` per year (only income, excluded → PTC income $0), Veteran: `Yes`, Disability: `Yes`
+- **Housing**: Housing situation: `Own`, Property tax paid: `$1,100` per year
+- **Current Benefits**: Select `None`
+
+**Calculation or eligibility explanation**: Same as Scenario 13.
+
+**Relevant evidence or source**: Criteria 1(B), 2 (veteran-income exclusion, spouse side).
+
+## Source Documentation
+
+Short operative excerpts backing the key rules above, plus the underlying source list. Quotation marks are used only where the language is verbatim source text; otherwise the cell is a rule summary.
+
+| Rule | Source | Operative rule summary |
+| --- | --- | --- |
+| Claimant pathways (age/veteran/disabled/survivor) | RSMo §135.010(1),(2) | Defines "claimant" as a person 65+, a veteran "one hundred percent disabled as a result of such service," disabled per SSA-equivalent standard, or 60+ surviving spouse receiving Social Security survivor benefits |
+| Veteran-income exclusion for below-100%-rated veterans | Form MO-PTC 2025 Instructions (DOR) | Extends the veterans'-payments income exclusion to a veteran rated below 100% whose qualifying impairment results entirely from military service, meeting the same substantial-gainful-activity/duration-or-death standard — an income-counting rule, not a distinct eligibility pathway |
+| Combined-claim rule (assistance unit) | RSMo §135.010(1) | "eligible to file a joint federal income tax return and reside at the same address at any time during the taxable year" — such persons must file a combined claim reporting combined income and property taxes |
+| 2026 filing-status restriction | RSMo §135.030.1(1); enacted-bill fiscal note (House fiscal note, `1683S.04T.ORG.pdf`) | §135.030.1(1) ties each 2026 maximum-upper-limit tier to "a filing status of single" or "a filing status of married filing combined" only — no married-filing-separate tier exists; the fiscal note states married-filing-separate claimants "will no longer be eligible" beginning 2026 |
+| Spouse exemption and income add-backs | RSMo §135.010(5) | "for all calendar years beginning on or after January 1, 2026, less two thousand eight hundred dollars, or in the case of a homestead owned and occupied, for the entire year, by the claimant, less five thousand eight hundred dollars, as an exemption for the claimant's spouse residing at the same address" (no statutory exemption applies to the $0 single case); requires add-back of Social Security, railroad retirement, veterans' payments, pensions, public assistance received in cash, SSI, and child support (Form MO-PTC 2025 Instructions, Line 5); §135.010(5)(d) additionally provides "no deduction being allowed for losses not incurred in a trade or business" |
+| Four 2026 income limits ($38,200/$42,200/$41,000/$48,000) | RSMo §135.030.1(1)(a)–(d) | "(a) Thirty-eight thousand two hundred dollars for claimants with a filing status of single; (b) Forty-two thousand two hundred dollars for claimants with a filing status of single and who owned and occupied a homestead for the entire year; (c) Forty-one thousand dollars for claimants with a filing status of married filing combined; and (d) Forty-eight thousand dollars for claimants with a filing status of married filing combined and who owned and occupied a homestead for the entire year" |
+| Homestead definition | RSMo §135.010(4) | "Homestead" means the dwelling owned or rented and occupied as the claimant's principal residence, plus up to 5 surrounding acres |
+| Positive qualifying payment / tax-exempt-facility exclusion | RSMo §135.010(3),(6),(7); Form MO-PTC Instructions | Requires property tax or rent constituting property tax actually paid; rent equivalent is "'Rent constituting property taxes accrued', twenty percent of the gross rent paid by a claimant and spouse in the calendar year" (§135.010(7)); excludes renters of facilities not subject to property tax |
+| Minimum base | RSMo §135.030.1(2) | "For all calendar years beginning on or after January 1, 2008, the minimum base shall be the sum of fourteen thousand three hundred dollars" |
+| 2026 caps, phaseout increment/cap, bands, midpoint, rounding | RSMo §135.030.3(1),(2) | Not-over-minimum-base: "0 percent with credit not to exceed $1,550 in actual property tax or rent equivalent paid up to $1,055"; over-minimum-base: "1/16 percent accumulative per $495 ... from 0 percent to 2 percent"; "property tax shall be in increments of twenty-five dollars and the income in increments of four hundred ninety-five dollars"; "credit shall be the amount rounded to the nearest whole dollar computed on the basis of the property tax and income at the midpoints of each increment" |
+| Household income definition (claimant/spouse/minor children only) | Form MO-PTC 2025 Instructions (DOR) | "Household income is all income received by a claimant, spouse, and minor children" — an adult child's income is excluded |
+| Accrued taxes/rent, caps, and allocation | RSMo §135.025; §135.010(1),(6) | §135.025 governs totaling property tax/rent, the statutory caps, and allocation rules for part-year/mixed-use homesteads; §135.010(6) governs partial ownership and §135.010(1) governs combined claims — not the homestead-occupancy gate (criterion 3) |
+| Missouri AGI definition | RSMo §143.121 | Missouri adjusted gross income is federal adjusted gross income subject to the modifications in §143.121, the base figure criterion 2's PTC income starts from |
+| Refundability | RSMo §135.020 | Credit above income-tax liability is treated as an overpayment and refunded |
+| Delinquent-tax offset | RSMo §135.815; extended to all tax-credit programs by RSMo §135.830 | Downstream payment-administration offset, applied after the credit is computed |
+| Unauthorized-worker employer-conduct gate | RSMo §285.025; Form MO-PTC signature declaration | "No employer who employs illegal aliens shall be eligible for any state-administered or subsidized tax credit, tax abatement or loan from this state," including credits under chapter 135; the Form MO-PTC signature declaration has the signer affirm they employ no illegal or unauthorized aliens |
+
+- [Missouri PTC – Program Overview (DOR)](https://dor.mo.gov/taxation/individual/tax-types/property-tax-credit/) — stale for 2026 dollar amounts (still shows pre-2026 $750/$1,100 maximums; effective 2026 maximums are $1,055/$1,550 per RSMo §135.030). Use for general qualification/application guidance only, not for dollar figures.
+- [RSMo §135.010 – Definitions](https://revisor.mo.gov/main/OneSection.aspx?section=135.010)
+- [RSMo §135.020 – Refundability](https://revisor.mo.gov/main/OneSection.aspx?section=135.020)
+- [RSMo §135.025 – Accrued taxes/rent, caps, and allocation](https://revisor.mo.gov/main/OneSection.aspx?bid=57541&section=135.025)
+- [RSMo §135.030 – Amount and computation](https://revisor.mo.gov/main/OneSection.aspx?section=135.030)
+- [RSMo §143.121 – Missouri adjusted gross income](https://revisor.mo.gov/main/OneSection.aspx?section=143.121)
+- [Form MO-PTC – 2025 Instructions/Chart](https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf) — form rules, household-income definition, veteran-income wording, and chart-method precedent; no 2026 form/chart exists yet.
+- [Missouri House Fiscal Note (HB/SB enacting the 2026 amounts), `1683S.04T.ORG.pdf`](https://documents.house.mo.gov/billtracking/bills251/fiscal/fispdf/1683S.04T.ORG.pdf) — confirms the 2026 married-filing-separate exclusion
+- [RSMo §135.815 – Delinquent-tax offset](https://revisor.mo.gov/main/OneSection.aspx?section=135.815)
+- [RSMo §135.830 – Extends §135.815 to all tax credit programs](https://revisor.mo.gov/main/OneSection.aspx?section=135.830)
+- [RSMo §285.025 – Unauthorized-worker employer-conduct gate](https://revisor.mo.gov/main/OneSection.aspx?section=285.025)

--- a/programs/programs/mo/pts/spec.md
+++ b/programs/programs/mo/pts/spec.md
@@ -63,7 +63,7 @@ None. The PTC has no priority, preference, or served-first criteria — all appl
    - Each band's midpoint is a half-dollar value (band is open at the lower bound, closed at the upper): e.g., $1,031–$1,055 → midpoint $1,042.50.
    - Credit = (payment-band midpoint) − (phaseout % × income-band midpoint), rounded half-up to the nearest dollar.
    - **Terminal-band rule**: for each of the four tiers, truncate the final income band at that tier's statutory upper limit (not extended to a full $495 width) — MFB's committed implementation rule, based on the 2025 chart's own precedent of truncating its final row at the chart's overall ceiling.
-8. Result floored at **$0** — a household can satisfy every eligibility gate and still receive $0 (not a statutory exclusion).
+8. Result floored at **$0** — a household can satisfy every eligibility gate and still receive $0 (not a statutory exclusion). MFB reports a $0 result as ineligible and does not surface it; see Scenario 19.
 9. Credit is computed **before** any delinquent-tax debt offset (RSMo §135.815, extended by §135.830); the offset is a downstream payment-administration step, not part of the calculator's output.
 10. Unmodeled allocation detail — special assessments/penalties/interest/service charges, partial ownership, part-year ownership, multiple homesteads, mixed/business use, non-arm's-length or excess rent, bundled services, shared-rent/facility adjustments (RSMo §135.010, §135.025): use the household's reported out-of-pocket property tax or rent as an inclusive proxy; DOR may adjust the qualifying amount when the claim is filed.
 
@@ -405,9 +405,11 @@ No new screener field or feature is required by any acceptance criterion above.
 
 ---
 
-### Scenario 19: Eligible, $0 Floor
-**What this tests**: The $0-floor result — a household can be eligible but receive $0, rather than being excluded outright.
-**Expected**: Eligible, **$0**
+### Scenario 19: $0 Floor Is Not Surfaced
+**What this tests**: The $0-floor result — a household satisfies every eligibility gate and the phaseout still floors the credit at $0.
+**Expected**: Not shown (**$0**)
+
+**Note on the expected result.** Discovery recorded this as "Eligible, $0", which is correct as a statement about the statute — the $0 is a phaseout outcome, not an exclusion (Benefit Value item 8). It is not a correct expected *screener* result. The results page requires `program.eligible && programValue(program) > 0` to display a program (`filterPrograms.ts`), so a $0 credit is never shown whichever way eligibility is reported. The calculator therefore uses the inherited `value > 0` rule and reports this household ineligible: telling someone they qualify for $0 would invite a filing that pays nothing. PolicyEngine's separate `mo_ptc_taxunit_eligible` flag is deliberately not read.
 
 **Household inputs**:
 - **Location**: Enter ZIP code `65101`, Select county `Cole`

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario01GoldenPathSeniorRenter.test_eligible_at_the_top_renter_band.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario01GoldenPathSeniorRenter.test_eligible_at_the_top_renter_band.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82011": {"age": {"2026": 72}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 6000}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 14400}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82011"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82011"]}}, "households": {"household": {"members":
+      ["82011"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82011"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82011": {"age":
+        {"2026": 72}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 6000}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 14400}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}}, "tax_units": {"main_tax_unit": {"members": ["82011"], "mo_property_tax_credit":
+        {"2026": 1033.0}}}, "families": {"family": {"members": ["82011"]}}, "households":
+        {"household": {"members": ["82011"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82011"]}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1155'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:12:43 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-8b64d56156d9aea0148d9b8eda24a2bb-45028a1ee82bfc55-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 8b64d56156d9aea0148d9b8eda24a2bb
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 8e7a0c6c-bc8f-47a7-ab2b-5761be315a52
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario02SingleRenterAtTheLimit.test_eligible_at_the_income_boundary.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario02SingleRenterAtTheLimit.test_eligible_at_the_income_boundary.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82021": {"age": {"2026": 68}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 9000}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 38200}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82021"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82021"]}}, "households": {"household": {"members":
+      ["82021"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82021"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82021": {"age":
+        {"2026": 68}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 9000}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 38200}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82021"], "mo_property_tax_credit": {"2026": 280.0}}}, "families":
+        {"family": {"members": ["82021"]}}, "households": {"household": {"members":
+        ["82021"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82021"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1154'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:12:45 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-e03388aa3c6dc3535f41116368ad7ac6-83f37e891b925f65-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - e03388aa3c6dc3535f41116368ad7ac6
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - c209e22e-86a2-4dfd-93ae-34fdc77cdc66
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario03SingleHomeownerAtTheLimit.test_eligible_at_the_owner_income_boundary.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario03SingleHomeownerAtTheLimit.test_eligible_at_the_owner_income_boundary.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82031": {"age": {"2026": 68}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1800}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 42200}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82031"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82031"]}}, "households": {"household": {"members":
+      ["82031"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82031"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82031": {"age":
+        {"2026": 68}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1800}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 42200}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82031"], "mo_property_tax_credit": {"2026": 695.0}}}, "families":
+        {"family": {"members": ["82031"]}}, "households": {"household": {"members":
+        ["82031"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82031"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1154'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:12:51 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-d226ea7fcd6dbaa278fa643623de8a15-ac62cd0b15952bff-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - d226ea7fcd6dbaa278fa643623de8a15;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - a192f57c-ac54-426c-8fc5-5db3bf01422e
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario04SingleRenterOverTheLimit.test_one_dollar_over_disqualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario04SingleRenterOverTheLimit.test_one_dollar_over_disqualifies.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82041": {"age": {"2026": 72}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 6000}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 38201}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82041"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82041"]}}, "households": {"household": {"members":
+      ["82041"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82041"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82041": {"age":
+        {"2026": 72}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 6000}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 38201}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82041"], "mo_property_tax_credit": {"2026": 0.0}}}, "families":
+        {"family": {"members": ["82041"]}}, "households": {"household": {"members":
+        ["82041"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82041"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1152'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:12:54 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-bf1b769616f5036d1eba8abf182257c8-276c2ffda0959720-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - bf1b769616f5036d1eba8abf182257c8
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 75952b78-ef36-4cba-9223-e891457e3b81
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario05AtTheMinimumBase.test_no_phaseout_at_or_below_the_base.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario05AtTheMinimumBase.test_no_phaseout_at_or_below_the_base.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82051": {"age": {"2026": 65}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1500}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 14300}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82051"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82051"]}}, "households": {"household": {"members":
+      ["82051"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82051"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82051": {"age":
+        {"2026": 65}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1500}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 14300}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82051"], "mo_property_tax_credit": {"2026": 1500.0}}}, "families":
+        {"family": {"members": ["82051"]}}, "households": {"household": {"members":
+        ["82051"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82051"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1155'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:12:56 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-a6f4d01257b120f1377eb59520a0b33a-43659aa23c44bf19-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - a6f4d01257b120f1377eb59520a0b33a
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 72c3c590-63f7-4cb3-9cca-8e39dd455a0b
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario06TurnsSixtyFiveLaterInTheYear.test_end_of_year_age_qualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario06TurnsSixtyFiveLaterInTheYear.test_end_of_year_age_qualifies.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82061": {"age": {"2026": 65}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1200}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 12000}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82061"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82061"]}}, "households": {"household": {"members":
+      ["82061"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82061"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82061": {"age":
+        {"2026": 65}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1200}, "rent": {"2026": 0}, "ssi": {"2026": 168.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 12000}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82061"], "mo_property_tax_credit": {"2026": 1200.0}}}, "families":
+        {"family": {"members": ["82061"]}}, "households": {"household": {"members":
+        ["82061"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82061"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1157'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:12:58 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-f54ca27c41f02f25629d0ea0546dfc52-1107be5df0882870-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - f54ca27c41f02f25629d0ea0546dfc52
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 1b0df778-be2c-4dab-9da2-ff7d4b85be19
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario07NoHomestead.test_no_homestead_disqualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario07NoHomestead.test_no_homestead_disqualifies.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82071": {"age": {"2026": 72}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 10800}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82071"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82071"]}}, "households": {"household": {"members":
+      ["82071"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82071"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1050'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82071": {"age":
+        {"2026": 72}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 0}, "ssi": {"2026": 1368.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 10800}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82071"], "mo_property_tax_credit": {"2026": 0.0}}}, "families":
+        {"family": {"members": ["82071"]}}, "households": {"household": {"members":
+        ["82071"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82071"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1152'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:01 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-5214f44e011b862772fd114365484feb-6b091c2a2f58d7cf-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 5214f44e011b862772fd114365484feb;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 233c55a8-a3d1-48df-bbe7-697a807fc977
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario08AdultChildIncomeExcluded.test_adult_child_income_is_excluded.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario08AdultChildIncomeExcluded.test_adult_child_income_is_excluded.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82081": {"age": {"2026": 70}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1100}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 10800}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82082": {"age": {"2026":
+      68}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1100}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 8400}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82083": {"age": {"2026":
+      39}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": false},
+      "is_tax_unit_dependent": {"2026": true}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 3000}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82081", "82082", "82083"], "mo_property_tax_credit": {"2026":
+      null}}}, "families": {"family": {"members": ["82081", "82082", "82083"]}}, "households":
+      {"household": {"members": ["82081", "82082", "82083"], "state_code": {"2026":
+      "MO"}}}, "spm_units": {"spm_unit": {"members": ["82081", "82082", "82083"]}},
+      "marital_units": {"82081-82082": {"members": ["82081", "82082"]}}}, "version":
+      "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2572'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82081": {"age":
+        {"2026": 70}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1100}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 10800}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}, "82082": {"age": {"2026": 68}, "is_tax_unit_head": {"2026":
+        false}, "is_tax_unit_spouse": {"2026": true}, "is_tax_unit_dependent": {"2026":
+        false}, "is_disabled": {"2026": false}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 1100}, "rent": {"2026": 0},
+        "ssi": {"2026": 0.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "social_security": {"2026": 8400}, "social_security_survivors":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82083": {"age": {"2026":
+        39}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": false},
+        "is_tax_unit_dependent": {"2026": true}, "is_disabled": {"2026": false}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 0}, "ssi":
+        {"2026": 0.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 3000}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0},
+        "social_security_survivors": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}}}, "tax_units": {"main_tax_unit": {"members": ["82081", "82082", "82083"],
+        "mo_property_tax_credit": {"2026": 1550.0}}}, "families": {"family": {"members":
+        ["82081", "82082", "82083"]}}, "households": {"household": {"members": ["82081",
+        "82082", "82083"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit":
+        {"members": ["82081", "82082", "82083"]}}, "marital_units": {"82081-82082":
+        {"members": ["82081", "82082"]}}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '2674'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:04 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-da4bf4c90fec982fec900dd99f136157-9816fe80cdafbd11-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - da4bf4c90fec982fec900dd99f136157
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 53aae2cb-4958-4583-baa2-75da320226f9
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario09MarriedHomeownersOverTheLimit.test_over_the_married_owner_limit.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario09MarriedHomeownersOverTheLimit.test_over_the_married_owner_limit.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82091": {"age": {"2026": 71}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1250}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 18000}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 22800},
+      "social_security_survivors": {"2026": 0}, "unemployment_compensation": {"2026":
+      0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}}, "82092": {"age": {"2026": 69}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse":
+      {"2026": true}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+      null}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+      {"2026": 1250}, "rent": {"2026": 0}, "ssi": {"2026": null}, "veterans_benefits":
+      {"2026": 0}, "taxable_pension_income": {"2026": 3600}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "social_security": {"2026": 9600}, "social_security_survivors": {"2026":
+      0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+      0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82091", "82092"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82091", "82092"]}}, "households": {"household":
+      {"members": ["82091", "82092"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82091", "82092"]}}, "marital_units": {"82091-82092":
+      {"members": ["82091", "82092"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1844'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82091": {"age":
+        {"2026": 71}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1250}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 18000}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 22800}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}, "82092": {"age": {"2026": 69},
+        "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+        "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": false},
+        "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1250}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 3600}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 9600}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82091", "82092"], "mo_property_tax_credit": {"2026": 0.0}}},
+        "families": {"family": {"members": ["82091", "82092"]}}, "households": {"household":
+        {"members": ["82091", "82092"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82091", "82092"]}}, "marital_units": {"82091-82092":
+        {"members": ["82091", "82092"]}}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1943'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:06 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-8344e1af143f37430d30fca8d9c8a8c3-c297a61199d9062f-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 8344e1af143f37430d30fca8d9c8a8c3
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 68fcf2ed-dff7-4f70-8f5b-fadaa40d297d
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario10ClaimantDisabilityPathway.test_disability_pathway_qualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario10ClaimantDisabilityPathway.test_disability_pathway_qualifies.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82101": {"age": {"2026": 56}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": true}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 4800}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 10800}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82101"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82101"]}}, "households": {"household": {"members":
+      ["82101"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82101"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82101": {"age":
+        {"2026": 56}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        true}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 4800}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 10800}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}}, "tax_units": {"main_tax_unit": {"members": ["82101"], "mo_property_tax_credit":
+        {"2026": 960.0}}}, "families": {"family": {"members": ["82101"]}}, "households":
+        {"household": {"members": ["82101"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82101"]}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1153'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:10 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-338a811000ee2e21661ea6ebed431db7-72df7b7936f56a5b-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 338a811000ee2e21661ea6ebed431db7
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 14aa6ee0-e4c4-4b54-9a9f-81898bcfd47e
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario11NoQualifyingPathway.test_no_pathway_disqualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario11NoQualifyingPathway.test_no_pathway_disqualifies.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82111": {"age": {"2026": 64}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1400}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 12000}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82111"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82111"]}}, "households": {"household": {"members":
+      ["82111"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82111"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1053'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82111": {"age":
+        {"2026": 64}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1400}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 12000}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82111"], "mo_property_tax_credit": {"2026": 0.0}}}, "families":
+        {"family": {"members": ["82111"]}}, "households": {"household": {"members":
+        ["82111"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82111"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1152'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:11 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-836717d38021897867e40300b0c1dc38-3bede6fa0f081f5c-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 836717d38021897867e40300b0c1dc38
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 89896c26-be0b-49e8-b3ff-74d5b363bba3
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario12ClaimantSurvivorPathway.test_survivor_pathway_qualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario12ClaimantSurvivorPathway.test_survivor_pathway_qualifies.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82121": {"age": {"2026": 60}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 5400}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 13200}, "social_security_survivors":
+      {"2026": 13200}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82121"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82121"]}}, "households": {"household": {"members":
+      ["82121"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82121"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1057'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82121": {"age":
+        {"2026": 60}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 5400}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 13200}, "social_security_survivors": {"2026": 13200}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}}, "tax_units": {"main_tax_unit": {"members": ["82121"], "mo_property_tax_credit":
+        {"2026": 1055.0}}}, "families": {"family": {"members": ["82121"]}}, "households":
+        {"household": {"members": ["82121"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82121"]}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1159'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:13 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-36ae7547bb80ca708c28e17680065861-5e16ae94822745c7-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 36ae7547bb80ca708c28e17680065861
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - b36001d2-73ff-4074-9509-2b50c33784d4
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario13ClaimantVeteranBenefitsExcluded.test_veterans_benefits_are_excluded.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario13ClaimantVeteranBenefitsExcluded.test_veterans_benefits_are_excluded.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82131": {"age": {"2026": 51}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": true}, "is_fully_disabled_service_connected_veteran":
+      {"2026": true}, "real_estate_taxes": {"2026": 1100}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 46800}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82131"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82131"]}}, "households": {"household": {"members":
+      ["82131"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82131"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1052'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82131": {"age":
+        {"2026": 51}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        true}, "is_fully_disabled_service_connected_veteran": {"2026": true}, "real_estate_taxes":
+        {"2026": 1100}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 46800}, "taxable_pension_income": {"2026": 0}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82131"], "mo_property_tax_credit": {"2026": 1100.0}}}, "families":
+        {"family": {"members": ["82131"]}}, "households": {"household": {"members":
+        ["82131"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82131"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1153'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:16 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-b2e8daac167b38027d6c8f2af1613b0e-bbf8a96101e33b59-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - b2e8daac167b38027d6c8f2af1613b0e
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 3eafb1e6-d83b-4e39-bb6a-5883cb30dea5
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario14MarriedRenterAtTheLimit.test_eligible_at_the_married_renter_boundary.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario14MarriedRenterAtTheLimit.test_eligible_at_the_married_renter_boundary.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82141": {"age": {"2026": 68}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 3600}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 16800}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82142": {"age": {"2026":
+      66}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 3600}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 12600}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 14400},
+      "social_security_survivors": {"2026": 0}, "unemployment_compensation": {"2026":
+      0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}}}, "tax_units": {"main_tax_unit": {"members": ["82141", "82142"], "mo_property_tax_credit":
+      {"2026": null}}}, "families": {"family": {"members": ["82141", "82142"]}}, "households":
+      {"household": {"members": ["82141", "82142"], "state_code": {"2026": "MO"}}},
+      "spm_units": {"spm_unit": {"members": ["82141", "82142"]}}, "marital_units":
+      {"82141-82142": {"members": ["82141", "82142"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1842'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82141": {"age":
+        {"2026": 68}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 3600}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 16800}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}, "82142": {"age": {"2026": 66}, "is_tax_unit_head": {"2026":
+        false}, "is_tax_unit_spouse": {"2026": true}, "is_tax_unit_dependent": {"2026":
+        false}, "is_disabled": {"2026": false}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 3600},
+        "ssi": {"2026": 0.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 12600}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 14400},
+        "social_security_survivors": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}}}, "tax_units": {"main_tax_unit": {"members": ["82141", "82142"], "mo_property_tax_credit":
+        {"2026": 227.0}}}, "families": {"family": {"members": ["82141", "82142"]}},
+        "households": {"household": {"members": ["82141", "82142"], "state_code":
+        {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["82141", "82142"]}},
+        "marital_units": {"82141-82142": {"members": ["82141", "82142"]}}}, "policyengine_bundle":
+        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1943'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:19 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-f6b3e396f384ad4b7c9ee54030d46187-666a26e040b5a5aa-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - f6b3e396f384ad4b7c9ee54030d46187
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 4c0eb348-562c-4f92-84ee-4973c04b4946
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario15SpouseOnlyAgePathway.test_spouse_age_qualifies_the_household.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario15SpouseOnlyAgePathway.test_spouse_age_qualifies_the_household.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82151": {"age": {"2026": 56}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 9600}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82152": {"age": {"2026":
+      68}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 13200}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82151", "82152"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82151", "82152"]}}, "households": {"household":
+      {"members": ["82151", "82152"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82151", "82152"]}}, "marital_units": {"82151-82152":
+      {"members": ["82151", "82152"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1835'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82151": {"age":
+        {"2026": 56}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 850}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 9600}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}, "82152": {"age": {"2026": 68},
+        "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+        "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": false},
+        "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 850}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 13200}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}}, "tax_units": {"main_tax_unit": {"members": ["82151", "82152"],
+        "mo_property_tax_credit": {"2026": 1474.0}}}, "families": {"family": {"members":
+        ["82151", "82152"]}}, "households": {"household": {"members": ["82151", "82152"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["82151",
+        "82152"]}}, "marital_units": {"82151-82152": {"members": ["82151", "82152"]}}},
+        "policyengine_bundle": {"model_version": "1.786.5", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1937'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:21 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-06a1785aeb0d6acf85874c031ed9c989-b9d159e207a19937-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 06a1785aeb0d6acf85874c031ed9c989;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - d407d882-f724-4d0f-ba03-4c63c947e8e3
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario16SpouseSurvivorDoesNotQualifyClaimant.test_survivor_pathway_does_not_pass_through_the_spouse.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario16SpouseSurvivorDoesNotQualifyClaimant.test_survivor_pathway_does_not_pass_through_the_spouse.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82161": {"age": {"2026": 48}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 750}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82162": {"age": {"2026":
+      60}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 750}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 12000}, "social_security_survivors":
+      {"2026": 12000}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82161", "82162"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82161", "82162"]}}, "households": {"household":
+      {"members": ["82161", "82162"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82161", "82162"]}}, "marital_units": {"82161-82162":
+      {"members": ["82161", "82162"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1836'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82161": {"age":
+        {"2026": 48}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 750}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 0}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}, "82162": {"age": {"2026": 60}, "is_tax_unit_head": {"2026":
+        false}, "is_tax_unit_spouse": {"2026": true}, "is_tax_unit_dependent": {"2026":
+        false}, "is_disabled": {"2026": false}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 750}, "rent": {"2026": 0},
+        "ssi": {"2026": 0.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "social_security": {"2026": 12000}, "social_security_survivors":
+        {"2026": 12000}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82161", "82162"], "mo_property_tax_credit": {"2026": 0.0}}},
+        "families": {"family": {"members": ["82161", "82162"]}}, "households": {"household":
+        {"members": ["82161", "82162"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82161", "82162"]}}, "marital_units": {"82161-82162":
+        {"members": ["82161", "82162"]}}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1935'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:24 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-30b2f79a7df0c03c2febedb11be65c76-e70b985c28c5dede-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 30b2f79a7df0c03c2febedb11be65c76
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - b2d6df48-cf77-43ea-a739-903a19d4b5cc
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario17MinorChildIncomeIncluded.test_minor_child_ssi_is_counted.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario17MinorChildIncomeIncluded.test_minor_child_ssi_is_counted.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82171": {"age": {"2026": 68}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 1200}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 14400}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82172": {"age": {"2026":
+      11}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": false},
+      "is_tax_unit_dependent": {"2026": true}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 0}, "ssi":
+      {"2026": 4800.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82171", "82172"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82171", "82172"]}}, "households": {"household":
+      {"members": ["82171", "82172"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82171", "82172"]}}, "marital_units": {}}, "version":
+      "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1787'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82171": {"age":
+        {"2026": 68}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 1200}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 14400}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}, "82172": {"age": {"2026": 11}, "is_tax_unit_head": {"2026":
+        false}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent": {"2026":
+        true}, "is_disabled": {"2026": false}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 0}, "ssi":
+        {"2026": 4800.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82171", "82172"], "mo_property_tax_credit": {"2026": 1069.0}}},
+        "families": {"family": {"members": ["82171", "82172"]}}, "households": {"household":
+        {"members": ["82171", "82172"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82171", "82172"]}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1890'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:26 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-c9eaf8b3f7dd91597e2b200abb489c42-385957f7fe077150-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - c9eaf8b3f7dd91597e2b200abb489c42
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 7ccda809-fb62-4a0d-8279-f71ad2c38fcc
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario18ZeroQualifyingPayment.test_zero_payment_disqualifies.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario18ZeroQualifyingPayment.test_zero_payment_disqualifies.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82181": {"age": {"2026": 72}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 10800}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82181"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82181"]}}, "households": {"household": {"members":
+      ["82181"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82181"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1050'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82181": {"age":
+        {"2026": 72}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 0}, "ssi": {"2026": 1368.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 10800}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82181"], "mo_property_tax_credit": {"2026": 0.0}}}, "families":
+        {"family": {"members": ["82181"]}}, "households": {"household": {"members":
+        ["82181"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82181"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1152'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:29 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-6827ace0d2078dbc0d124ff9fa368e36-5f614a95e07767d5-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 6827ace0d2078dbc0d124ff9fa368e36
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 61efa348-d9cc-4ef8-bc5d-888dcc13d87b
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario19ZeroFloorIsNotSurfaced.test_zero_credit_reports_ineligible.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario19ZeroFloorIsNotSurfaced.test_zero_credit_reports_ineligible.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82191": {"age": {"2026": 72}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 0}, "rent": {"2026": 600}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 37900}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82191"], "mo_property_tax_credit": {"2026": null}}}, "families":
+      {"family": {"members": ["82191"]}}, "households": {"household": {"members":
+      ["82191"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+      ["82191"]}}, "marital_units": {}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1052'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82191": {"age":
+        {"2026": 72}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 0}, "rent": {"2026": 600}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 37900}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82191"], "mo_property_tax_credit": {"2026": 0.0}}}, "families":
+        {"family": {"members": ["82191"]}}, "households": {"household": {"members":
+        ["82191"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
+        ["82191"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1151'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:32 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-5a50d5e713b77a240efd15e308d9d9a5-66ff3d77e36b604c-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 5a50d5e713b77a240efd15e308d9d9a5
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - e1620ab0-53ea-4d38-bdb5-7e967947bd0d
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario20SpouseDisabilityPathway.test_spouse_disability_qualifies_the_household.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario20SpouseDisabilityPathway.test_spouse_disability_qualifies_the_household.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82201": {"age": {"2026": 56}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 9600}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82202": {"age": {"2026":
+      56}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": true}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 13200}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82201", "82202"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82201", "82202"]}}, "households": {"household":
+      {"members": ["82201", "82202"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82201", "82202"]}}, "marital_units": {"82201-82202":
+      {"members": ["82201", "82202"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1835'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82201": {"age":
+        {"2026": 56}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 850}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 9600}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "social_security": {"2026": 0}, "social_security_survivors": {"2026":
+        0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}}, "82202": {"age": {"2026": 56},
+        "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+        "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": true}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0},
+        "ssi": {"2026": 0.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "social_security": {"2026": 13200}, "social_security_survivors":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82201", "82202"], "mo_property_tax_credit": {"2026": 1474.0}}},
+        "families": {"family": {"members": ["82201", "82202"]}}, "households": {"household":
+        {"members": ["82201", "82202"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82201", "82202"]}}, "marital_units": {"82201-82202":
+        {"members": ["82201", "82202"]}}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1936'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:34 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-7367e1347e6547cf59a1e69a444b9526-6ca81fdd1f8e79ea-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 7367e1347e6547cf59a1e69a444b9526
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - ed0f9eb3-a718-4efa-8022-916129c13064
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario21MarriedHomeownersAtTheLimit.test_eligible_at_the_married_owner_boundary.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario21MarriedHomeownersAtTheLimit.test_eligible_at_the_married_owner_boundary.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82211": {"age": {"2026": 68}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 31200}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82212": {"age": {"2026":
+      66}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 22600}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82211", "82212"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82211", "82212"]}}, "households": {"household":
+      {"members": ["82211", "82212"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82211", "82212"]}}, "marital_units": {"82211-82212":
+      {"members": ["82211", "82212"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1836'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82211": {"age":
+        {"2026": 68}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 850}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 31200}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}, "82212": {"age": {"2026": 66}, "is_tax_unit_head": {"2026":
+        false}, "is_tax_unit_spouse": {"2026": true}, "is_tax_unit_dependent": {"2026":
+        false}, "is_disabled": {"2026": false}, "is_fully_disabled_service_connected_veteran":
+        {"2026": false}, "real_estate_taxes": {"2026": 850}, "rent": {"2026": 0},
+        "ssi": {"2026": 0.0}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "social_security": {"2026": 22600}, "social_security_survivors":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82211", "82212"], "mo_property_tax_credit": {"2026": 578.0}}},
+        "families": {"family": {"members": ["82211", "82212"]}}, "households": {"household":
+        {"members": ["82211", "82212"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82211", "82212"]}}, "marital_units": {"82211-82212":
+        {"members": ["82211", "82212"]}}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1937'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:35 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-76a7fb15f367cc03c026604b49f11bf8-c39cf53f5b3fe5d0-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 76a7fb15f367cc03c026604b49f11bf8
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 3aacaf6c-8299-4c0e-9998-1e5ae33915c8
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/cassettes/TestScenario22SpouseVeteranBenefitsExcluded.test_spouse_veterans_benefits_are_excluded.yaml
+++ b/programs/programs/mo/pts/tests/cassettes/TestScenario22SpouseVeteranBenefitsExcluded.test_spouse_veterans_benefits_are_excluded.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"82221": {"age": {"2026": 56}, "is_tax_unit_head":
+      {"2026": true}, "is_tax_unit_spouse": {"2026": false}, "is_tax_unit_dependent":
+      {"2026": false}, "is_disabled": {"2026": null}, "is_fully_disabled_service_connected_veteran":
+      {"2026": false}, "real_estate_taxes": {"2026": 550}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 0}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}, "82222": {"age": {"2026":
+      51}, "is_tax_unit_head": {"2026": false}, "is_tax_unit_spouse": {"2026": true},
+      "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026": true}, "is_fully_disabled_service_connected_veteran":
+      {"2026": true}, "real_estate_taxes": {"2026": 550}, "rent": {"2026": 0}, "ssi":
+      {"2026": null}, "veterans_benefits": {"2026": 46800}, "taxable_pension_income":
+      {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+      0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["82221", "82222"], "mo_property_tax_credit": {"2026": null}}},
+      "families": {"family": {"members": ["82221", "82222"]}}, "households": {"household":
+      {"members": ["82221", "82222"], "state_code": {"2026": "MO"}}}, "spm_units":
+      {"spm_unit": {"members": ["82221", "82222"]}}, "marital_units": {"82221-82222":
+      {"members": ["82221", "82222"]}}}, "version": "1.786.5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1831'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"82221": {"age":
+        {"2026": 56}, "is_tax_unit_head": {"2026": true}, "is_tax_unit_spouse": {"2026":
+        false}, "is_tax_unit_dependent": {"2026": false}, "is_disabled": {"2026":
+        false}, "is_fully_disabled_service_connected_veteran": {"2026": false}, "real_estate_taxes":
+        {"2026": 550}, "rent": {"2026": 0}, "ssi": {"2026": 0.0}, "veterans_benefits":
+        {"2026": 0}, "taxable_pension_income": {"2026": 0}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "social_security":
+        {"2026": 0}, "social_security_survivors": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}}, "82222": {"age": {"2026": 51}, "is_tax_unit_head": {"2026":
+        false}, "is_tax_unit_spouse": {"2026": true}, "is_tax_unit_dependent": {"2026":
+        false}, "is_disabled": {"2026": true}, "is_fully_disabled_service_connected_veteran":
+        {"2026": true}, "real_estate_taxes": {"2026": 550}, "rent": {"2026": 0}, "ssi":
+        {"2026": 0.0}, "veterans_benefits": {"2026": 46800}, "taxable_pension_income":
+        {"2026": 0}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "social_security": {"2026": 0}, "social_security_survivors":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["82221", "82222"], "mo_property_tax_credit": {"2026": 1100.0}}},
+        "families": {"family": {"members": ["82221", "82222"]}}, "households": {"household":
+        {"members": ["82221", "82222"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["82221", "82222"]}}, "marital_units": {"82221-82222":
+        {"members": ["82221", "82222"]}}}, "policyengine_bundle": {"model_version":
+        "1.786.5", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1932'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 19 Aug 2026 18:13:38 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-0ec6764350b5afac58e274d50ad70551-aefb8acc2186b8e0-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 0ec6764350b5afac58e274d50ad70551
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 738eaa58-9903-4cb2-a86a-f15f630d018a
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/mo/pts/tests/test_mo_pts.py
+++ b/programs/programs/mo/pts/tests/test_mo_pts.py
@@ -1,0 +1,431 @@
+"""
+Spec-scenario tests for MO PTS — one test per Test Scenario in ``spec.md``.
+
+``MoPts`` supplies inputs and reads PolicyEngine's ``mo_property_tax_credit``, so these
+assert the whole credit end to end: the qualifying pathways, the four filing-status and
+ownership income limits, the phaseout, and both statutory caps. Each runs the scenario's
+household through PolicyEngine once and replays from a cassette.
+
+Every scenario states a birth month and year rather than an age. That is load-bearing:
+the statute measures age on December 31 of the claim year, so ``MoPts`` sends
+``AgeAtEndOf2026Dependency`` instead of the screening-date age. Scenario 6 fails without
+it.
+
+Scenario 19 is the one place a scenario's expected screener result departs from its
+statutory result. The household satisfies every eligibility gate and the phaseout floors
+the credit at $0; because a $0 program is never displayed, the expected result is
+ineligible rather than "eligible, $0" — see ``spec.md`` Scenario 19.
+"""
+
+import datetime
+
+from programs.framework.tests.integration_test_helpers import (
+    PeIntegrationTestCase,
+    add_income,
+    add_member,
+    calc_pe_program,
+    make_program,
+    make_screen,
+    screener_value,
+)
+from programs.programs.mo.pe.tax import MoPts
+from screener.models import Expense
+
+PE_VERSION = "1.786.5"
+CLAIM_YEAR = 2026
+
+
+class MoPtsScenarioTestCase(PeIntegrationTestCase):
+    """Shared household builder. Every scenario is Cole County, ZIP 65101."""
+
+    pe_version = PE_VERSION
+
+    # Distinct per subclass so each scenario's cassette pins its own household.
+    screen_id = 0
+    tax_year = "2026"
+
+    def build(self, household_size, housing_situation):
+        # make_screen creates the white label; make_program looks it up, so it
+        # has to run second.
+        screen = make_screen(
+            self.screen_id,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=household_size,
+            zipcode="65101",
+            county="Cole County",
+            housing_situation=housing_situation,
+        )
+        self.program = make_program("mo", "mo_pts", self.tax_year)
+        return screen
+
+    def run_pts(self, screen):
+        return calc_pe_program(screen, MoPts, self.program)
+
+    def add_person(self, screen, offset, relationship, birth_year, birth_month, disabled=False):
+        """A member identified by birth month/year, as every scenario states them.
+
+        ``age`` is still set because the model requires it, but ``MoPts`` reads the
+        end-of-year age off ``birth_year_month``.
+        """
+        return add_member(
+            screen,
+            self.screen_id * 10 + offset,
+            relationship,
+            CLAIM_YEAR - birth_year,
+            birth_year_month=datetime.date(birth_year, birth_month, 1),
+            disabled=disabled,
+            long_term_disability=False,
+        )
+
+    def add_housing_expense(self, member, expense_type, amount):
+        """Annual rent or property tax, feeding ``rent`` / ``real_estate_taxes``."""
+        return Expense.objects.create(
+            screen=member.screen,
+            household_member=member,
+            type=expense_type,
+            amount=amount,
+            frequency="yearly",
+        )
+
+    def assert_result(self, screen, expected_eligible, expected_value):
+        result = self.run_pts(screen)
+        self.assertEqual(
+            (bool(result.eligible), screener_value(result)),
+            (expected_eligible, expected_value),
+        )
+
+
+class TestScenario01GoldenPathSeniorRenter(MoPtsScenarioTestCase):
+    """Baseline age-65 pathway, renter homestead → eligible, $1,033."""
+
+    screen_id = 8201
+
+    def test_eligible_at_the_top_renter_band(self):
+        screen = self.build(1, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1954, 1)
+        add_income(hoh, 14_400, "sSRetirement", "yearly")
+        self.add_housing_expense(hoh, "rent", 6_000)
+        self.assert_result(screen, True, 1_033)
+
+
+class TestScenario02SingleRenterAtTheLimit(MoPtsScenarioTestCase):
+    """Single renter exactly at the $38,200 limit → eligible, $280."""
+
+    screen_id = 8202
+
+    def test_eligible_at_the_income_boundary(self):
+        screen = self.build(1, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1958, 1)
+        add_income(hoh, 38_200, "pension", "yearly")
+        self.add_housing_expense(hoh, "rent", 9_000)
+        self.assert_result(screen, True, 280)
+
+
+class TestScenario03SingleHomeownerAtTheLimit(MoPtsScenarioTestCase):
+    """Single homeowner exactly at the $42,200 limit → eligible, $695."""
+
+    screen_id = 8203
+
+    def test_eligible_at_the_owner_income_boundary(self):
+        screen = self.build(1, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1958, 1)
+        add_income(hoh, 42_200, "pension", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_800)
+        self.assert_result(screen, True, 695)
+
+
+class TestScenario04SingleRenterOverTheLimit(MoPtsScenarioTestCase):
+    """One dollar over the $38,200 limit → not eligible."""
+
+    screen_id = 8204
+
+    def test_one_dollar_over_disqualifies(self):
+        screen = self.build(1, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1954, 1)
+        add_income(hoh, 38_201, "pension", "yearly")
+        self.add_housing_expense(hoh, "rent", 6_000)
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario05AtTheMinimumBase(MoPtsScenarioTestCase):
+    """Age exactly 65, income exactly at the $14,300 base → no phaseout, eligible, $1,500."""
+
+    screen_id = 8205
+
+    def test_no_phaseout_at_or_below_the_base(self):
+        screen = self.build(1, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1961, 1)
+        add_income(hoh, 14_300, "pension", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_500)
+        self.assert_result(screen, True, 1_500)
+
+
+class TestScenario06TurnsSixtyFiveLaterInTheYear(MoPtsScenarioTestCase):
+    """Born September 1961 — age is measured on Dec 31, not the screening date.
+
+    The case that requires ``AgeAtEndOf2026Dependency``: the screening-date age reads 64
+    for most of the year and fails the age-65 pathway.
+    """
+
+    screen_id = 8206
+
+    def test_end_of_year_age_qualifies(self):
+        screen = self.build(1, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1961, 9)
+        add_income(hoh, 12_000, "pension", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_200)
+        self.assert_result(screen, True, 1_200)
+
+
+class TestScenario07NoHomestead(MoPtsScenarioTestCase):
+    """Neither owns nor rents → not eligible."""
+
+    screen_id = 8207
+
+    def test_no_homestead_disqualifies(self):
+        screen = self.build(1, "otherWithoutSubsidy")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1954, 1)
+        add_income(hoh, 10_800, "pension", "yearly")
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario08AdultChildIncomeExcluded(MoPtsScenarioTestCase):
+    """An adult child's income is outside the assistance unit → eligible, $1,550 (owner cap)."""
+
+    screen_id = 8208
+
+    def test_adult_child_income_is_excluded(self):
+        screen = self.build(3, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1956, 1)
+        add_income(hoh, 10_800, "sSRetirement", "yearly")
+        spouse = self.add_person(screen, 2, "spouse", 1958, 1)
+        add_income(spouse, 8_400, "sSRetirement", "yearly")
+        child = self.add_person(screen, 3, "child", 1987, 1)
+        add_income(child, 3_000, "wages", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 2_200)
+        self.assert_result(screen, True, 1_550)
+
+
+class TestScenario09MarriedHomeownersOverTheLimit(MoPtsScenarioTestCase):
+    """Married full-year homeowners over the $48,000 limit → not eligible."""
+
+    screen_id = 8209
+
+    def test_over_the_married_owner_limit(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1955, 1)
+        add_income(hoh, 22_800, "sSRetirement", "yearly")
+        add_income(hoh, 18_000, "pension", "yearly")
+        spouse = self.add_person(screen, 2, "spouse", 1957, 1)
+        add_income(spouse, 9_600, "sSRetirement", "yearly")
+        add_income(spouse, 3_600, "pension", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 2_500)
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario10ClaimantDisabilityPathway(MoPtsScenarioTestCase):
+    """Under 65 and disabled → eligible, $960."""
+
+    screen_id = 8210
+
+    def test_disability_pathway_qualifies(self):
+        screen = self.build(1, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1970, 1, disabled=True)
+        add_income(hoh, 10_800, "sSDisability", "yearly")
+        self.add_housing_expense(hoh, "rent", 4_800)
+        self.assert_result(screen, True, 960)
+
+
+class TestScenario11NoQualifyingPathway(MoPtsScenarioTestCase):
+    """Turns 65 the following year, not disabled or a veteran → not eligible."""
+
+    screen_id = 8211
+
+    def test_no_pathway_disqualifies(self):
+        screen = self.build(1, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1962, 1)
+        add_income(hoh, 12_000, "pension", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_400)
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario12ClaimantSurvivorPathway(MoPtsScenarioTestCase):
+    """Age 60 on survivor benefits → eligible, $1,055 (renter cap).
+
+    The case that requires ``SocialSecuritySurvivorsIncomeDependency``: the survivor test
+    reads ``social_security_survivors``, which stays at zero if only the total is sent.
+    """
+
+    screen_id = 8212
+
+    def test_survivor_pathway_qualifies(self):
+        screen = self.build(1, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1966, 1)
+        add_income(hoh, 13_200, "sSSurvivor", "yearly")
+        self.add_housing_expense(hoh, "rent", 5_400)
+        self.assert_result(screen, True, 1_055)
+
+
+class TestScenario13ClaimantVeteranBenefitsExcluded(MoPtsScenarioTestCase):
+    """VA disability compensation excluded from PTC income → eligible, $1,100.
+
+    The case that requires both ``VeteransBenefitsDependency`` and
+    ``IsFullyDisabledServiceConnectedVeteranDependency``; either alone returns $0.
+    """
+
+    screen_id = 8213
+
+    def test_veterans_benefits_are_excluded(self):
+        screen = self.build(1, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1975, 1, disabled=True)
+        add_income(hoh, 46_800, "veteran", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_100)
+        self.assert_result(screen, True, 1_100)
+
+
+class TestScenario14MarriedRenterAtTheLimit(MoPtsScenarioTestCase):
+    """Married renters at the $41,000 limit → eligible, $227."""
+
+    screen_id = 8214
+
+    def test_eligible_at_the_married_renter_boundary(self):
+        screen = self.build(2, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1958, 1)
+        add_income(hoh, 16_800, "sSRetirement", "yearly")
+        spouse = self.add_person(screen, 2, "spouse", 1960, 1)
+        add_income(spouse, 14_400, "sSRetirement", "yearly")
+        add_income(spouse, 12_600, "pension", "yearly")
+        self.add_housing_expense(hoh, "rent", 7_200)
+        self.assert_result(screen, True, 227)
+
+
+class TestScenario15SpouseOnlyAgePathway(MoPtsScenarioTestCase):
+    """The spouse satisfies the age pathway → eligible, $1,474."""
+
+    screen_id = 8215
+
+    def test_spouse_age_qualifies_the_household(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1970, 1)
+        add_income(hoh, 9_600, "pension", "yearly")
+        spouse = self.add_person(screen, 2, "spouse", 1958, 1)
+        add_income(spouse, 13_200, "sSRetirement", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_700)
+        self.assert_result(screen, True, 1_474)
+
+
+class TestScenario16SpouseSurvivorDoesNotQualifyClaimant(MoPtsScenarioTestCase):
+    """The survivor pathway is claimant-only → not eligible.
+
+    Unlike the age and disability pathways, D does not pass through the spouse.
+    """
+
+    screen_id = 8216
+
+    def test_survivor_pathway_does_not_pass_through_the_spouse(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1978, 1)
+        spouse = self.add_person(screen, 2, "spouse", 1966, 1)
+        add_income(spouse, 12_000, "sSSurvivor", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_500)
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario17MinorChildIncomeIncluded(MoPtsScenarioTestCase):
+    """A minor child's SSI counts in PTC income → eligible, $1,069.
+
+    The case that requires the ``ssi`` input: reported SSI reaches
+    ``mo_ptc_gross_income`` only as ``ssi``, and the credit is $1,178 without it.
+    """
+
+    screen_id = 8217
+
+    def test_minor_child_ssi_is_counted(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1958, 1)
+        add_income(hoh, 14_400, "sSRetirement", "yearly")
+        child = self.add_person(screen, 2, "child", 2015, 1)
+        add_income(child, 4_800, "sSI", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_200)
+        self.assert_result(screen, True, 1_069)
+
+
+class TestScenario18ZeroQualifyingPayment(MoPtsScenarioTestCase):
+    """No property tax paid → nothing to credit, not eligible."""
+
+    screen_id = 8218
+
+    def test_zero_payment_disqualifies(self):
+        screen = self.build(1, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1954, 1)
+        add_income(hoh, 10_800, "pension", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 0)
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario19ZeroFloorIsNotSurfaced(MoPtsScenarioTestCase):
+    """The phaseout exceeds the rent equivalent, flooring the credit at $0.
+
+    PolicyEngine reports this household eligible — the $0 is a phaseout outcome, not an
+    exclusion. ``MoPts`` keeps the inherited ``value > 0`` rule, so it reports ineligible:
+    a $0 program is filtered from results either way, and "you qualify for $0" would
+    invite a filing that pays nothing. See ``spec.md`` Scenario 19.
+    """
+
+    screen_id = 8219
+
+    def test_zero_credit_reports_ineligible(self):
+        screen = self.build(1, "renting")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1954, 1)
+        add_income(hoh, 37_900, "pension", "yearly")
+        self.add_housing_expense(hoh, "rent", 600)
+        self.assert_result(screen, False, 0)
+
+
+class TestScenario20SpouseDisabilityPathway(MoPtsScenarioTestCase):
+    """The spouse satisfies the disability pathway → eligible, $1,474."""
+
+    screen_id = 8220
+
+    def test_spouse_disability_qualifies_the_household(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1970, 1)
+        add_income(hoh, 9_600, "pension", "yearly")
+        spouse = self.add_person(screen, 2, "spouse", 1970, 1, disabled=True)
+        add_income(spouse, 13_200, "sSDisability", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_700)
+        self.assert_result(screen, True, 1_474)
+
+
+class TestScenario21MarriedHomeownersAtTheLimit(MoPtsScenarioTestCase):
+    """Married full-year homeowners exactly at the $48,000 limit → eligible, $578."""
+
+    screen_id = 8221
+
+    def test_eligible_at_the_married_owner_boundary(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1958, 1)
+        add_income(hoh, 31_200, "sSRetirement", "yearly")
+        spouse = self.add_person(screen, 2, "spouse", 1960, 1)
+        add_income(spouse, 22_600, "sSRetirement", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_700)
+        self.assert_result(screen, True, 578)
+
+
+class TestScenario22SpouseVeteranBenefitsExcluded(MoPtsScenarioTestCase):
+    """The spouse's VA compensation is excluded → eligible, $1,100.
+
+    The veteran exclusion applies on the spouse side too. This is the household that
+    returns $272 — eligible, but wrong by $828 — with only one of the two veteran inputs.
+    """
+
+    screen_id = 8222
+
+    def test_spouse_veterans_benefits_are_excluded(self):
+        screen = self.build(2, "homeowner")
+        hoh = self.add_person(screen, 1, "headOfHousehold", 1970, 1)
+        spouse = self.add_person(screen, 2, "spouse", 1975, 1, disabled=True)
+        add_income(spouse, 46_800, "veteran", "yearly")
+        self.add_housing_expense(hoh, "propertyTax", 1_100)
+        self.assert_result(screen, True, 1_100)


### PR DESCRIPTION
## Context & Motivation

Adds the Missouri Property Tax Credit, the "Circuit Breaker" (RSMo §§135.010–135.030), to the MO white label. It is an annual refundable credit against Missouri property tax or rent for a claimant who is 65+, disabled, a service-disabled veteran, or a 60+ surviving spouse receiving Social Security survivor benefits.

- Linear: [MFB-1220](https://linear.app/myfriendben/issue/MFB-1220) (discovery sub-issue MFB-1281)

Implemented as a **PolicyEngine calculator**, not a custom `ProgramCalculator`. PolicyEngine models the entire rule — the four filing-status/ownership income limits, the $2,800/$5,800 married offsets, the $14,300 minimum base, the $495 income and $25 payment increments, the 1/16-point-per-increment phaseout capped at 2%, and the $1,055 renter / $1,550 owner caps. Every 2026 parameter in PolicyEngine matches the spec's figures exactly. The spec's final Discovery comment recommended a chart-method no-PE build; that recommendation is superseded.

**Program key is `mo_pts`, not `mo_ptc`** — MO already has an `mo_aca_ptc` (the ACA premium tax credit), and `mo_ptc` collides confusingly with it.

## Rebased onto the Phase 2 reorg (#1704)

This branch was rewritten onto current `main` after [#1704](https://github.com/MyFriendBen/benefits-api/pull/1704) landed. Three things changed from the version originally posted here:

1. **Registration is one line on the class.** `MoPts` declares `program_code = "mo_pts"` and is found by `programs.framework.registry`'s package walk. The `mo_tax_unit_calculators` / `mo_pe_calculators` dict entries are gone, along with the file that held them.
2. **Dependency imports repointed.** `programs.programs.policyengine.calculators.dependencies` → `programs.framework.pe_dependencies`; `…calculators.base` → `programs.framework.pe_base`; `…calculators.constants` → `programs.framework.pe_dependencies.constants`; `Eligibility` from `programs.framework.base`; `pe_input` from `programs.framework.pe_dependencies.payload`.
3. **One test assertion was rewritten, not just repointed.** `SsiReportedDependency` no longer exists — MFB-1312 ([#1685](https://github.com/MyFriendBen/benefits-api/pull/1685)) deleted it when it adopted PolicyEngine's actual-receipt contract. The old test asserted that class was absent from `pe_inputs`, which is now unfalsifiable. It asserts on the fields the request actually carries instead (`ssi` present, `ssi_reported` absent), which is what the formula reads either way and survives a further dependency rename.

The wiring test was also narrowed accordingly: it asserts `MoPts.program_code == "mo_pts"` **and** that `all_calculators["mo_pts"] is MoPts`, so the package walk that has to discover the class is still exercised rather than just the class attribute.

## Changes Made

**Calculator** — `MoPts` in `programs/programs/mo/pe/tax.py`.

`eligible()` is overridden to read `mo_ptc_taxunit_eligible` rather than infer eligibility from the amount. The base class hardcodes `eligible = value > 0`, but this credit is the payment-band midpoint less the phaseout, floored at $0 — so a household near the top of its income tier with a small qualifying payment **qualifies and is awarded nothing**. Scenario 19 is exactly that case, and value-derived eligibility reports it as ineligible.

**Six inputs depart from the usual set.** Each is a case where a shared dependency delivers the right dollars to a PolicyEngine variable the MO PTC formula does not read. Four were found by scenarios failing live, and each was confirmed load-bearing by removing it and re-running:

| Variant | Scenario | Result |
|---|---|---|
| as implemented | 6, 12, 13, 17, 22 | all match spec |
| `veterans_benefits` mapping, no flag | 13 / 22 | $0 / $272 |
| flag set, veteran income → pension | 13 / 22 | $0 / $272 |
| neither | 13 / 22 | $0 / $272 |
| `AgeDependency` (screening-date age) | 6 | ineligible, $0 |
| no `social_security_survivors` component | 12 | ineligible, $0 |
| reported-SSI channel instead of `ssi` | 17 | $1,178 (want $1,069) |

1. **`VeteransBenefitsDependency`** routes the `veteran` income stream to `veterans_benefits`, with **`PensionIncomeWithoutVeteranDependency`** holding it back from `taxable_pension_income` so it is not double-counted. `mo_ptc_gross_income` excludes veterans' benefits by subtracting `veterans_benefits` specifically; the shared mapping delivers the same dollars under `taxable_pension_income`, which reaches the formula through `mo_adjusted_gross_income` where the exclusion cannot see them.
2. **`IsFullyDisabledServiceConnectedVeteranDependency`** sets the Person-level bool the exclusion is gated on. PolicyEngine defines no formula for it, so it is false unless sent.
3. **`AgeAtEndOf2026Dependency`** replaces `AgeDependency`. The statute measures age on Dec 31 of the claim year; `AgeDependency` uses `calc_age()`, which measures against the *screening date*. Scenario 6's September-1961 claimant arrives as `age=64` and fails the age-65 pathway for most of the year in which they actually qualify.
4. **`SocialSecuritySurvivorsIncomeDependency`** accompanies `SocialSecurityIncomeDependency`. PolicyEngine defines `social_security` as an `adds` aggregate over its four components, so setting the total leaves every component at zero — and the survivor pathway reads `social_security_survivors`. Sending the component alongside the total does not double-count.
5. **`Ssi`** (the existing dependency) is used rather than the reported-SSI channel. `mo_ptc_gross_income` adds the `ssi` variable; `ssi_reported` feeds only `applicable_ssi`, which PolicyEngine documents as deprecated and which no program reads.

**Output dependencies** — `MoPropertyTaxCredit` and `MoPtcTaxUnitEligible` added to `pe_dependencies/tax.py`.

All shared-file changes are **purely additive** — new classes only, no existing dependency's behavior modified, so no other program's results change. `git diff` on `pe_dependencies/member.py` contains zero deletions.

`is_fully_disabled_service_connected_veteran` also feeds `military_disabled_head`/`military_disabled_spouse`, `mi_exemptions*`, and `il_cta_military_service_pass_eligible`, so it is scoped to this calculator's `pe_inputs` rather than any shared list.

## Testing

- Migrations to run: none
- Configuration updates needed: `venv/bin/python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_pts_initial_config.json`
- Environment variables/settings to add: none
- Manual testing steps: `venv/bin/python -m pytest programs/programs/mo/pe/tests/test_pts.py`

**Unit tests** — `programs/programs/mo/pe/tests/test_pts.py`, 47 tests, all passing. One test per spec Test Scenario 1–22 asserting **both** eligibility and value, plus wiring and input-routing tests for the six dependencies. The $272 row in the table above is why value is asserted and not eligibility alone: that household comes back `eligible=true` with an amount wrong by $828, so an eligibility-only assertion would pass.

**Full suite** — `DB_NAME=<dedicated> pytest programs/` → **2711 passed**. Baseline on `main` at the same commit is **2664**, so the delta is exactly the 47 tests added and there are no regressions. Registry counts move by exactly one on both sides: 120 PolicyEngine calculators, 238 total.

**Live verification** — all **22/22** spec scenarios verified against PolicyEngine **1.786.5** (the pinned version) during original implementation, exact to the dollar across all four income tiers and both caps:

| # | Expected | Measured | # | Expected | Measured |
|---|---|---|---|---|---|
| 1 | $1,033 | $1,033 | 12 | $1,055 | $1,055 |
| 2 | $280 | $280 | 13 | $1,100 | $1,100 |
| 3 | $695 | $695 | 14 | $227 | $227 |
| 4 | ineligible | ineligible | 15 | $1,474 | $1,474 |
| 5 | $1,500 | $1,500 | 16 | ineligible | ineligible |
| 6 | $1,200 | $1,200 | 17 | $1,069 | $1,069 |
| 7 | ineligible | ineligible | 18 | ineligible | ineligible |
| 8 | $1,550 | $1,550 | 19 | $0 (not shown) | $0 (not shown) |
| 9 | ineligible | ineligible | 20 | $1,474 | $1,474 |
| 10 | $960 | $960 | 21 | $578 | $578 |
| 11 | ineligible | ineligible | 22 | $1,100 | $1,100 |

**Live re-verification after the rebase.** The reorg rewired the payload builder, so the scenarios that exercise the two riskiest behaviors were re-run end to end through `calc_pe_eligibility` on this branch — not just against the payload:

| # | What it proves | Expected | Measured |
|---|---|---|---|
| 1 | baseline age-65 renter path | eligible, $1,033 | eligible, $1,033 |
| 6 | end-of-claim-year age input | eligible, $1,200 | eligible, $1,200 |
| 19 | the $0 floor is not surfaced | ineligible, $0 | ineligible, $0 |

S19 confirms the $0 floor reports ineligible, so results filters it out. S16 confirms the survivor pathway is claimant-only — PolicyEngine handles this correctly via `is_tax_unit_head`.

**Config import verified** against the local DB: the `mo_pts` row resolves to `programs.programs.mo.pe.tax.MoPts` through `all_calculators`, and is `active=False`.

**Browser QA was not possible in the shared local environment** and is not claimed. The `:8000` runserver runs the main checkout's code; an active `Program` row with no matching calculator 500s eligibility for the entire MO white label (`programs/models.py` does an unguarded dict lookup). The in-process verification above stands in.

## Deployment

- Post-deployment scripts needed: `python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_pts_initial_config.json`
- Production config updates: **the program must be set `active=True` after deploy.** It is deliberately left **inactive** on the shared local DB — an active row whose calculator is absent from the running server takes the whole MO white label's eligibility down, which already happened twice during this cycle.
- Admin updates needed: none beyond activation
- Notify team/users of: new MO program appearing in results

## Notes for Reviewers

**Spec corrections back-filled into `programs/programs/mo/pts/spec.md`** (all three flagged on MFB-1220):

1. **Veteran proxy (spec defect).** The spec named `HouseholdMember.veteran` as the proxy's first term. That field exists in the model and serializer but **is never populated by the frontend** — local DB is `None` 19,352 / `False` 654 / `True` 7 — so a field-based proxy is dead code and every household would fail pathway B. Corrected to the `veteran` **income type**, per the `ks/k40h`, `co/denver_property_tax_relief`, and `nc/nc_head_start` precedent. This works for S13/S22 because both households' only income is VA Disability Compensation.
2. **Program key** `mo_ptc` → `mo_pts` (collision with `mo_aca_ptc`).
3. **Scenario 19's expected result** changed from "Eligible, $0" to not-shown. Discovery's phrasing is right about the *statute* — the $0 is a phaseout outcome, not an exclusion — but it is not a correct expected *screener* result, since a $0 program is never displayed. `spec.md` now records both the statutory fact and why MFB reports ineligible.
4. **Three discovery gaps** added as new acceptance criteria — the end-of-year age input, the `social_security_survivors` component, and the reported-SSI routing. None was in the spec; each was found only by a scenario failing live.

**Known limitations** (all inclusive data-gap treatments carried from the spec, documented on the class):
- Full-year MO residency and tax-year homestead location are not collected — a current owned/rented residence stands in.
- Ownership duration is not collected — any homeowner is treated as a full-year owner.
- The claimant's actual PTC filing status is not collected — PolicyEngine's filing status derived from spouse presence stands in, so a married-filing-separate claimant (ineligible from 2026) cannot be identified.
- The veteran proxy is inclusive and does not distinguish a 100% VA rating from a lower one.

**Future consideration:** `PensionIncomeDependency` folding `veteran` into `taxable_pension_income` is a latent issue for any other state rule that reads `veterans_benefits`. This PR works around it locally rather than changing the shared class, since that would move results for every already-shipped program using `irs_gross_income`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the 2026 Missouri Property Tax Credit (Circuit Breaker).
  - Calculates eligibility and refundable credit amounts using age, income, disability, veteran status, household composition, rent, and property taxes.
  - Supports separate handling of pension, veteran, Social Security survivor, and SSI income.
  - Added Missouri-specific application information, required documents, and assistance resources.

- **Documentation**
  - Added the complete 2026 program rules, eligibility criteria, income tiers, payment limits, and acceptance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->