### PR TITLE
MFB-1638: fix latent bugs in TotalHoursWorkedDependency

### DIFF
--- a/programs/framework/pe_dependencies/member.py
+++ b/programs/framework/pe_dependencies/member.py
@@ -1,3 +1,5 @@
+from screener.models import EARNED_INCOME_TYPES
+
 from .base import Member
 from .receipt import SSI_INCOME_TYPE, member_reports_ssi_amount, screen_reports_ssi_without_amount
 
@@ -522,8 +524,26 @@ class SnapChildSupportDependency(Member):
 
 
 class TotalHoursWorkedDependency(Member):
+    """
+    Weekly hours worked, taken from hourly income streams and approximated from the
+    rest at minimum wage.
+
+    Only *earned* income counts. The approximation branch divides income by a wage,
+    which is only meaningful for money paid for work: run over an unearned stream it
+    invents hours nobody worked, and PolicyEngine's SNAP/TANF work screens read this
+    field. A 45-year-old with $2,000/mo of SSDI would otherwise be credited ~69
+    "work" hours a week and clear every work requirement.
+
+    Subclasses override ``minimum_wage`` with their state's rate; the federal floor
+    is the conservative default, since a lower wage buys more approximated hours.
+    """
+
     field = "weekly_hours_worked_before_lsr"
-    dependencies = ("income_frequency",)
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
 
     minimum_wage = 7.25
     work_weeks_in_month = 4
@@ -532,17 +552,37 @@ class TotalHoursWorkedDependency(Member):
         hours = 0
 
         for income in self.member.income_streams.all():
+            if income.type not in EARNED_INCOME_TYPES:
+                continue
+
             if income.frequency == "hourly":
+                # hours_worked is nullable and, unlike type/amount/frequency, is not
+                # reported by IncomeStream.missing_fields(), so can_calc() will not
+                # hold the request back when it is absent. An hourly stream's amount
+                # is a rate, so there is nothing to approximate hours from either.
+                # Contribute nothing rather than raising and failing the whole build.
+                if income.hours_worked is None:
+                    continue
+
                 hours += int(income.hours_worked)
                 continue
 
-            # aproximate weekly hours using the minimum wage in MA
+            # approximate weekly hours by valuing the income at minimum wage
             hours += int(income.monthly()) / self.minimum_wage / self.work_weeks_in_month
 
         return hours
 
 
 class MaTotalHoursWorkedDependency(TotalHoursWorkedDependency):
+    """
+    Massachusetts approximation, at the state minimum wage.
+
+    Every MA calculator sending this field must use this subclass. Two dependencies
+    writing different values to the same field and period raise ``DependencyError``
+    in ``update_unit``, so mixing this with the base class inside one MA screen
+    fails the request build.
+    """
+
     minimum_wage = 15
 
 

--- a/programs/framework/pe_dependencies/tests/test_member.py
+++ b/programs/framework/pe_dependencies/tests/test_member.py
@@ -2034,3 +2034,153 @@ class TestChildSupportReceivedDependency(TestCase):
         self.assertNotEqual(received.field, paid.field)
         self.assertEqual(received.value(), 4800)
         self.assertEqual(paid.value(), 3000)  # $500/month * 12 / household_size(2)
+
+
+class TestTotalHoursWorkedDependency(TestCase):
+    """Tests for TotalHoursWorkedDependency, which feeds PolicyEngine's
+    weekly_hours_worked_before_lsr — the input behind the SNAP general work and ABAWD
+    work requirements as well as MA TAFDC/EAEDC and TX CCS work screens (MFB-1638)."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=45)
+
+    def _income(self, **kwargs):
+        return IncomeStream.objects.create(screen=self.screen, household_member=self.head, **kwargs)
+
+    def _dep(self):
+        return member.TotalHoursWorkedDependency(self.screen, self.head, {})
+
+    def test_field_name_matches_policyengine_variable(self):
+        self.assertEqual(member.TotalHoursWorkedDependency.field, "weekly_hours_worked_before_lsr")
+
+    def test_declares_the_income_fields_it_reads(self):
+        """value() branches on stream type and reads amounts, so a screen missing either
+        must gate the calculator rather than produce a wrong hours figure."""
+        self.assertEqual(
+            member.TotalHoursWorkedDependency.dependencies,
+            ("income_type", "income_amount", "income_frequency"),
+        )
+
+    def test_no_income_is_zero_hours(self):
+        self.assertEqual(self._dep().value(), 0)
+
+    def test_hourly_wages_report_their_hours_directly(self):
+        self._income(type="wages", amount=20, frequency="hourly", hours_worked=30)
+
+        self.assertEqual(self._dep().value(), 30)
+
+    def test_non_hourly_wages_are_approximated_at_minimum_wage(self):
+        self._income(type="wages", amount=2000, frequency="monthly")
+
+        # $2,000/mo / $7.25 an hour / 4 weeks a month
+        self.assertAlmostEqual(self._dep().value(), 2000 / 7.25 / 4)
+
+    def test_self_employment_counts_as_earned(self):
+        self._income(type="selfEmployment", amount=1000, frequency="monthly")
+
+        self.assertAlmostEqual(self._dep().value(), 1000 / 7.25 / 4)
+
+    def test_hourly_and_non_hourly_earned_streams_sum(self):
+        self._income(type="wages", amount=20, frequency="hourly", hours_worked=10)
+        self._income(type="selfEmployment", amount=1000, frequency="monthly")
+
+        self.assertAlmostEqual(self._dep().value(), 10 + 1000 / 7.25 / 4)
+
+    # --- Bug 1: unearned income must not manufacture work hours (MFB-1638) ---
+
+    def test_unearned_income_alone_is_zero_hours(self):
+        """A disabled 45-year-old living on SSDI works no hours. Approximating hours
+        from unearned income credited ~69 hours/week and cleared every work screen."""
+        self._income(type="sSDisability", amount=2000, frequency="monthly")
+
+        self.assertEqual(self._dep().value(), 0)
+
+    def test_unearned_income_does_not_inflate_earned_hours(self):
+        self._income(type="pension", amount=2000, frequency="monthly")
+        self._income(type="wages", amount=1000, frequency="monthly")
+
+        self.assertAlmostEqual(self._dep().value(), 1000 / 7.25 / 4)
+
+    def test_every_unearned_type_the_screener_collects_is_ignored(self):
+        for income_type in ("sSI", "sSRetirement", "unemployment", "childSupport", "investment", "rental"):
+            with self.subTest(income_type=income_type):
+                IncomeStream.objects.all().delete()
+                self._income(type=income_type, amount=2000, frequency="monthly")
+
+                self.assertEqual(self._dep().value(), 0)
+
+    # --- Bug 2: a null hours_worked must not raise (MFB-1638) ---
+
+    def test_hourly_stream_without_hours_does_not_raise(self):
+        """hours_worked is nullable and is not covered by IncomeStream.missing_fields(),
+        so can_calc() cannot gate on it. int(None) used to raise TypeError out of
+        pe_input(), which runs outside calc_pe_eligibility's try/except and so failed
+        the entire PolicyEngine request build rather than one program."""
+        self._income(type="wages", amount=20, frequency="hourly", hours_worked=None)
+
+        self.assertEqual(self._dep().value(), 0)
+
+    def test_null_hours_does_not_discard_the_member_other_earned_streams(self):
+        self._income(type="wages", amount=20, frequency="hourly", hours_worked=None)
+        self._income(type="selfEmployment", amount=1000, frequency="monthly")
+
+        self.assertAlmostEqual(self._dep().value(), 1000 / 7.25 / 4)
+
+    # --- Other members' income belongs to those members ---
+
+    def test_only_counts_the_member_own_income(self):
+        spouse = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=44)
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=spouse, type="wages", amount=20, frequency="hourly", hours_worked=40
+        )
+        self._income(type="wages", amount=20, frequency="hourly", hours_worked=10)
+
+        self.assertEqual(self._dep().value(), 10)
+
+
+class TestMaTotalHoursWorkedDependency(TestCase):
+    """MA approximates at the state minimum wage rather than the federal floor, so it
+    credits fewer hours for the same income (MFB-1638)."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Massachusetts", code="ma", state_code="MA")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="02101",
+            county="Suffolk County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=45)
+
+    def test_uses_the_ma_minimum_wage(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=2000, frequency="monthly"
+        )
+
+        dep = member.MaTotalHoursWorkedDependency(self.screen, self.head, {})
+        self.assertAlmostEqual(dep.value(), 2000 / 15 / 4)
+
+    def test_shares_the_field_with_the_base_class(self):
+        """Same field and period as the base class, which is why an MA calculator that
+        sends both raises DependencyError."""
+        self.assertEqual(
+            member.MaTotalHoursWorkedDependency.field,
+            member.TotalHoursWorkedDependency.field,
+        )
+
+    def test_inherits_the_earned_income_filter(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSDisability", amount=2000, frequency="monthly"
+        )
+
+        dep = member.MaTotalHoursWorkedDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 0)

--- a/screener/models.py
+++ b/screener/models.py
@@ -13,6 +13,14 @@ from django.conf import settings
 from .feature_flags import FeatureFlagConfig, WHITELABEL_FEATURE_FLAGS
 from .irs_parameters import get_qualifying_relative_threshold
 
+# Income stream types that represent money earned from work. Everything else the
+# screener collects (SSDI, SSI, pension, unemployment, child support, ...) is
+# unearned. Read by calc_gross_income()'s "earned"/"unearned" selectors and by
+# PolicyEngine dependencies that need to reason about work rather than total
+# income (e.g. TotalHoursWorkedDependency approximating weekly hours). Keep this
+# as the single definition so those two never drift apart.
+EARNED_INCOME_TYPES: frozenset[str] = frozenset(("wages", "selfEmployment"))
+
 # Relationship values that are eligible for the dependent relationship checks
 # currently modeled in this method (qualifying-child proxy + qualifying-relative
 # proxy). NOTE:
@@ -526,7 +534,6 @@ class HouseholdMember(models.Model):
 
     def calc_gross_income(self, frequency, types, exclude=[]):
         gross_income = 0
-        earned_income_types = ["wages", "selfEmployment"]
 
         income_streams = self.income_streams.all()
         for income_stream in income_streams:
@@ -535,8 +542,8 @@ class HouseholdMember(models.Model):
 
             include_all = "all" in types
             specific_match = income_stream.type in types
-            earned_income_match = "earned" in types and income_stream.type in earned_income_types
-            unearned_income_match = "unearned" in types and income_stream.type not in earned_income_types
+            earned_income_match = "earned" in types and income_stream.type in EARNED_INCOME_TYPES
+            unearned_income_match = "unearned" in types and income_stream.type not in EARNED_INCOME_TYPES
             if include_all or earned_income_match or unearned_income_match or specific_match:
                 if frequency == "monthly":
                     gross_income += income_stream.monthly()


### PR DESCRIPTION
## Context & Motivation

Fixes two latent bugs in `TotalHoursWorkedDependency`, which feeds PolicyEngine's `weekly_hours_worked_before_lsr`.

- Closes [MFB-1638](https://linear.app/myfriendben/issue/MFB-1638/fix-latent-bugs-in-totalhoursworkeddependency-before-reusing-it-for)
- Blocks [MFB-1637](https://linear.app/myfriendben/issue/MFB-1637/send-weekly-hours-worked-before-lsr-on-all-snap-requests-before-pe)

Both bugs are reachable today on only three calculators — MA TAFDC, MA EAEDC, and TX CCS. MFB-1637 puts this dependency on **every SNAP state** before PolicyEngine drops its 40-hour default (becomes `current` Aug 26, 8pm ET), which turns both into load-bearing bugs. Shipping the SNAP wiring on top of bug 1 would hand working-adult work screens a number derived from pension and disability income.

## Changes Made

### Bug 1 — unearned income manufactured work hours

The approximation branch divided `income.monthly()` by a minimum wage across **all** income streams, not just earned ones. A 45-year-old living on $2,000/mo of SSDI or a pension was credited ~69 "work" hours a week, clearing every SNAP general-work and ABAWD screen.

Dividing income by a wage only means something for money paid for work. The branch now skips unearned streams.

### Bug 2 — `int(income.hours_worked)` raised `TypeError` when null

`IncomeStream.hours_worked` is nullable, and unlike `type`/`amount`/`frequency` it is **not** reported by `IncomeStream.missing_fields()` — so `can_calc()` has nothing to gate on. That asymmetry is the whole reason only this field crashes. Because `pe_input()` runs outside `calc_pe_eligibility`'s `try`/`except`, one hourly stream with no hours failed the **entire** PolicyEngine request build, not just one program.

Frontend validation makes this unreachable in practice (thanks @catonph) — handled anyway. An hourly stream's `amount` is a rate, so there is nothing to approximate hours from; the stream contributes nothing rather than raising.

### `EARNED_INCOME_TYPES` constant

The earned/unearned split was a local variable inside `HouseholdMember.calc_gross_income`. It is now a module constant in `screener/models.py`, read by both that method and this dependency, so the two definitions cannot drift.

### Declared dependencies

Added `income_type` and `income_amount` alongside the existing `income_frequency`. **Verified a gating no-op**, programmatically rather than by inspection — all three consumers already declare that triple via their other income inputs:

```
MaTafdc    already declares triple: True
MaEaedc    already declares triple: True
TxCcs      already declares triple: True
```

Also added docstrings to both classes, including why every MA calculator must use `MaTotalHoursWorkedDependency`: mixing the $15 and $7.25 variants in one screen writes two values to the same field and period and raises `DependencyError` in `update_unit` — the trap MFB-1637 calls out.

### Deliberately not changed

`work_weeks_in_month = 4` here vs. `Decimal(4.35)` in `IncomeStream._hour_to_month()`. The inconsistency leans toward crediting more hours (inclusive), and changing it shifts live MA/TX results — it belongs with MFB-1637's policy decision on the hours floor, not a bug fix.

## Testing

- **16 new tests** in `programs/framework/pe_dependencies/tests/test_member.py`: both bugs, the earned/unearned split across every unearned type the screener collects, hourly + non-hourly summing, member-scoping, and the MA min-wage subclass.
- **Verified as real regression tests** — with the fix reverted, 6 of the 16 fail. A regression test that passes both ways is not one.
- `programs/` + `screener/`: **3068 passed**, 1 failed.
- The one failure is `screener/tests/test_assistant_context.py::AssistantThrottleTests::test_start_endpoint_throttles_and_returns_429`. Confirmed pre-existing by stashing the change and re-running on a clean tree, where it fails identically. Unrelated to this diff.
- `black -l 120` clean.
- Rebased onto `main` after #1709 and re-verified: the branch was cut before that restructure, which moved MA EAEDC and TX CCS out of the `pe/` tree.

## Deployment

- **Post-deployment scripts needed:** none. No migrations, no config JSON, no translations.
- **Production config updates:** none.
- **Admin updates needed:** none.
- **Notify team/users of:** nothing user-facing **on the three current consumers' happy path**, but the behavior change is real and worth stating — see below.

Nothing here is manual; there is nothing for the merger or on-call to run.

**Value changes, scoped.** For MA TAFDC, MA EAEDC, and TX CCS, any member whose hours came partly from unearned income now reports fewer weekly hours. Direction depends on the program's rule: for a work *requirement* the household may now fail a screen it previously passed on phantom hours — that is the bug being fixed, not a regression. Households whose only income is earned are unaffected. Worth a QA pass on MA TAFDC/EAEDC and TX CCS for a household with mixed earned + unearned income.

**Sequencing.** This should land **before** MFB-1637 wires the dependency into `SNAP_BASE_INPUTS`. Shipping in the other order puts bug 1 on all seven SNAP states for the window between the two merges.

**Rollback:** `heroku rollback -a cobenefits-api`. No migration to reverse.

## Notes for Reviewers

- **The ticket's file path is stale.** It cites `programs/programs/policyengine/calculators/dependencies/member.py:450`; the code now lives at `programs/framework/pe_dependencies/member.py`. Both bugs were exactly as described.
- **On the null-hours fallback:** contributing 0 is the only honest option, not a shortcut. An hourly stream's `amount` is a rate, and `monthly()` routes hourly through `_hour_to_month()`, which multiplies by `hours_worked` — so it would raise on the same null. There is no amount-based estimate available.
- **Known limitation:** the minimum-wage approximation is inherently coarse — a member earning well above minimum wage has their hours understated. Pre-existing and unchanged; MFB-1637's floor decision is where that gets addressed.
- **Follow-up worth considering:** `hours_worked` is absent from `IncomeStream.missing_fields()`, which is why nothing gated this. Adding it would let `can_calc()` handle the case structurally instead of each reader guarding. Left out here — it would change gating for every calculator reading income, well beyond this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly work-hour calculations now count only earned income.
  * Hourly income with missing hours no longer causes calculation failures.
  * Unearned income no longer incorrectly generates or increases reported work hours.
  * Multiple earned-income sources are combined correctly.
  * Massachusetts calculations continue to use the state minimum wage for approximations.

* **Tests**
  * Added coverage for earned-income filtering, missing hours, income combinations, and state-specific calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->