### PR TITLE
MFB-1336: make county-specific apply links configurable and cover the county rules

### DIFF
--- a/programs/admin.py
+++ b/programs/admin.py
@@ -511,39 +511,6 @@ class TranslationOverrideAdmin(SecureAdmin):
         """Prefetch counties so the list column is one query, not one per row."""
         return super().get_queryset(request).prefetch_related("counties")
 
-    def _override_white_label(self, request):
-        """The white label of the override being edited, or None on the add page."""
-        obj_id = request.resolver_match.kwargs.get("object_id") if request.resolver_match else None
-        if not obj_id:
-            return None
-        return TranslationOverride.objects.filter(pk=obj_id).values_list("white_label", flat=True).first()
-
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        """Offer only programs from this override's own white label.
-
-        The picker is otherwise every program in every tenant, where choosing the
-        wrong one silently points the override at another state's program.
-        """
-        if db_field.name == "program":
-            white_label = self._override_white_label(request)
-            if white_label is not None:
-                kwargs["queryset"] = Program.objects.filter(white_label=white_label).order_by("name_abbreviated")
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)
-
-    def formfield_for_manytomany(self, db_field, request, **kwargs):
-        """Offer only counties from this override's own white label.
-
-        County matching is exact string equality against `Screen.county`, and each
-        white label spells its counties differently — Illinois stores "Cook" while
-        CO, NC, and WA store "Cook County". A county picked from the wrong tenant
-        can never match a screen, and the override then does nothing at all.
-        """
-        if db_field.name == "counties":
-            white_label = self._override_white_label(request)
-            if white_label is not None:
-                kwargs["queryset"] = County.objects.filter(white_label=white_label).order_by("name")
-        return super().formfield_for_manytomany(db_field, request, **kwargs)
-
     def get_counties(self, obj):
         """Show the county scope in the list so a mis-scoped override is visible."""
         names = [c.name for c in obj.counties.all()]

--- a/programs/admin.py
+++ b/programs/admin.py
@@ -498,14 +498,58 @@ class WebHookFunctionsAdmin(SecureAdmin):
 
 class TranslationOverrideAdmin(SecureAdmin):
     search_fields = ("external_name",)
-    list_display = ["get_str", "calculator", "active", "action_buttons"]
-    white_label_filter_horizontal = ("counties", "program")
+    list_display = ["get_str", "calculator", "field", "get_counties", "active", "action_buttons"]
+    list_filter = ["field", "active"]
     filter_horizontal = ("counties",)
     exclude = ["translation"]
     list_editable = ["active"]
 
     def has_add_permission(self, request):
         return False
+
+    def get_queryset(self, request):
+        """Prefetch counties so the list column is one query, not one per row."""
+        return super().get_queryset(request).prefetch_related("counties")
+
+    def _override_white_label(self, request):
+        """The white label of the override being edited, or None on the add page."""
+        obj_id = request.resolver_match.kwargs.get("object_id") if request.resolver_match else None
+        if not obj_id:
+            return None
+        return TranslationOverride.objects.filter(pk=obj_id).values_list("white_label", flat=True).first()
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        """Offer only programs from this override's own white label.
+
+        The picker is otherwise every program in every tenant, where choosing the
+        wrong one silently points the override at another state's program.
+        """
+        if db_field.name == "program":
+            white_label = self._override_white_label(request)
+            if white_label is not None:
+                kwargs["queryset"] = Program.objects.filter(white_label=white_label).order_by("name_abbreviated")
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        """Offer only counties from this override's own white label.
+
+        County matching is exact string equality against `Screen.county`, and each
+        white label spells its counties differently — Illinois stores "Cook" while
+        CO, NC, and WA store "Cook County". A county picked from the wrong tenant
+        can never match a screen, and the override then does nothing at all.
+        """
+        if db_field.name == "counties":
+            white_label = self._override_white_label(request)
+            if white_label is not None:
+                kwargs["queryset"] = County.objects.filter(white_label=white_label).order_by("name")
+        return super().formfield_for_manytomany(db_field, request, **kwargs)
+
+    def get_counties(self, obj):
+        """Show the county scope in the list so a mis-scoped override is visible."""
+        names = [c.name for c in obj.counties.all()]
+        return ", ".join(names) if names else "All counties"
+
+    get_counties.short_description = "Counties"
 
     def get_str(self, obj):
         return str(obj)

--- a/programs/translation_override_admin_tests.py
+++ b/programs/translation_override_admin_tests.py
@@ -1,14 +1,17 @@
 """
-Tests for TranslationOverrideAdmin's white-label scoping.
+Tests for TranslationOverrideAdmin.
 
-A translation override points at one program and an optional set of counties.
-Both pickers used to offer every row in every tenant, so a staffer configuring
-an IL override could pick a CO program or a CO county with nothing flagging it.
-County matching is exact string equality against `Screen.county` and each white
-label spells counties differently ("Cook" in IL, "Cook County" in CO/NC/WA), so a
-county from the wrong tenant produces an override that silently never fires.
+An override points at one program and an optional set of counties. Both pickers
+must offer only rows from the override's own white label: county matching is
+exact string equality against `Screen.county` and each white label spells its
+counties differently ("Cook" in IL, "Cook County" in CO/NC/WA), so a county from
+another tenant produces an override that silently never fires.
 
-These tests pin the querysets the admin form offers.
+That scoping comes from `SecureAdmin.get_form`, which narrows every
+`ModelChoiceField` on a white-label-bearing model to `obj.white_label`. The test
+below goes through `get_form` rather than the `formfield_for_*` hooks so it pins
+the guarantee a staffer actually gets, and would fail if that base-class behavior
+regressed.
 """
 
 from django.contrib.admin.sites import AdminSite
@@ -28,7 +31,7 @@ class _Superuser:
         return True
 
 
-class TranslationOverrideAdminScopingTests(TestCase):
+class TranslationOverrideAdminTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.il = WhiteLabel.objects.create(name="IL Admin Test", code="il_admin_test", state_code="IL")
@@ -50,34 +53,27 @@ class TranslationOverrideAdminScopingTests(TestCase):
         self.admin = TranslationOverrideAdmin(TranslationOverride, AdminSite())
         self.factory = RequestFactory()
 
-    def _request_for_override(self, override_id):
-        """A change-page request, with the resolver kwargs the admin reads."""
-        request = self.factory.get(f"/admin/programs/translationoverride/{override_id}/change/")
+    def _change_form(self):
+        """The form a staffer editing this override actually gets."""
+        request = self.factory.get(f"/admin/programs/translationoverride/{self.override.id}/change/")
         request.user = _Superuser()
-        request.resolver_match = type("M", (), {"kwargs": {"object_id": str(override_id)}})()
-        return request
+        return self.admin.get_form(request, obj=self.override)
 
-    def test_program_choices_scoped_to_own_white_label(self):
-        request = self._request_for_override(self.override.id)
-        field = self.admin.formfield_for_foreignkey(TranslationOverride._meta.get_field("program"), request)
-        programs = list(field.queryset)
+    def test_change_form_scopes_program_and_counties_to_own_white_label(self):
+        """Neither picker may offer another tenant's rows.
+
+        A cross-white-label county is the silent-failure case: it can never equal
+        the screen's county, so the override would do nothing with no error.
+        """
+        form = self._change_form()
+
+        programs = list(form.base_fields["program"].queryset)
         self.assertIn(self.il_program, programs)
         self.assertNotIn(self.co_program, programs)
 
-    def test_county_choices_scoped_to_own_white_label(self):
-        request = self._request_for_override(self.override.id)
-        field = self.admin.formfield_for_manytomany(TranslationOverride._meta.get_field("counties"), request)
-        counties = list(field.queryset)
+        counties = list(form.base_fields["counties"].queryset)
         self.assertIn(self.il_cook, counties)
         self.assertNotIn(self.co_denver, counties)
-
-    def test_choices_unscoped_when_no_object_id(self):
-        """Without an override in the URL there is no white label to scope to."""
-        request = self.factory.get("/admin/programs/translationoverride/")
-        request.user = _Superuser()
-        request.resolver_match = type("M", (), {"kwargs": {}})()
-        field = self.admin.formfield_for_manytomany(TranslationOverride._meta.get_field("counties"), request)
-        self.assertIn(self.co_denver, list(field.queryset))
 
     def test_get_counties_lists_scope(self):
         self.override.counties.set([self.il_cook])
@@ -87,6 +83,12 @@ class TranslationOverrideAdminScopingTests(TestCase):
         """An override with no counties applies everywhere — say so explicitly."""
         self.override.counties.clear()
         self.assertEqual(self.admin.get_counties(self.override), "All counties")
+
+    def test_changelist_prefetches_counties(self):
+        """The county column must not add a query per row."""
+        request = self.factory.get("/admin/programs/translationoverride/")
+        request.user = _Superuser()
+        self.assertIn("counties", self.admin.get_queryset(request)._prefetch_related_lookups)
 
     def test_add_permission_still_denied(self):
         """Creation stays in the translations portal, which builds the Translation."""

--- a/programs/translation_override_admin_tests.py
+++ b/programs/translation_override_admin_tests.py
@@ -1,0 +1,95 @@
+"""
+Tests for TranslationOverrideAdmin's white-label scoping.
+
+A translation override points at one program and an optional set of counties.
+Both pickers used to offer every row in every tenant, so a staffer configuring
+an IL override could pick a CO program or a CO county with nothing flagging it.
+County matching is exact string equality against `Screen.county` and each white
+label spells counties differently ("Cook" in IL, "Cook County" in CO/NC/WA), so a
+county from the wrong tenant produces an override that silently never fires.
+
+These tests pin the querysets the admin form offers.
+"""
+
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory, TestCase
+
+from programs.admin import TranslationOverrideAdmin
+from programs.models import County, Program, TranslationOverride
+from screener.models import WhiteLabel
+
+
+class _Superuser:
+    is_superuser = True
+    is_active = True
+    is_staff = True
+
+    def has_perm(self, *args, **kwargs):
+        return True
+
+
+class TranslationOverrideAdminScopingTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.il = WhiteLabel.objects.create(name="IL Admin Test", code="il_admin_test", state_code="IL")
+        cls.co = WhiteLabel.objects.create(name="CO Admin Test", code="co_admin_test", state_code="CO")
+
+        cls.il_cook = County.objects.create(name="Cook", white_label=cls.il)
+        cls.co_denver = County.objects.create(name="Denver County", white_label=cls.co)
+
+        cls.il_program = Program.objects.new_program("il_admin_test", "il_liheap_admin")
+        cls.co_program = Program.objects.new_program("co_admin_test", "co_liheap_admin")
+
+        cls.override = TranslationOverride.objects.new_translation_override(
+            "il_admin_test", "_show", "apply_button_link"
+        )
+        cls.override.program = cls.il_program
+        cls.override.save()
+
+    def setUp(self):
+        self.admin = TranslationOverrideAdmin(TranslationOverride, AdminSite())
+        self.factory = RequestFactory()
+
+    def _request_for_override(self, override_id):
+        """A change-page request, with the resolver kwargs the admin reads."""
+        request = self.factory.get(f"/admin/programs/translationoverride/{override_id}/change/")
+        request.user = _Superuser()
+        request.resolver_match = type("M", (), {"kwargs": {"object_id": str(override_id)}})()
+        return request
+
+    def test_program_choices_scoped_to_own_white_label(self):
+        request = self._request_for_override(self.override.id)
+        field = self.admin.formfield_for_foreignkey(TranslationOverride._meta.get_field("program"), request)
+        programs = list(field.queryset)
+        self.assertIn(self.il_program, programs)
+        self.assertNotIn(self.co_program, programs)
+
+    def test_county_choices_scoped_to_own_white_label(self):
+        request = self._request_for_override(self.override.id)
+        field = self.admin.formfield_for_manytomany(TranslationOverride._meta.get_field("counties"), request)
+        counties = list(field.queryset)
+        self.assertIn(self.il_cook, counties)
+        self.assertNotIn(self.co_denver, counties)
+
+    def test_choices_unscoped_when_no_object_id(self):
+        """Without an override in the URL there is no white label to scope to."""
+        request = self.factory.get("/admin/programs/translationoverride/")
+        request.user = _Superuser()
+        request.resolver_match = type("M", (), {"kwargs": {}})()
+        field = self.admin.formfield_for_manytomany(TranslationOverride._meta.get_field("counties"), request)
+        self.assertIn(self.co_denver, list(field.queryset))
+
+    def test_get_counties_lists_scope(self):
+        self.override.counties.set([self.il_cook])
+        self.assertEqual(self.admin.get_counties(self.override), "Cook")
+
+    def test_get_counties_reports_unscoped_override(self):
+        """An override with no counties applies everywhere — say so explicitly."""
+        self.override.counties.clear()
+        self.assertEqual(self.admin.get_counties(self.override), "All counties")
+
+    def test_add_permission_still_denied(self):
+        """Creation stays in the translations portal, which builds the Translation."""
+        request = self.factory.get("/admin/programs/translationoverride/add/")
+        request.user = _Superuser()
+        self.assertFalse(self.admin.has_add_permission(request))

--- a/programs/translation_overrides/test_county_overrides.py
+++ b/programs/translation_overrides/test_county_overrides.py
@@ -1,0 +1,216 @@
+"""
+Tests for county-branched translation overrides — the mechanism that lets one
+program serve a different "Apply Now" link depending on the household's county.
+
+A program has one `apply_button_link`. A `TranslationOverride` row scoped to a set
+of counties replaces it for screens in those counties; every other county falls
+through to the program's own field, which is the default. Coverage here:
+
+  1. TestTranslationOverrideCountyEligible - county_eligible() in isolation
+  2. TestApplyButtonLinkByCounty           - get_translation() end to end
+  3. TestCountyNameConventions             - the naming trap that makes a
+                                             misconfigured override a silent no-op
+
+County matching is exact string equality against `Screen.county`, and each white
+label carries its own convention: Illinois stores bare names ("Cook"), while CO,
+NC, and WA store the "X County" form. Note this is stricter than the substring
+test navigator filtering uses in `filter_by_county`, so a value that resolves a
+navigator can still fail to resolve an override.
+"""
+
+from django.conf import settings
+from django.test import TestCase
+
+from programs.models import County, Program, TranslationOverride
+from programs.translation_overrides import warning_calculators
+from programs.translation_overrides.base import TranslationOverrideCalculator
+from programs.util import Dependencies
+from screener.models import Screen, WhiteLabel
+
+CEDA_LINK = "https://www.cedaorg.net/en/find-services/gas-and-electric"
+DEFAULT_LIHEAP_LINK = "https://example.org/apply/il-liheap"
+
+
+def set_translation(translated_field, text: str) -> None:
+    """Set a Translation's text in the default language.
+
+    `new_program` leaves every translation at BLANK_TRANSLATION_PLACEHOLDER, so a
+    test that asserts on a real URL has to fill it in. These are django-parler
+    models, so the write has to target an explicit language.
+    """
+    translated_field.set_current_language(settings.LANGUAGE_CODE)
+    translated_field.text = text
+    translated_field.save()
+
+
+def get_translation_text(translation) -> str:
+    """Read a Translation's text in the default language."""
+    translation.set_current_language(settings.LANGUAGE_CODE)
+    return translation.text
+
+
+class TestTranslationOverrideCountyEligible(TestCase):
+    """Unit tests for TranslationOverrideCalculator.county_eligible()."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="IL Test", code="il_test", state_code="IL")
+        cls.cook = County.objects.create(name="Cook", white_label=cls.white_label)
+        cls.dupage = County.objects.create(name="DuPage", white_label=cls.white_label)
+        cls.program = Program.objects.new_program("il_test", "il_liheap_test")
+
+    def setUp(self):
+        self.override = TranslationOverride.objects.new_translation_override("il_test", "_show", "apply_button_link")
+        self.override.program = self.program
+        self.override.save()
+
+    def _calculator(self, county: str | None) -> TranslationOverrideCalculator:
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="60004", county=county, household_size=1, completed=False
+        )
+        return TranslationOverrideCalculator(screen, self.override, Dependencies())
+
+    def test_matching_county_is_eligible(self):
+        """Screen in a listed county gets the override."""
+        self.override.counties.set([self.cook])
+        self.assertTrue(self._calculator("Cook").county_eligible())
+
+    def test_unlisted_county_is_not_eligible(self):
+        """Screen outside the listed counties falls through to the default link."""
+        self.override.counties.set([self.cook])
+        self.assertFalse(self._calculator("DuPage").county_eligible())
+
+    def test_no_counties_applies_everywhere(self):
+        """An override with no counties is unscoped and applies to every screen."""
+        self.override.counties.clear()
+        self.assertTrue(self._calculator("DuPage").county_eligible())
+
+    def test_blank_county_falls_through(self):
+        """A screen with no county resolved cannot match a county-scoped override."""
+        self.override.counties.set([self.cook])
+        self.assertFalse(self._calculator(None).county_eligible())
+
+    def test_multiple_counties_match_any(self):
+        """Listing several counties matches a screen in any one of them."""
+        self.override.counties.set([self.cook, self.dupage])
+        self.assertTrue(self._calculator("Cook").county_eligible())
+        self.assertTrue(self._calculator("DuPage").county_eligible())
+
+    def test_show_calculator_defers_entirely_to_county(self):
+        """`_show` adds no eligibility rule of its own, so calc() is the county test.
+
+        This is what makes a plain county-branched link possible with no new code.
+        """
+        self.override.counties.set([self.cook])
+        self.assertIs(warning_calculators["_show"], TranslationOverrideCalculator)
+        self.assertTrue(self._calculator("Cook").calc())
+        self.assertFalse(self._calculator("DuPage").calc())
+
+
+class TestApplyButtonLinkByCounty(TestCase):
+    """End-to-end tests for a county-specific apply_button_link via get_translation()."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="IL Test", code="il_test", state_code="IL")
+        cls.cook = County.objects.create(name="Cook", white_label=cls.white_label)
+        cls.program = Program.objects.new_program("il_test", "il_liheap_e2e")
+        set_translation(cls.program.apply_button_link, DEFAULT_LIHEAP_LINK)
+
+    def setUp(self):
+        self.override = TranslationOverride.objects.new_translation_override("il_test", "_show", "apply_button_link")
+        self.override.program = self.program
+        self.override.save()
+        self.override.counties.set([self.cook])
+        set_translation(self.override.translation, CEDA_LINK)
+
+    def _link_for(self, county: str | None) -> str:
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="60004", county=county, household_size=1, completed=False
+        )
+        program = Program.objects.get(pk=self.program.pk)
+        return get_translation_text(program.get_translation(screen, Dependencies(), "apply_button_link"))
+
+    def test_cook_county_gets_ceda_link(self):
+        self.assertEqual(self._link_for("Cook"), CEDA_LINK)
+
+    def test_other_county_gets_default_link(self):
+        """The program's own field is the fallback — no default row is configured."""
+        self.assertEqual(self._link_for("DuPage"), DEFAULT_LIHEAP_LINK)
+
+    def test_inactive_override_is_ignored(self):
+        self.override.active = False
+        self.override.save()
+        self.assertEqual(self._link_for("Cook"), DEFAULT_LIHEAP_LINK)
+
+    def test_override_only_affects_its_own_field(self):
+        """An apply_button_link override must not change learn_more_link."""
+        set_translation(self.program.learn_more_link, "https://example.org/learn")
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="60004", county="Cook", household_size=1, completed=False
+        )
+        program = Program.objects.get(pk=self.program.pk)
+        self.assertEqual(
+            get_translation_text(program.get_translation(screen, Dependencies(), "learn_more_link")),
+            "https://example.org/learn",
+        )
+
+    def test_program_without_override_is_unaffected(self):
+        """Single-link programs keep working with no config change."""
+        other = Program.objects.new_program("il_test", "il_other_program")
+        set_translation(other.apply_button_link, "https://example.org/apply/other")
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="60004", county="Cook", household_size=1, completed=False
+        )
+        self.assertEqual(
+            get_translation_text(other.get_translation(screen, Dependencies(), "apply_button_link")),
+            "https://example.org/apply/other",
+        )
+
+
+class TestCountyNameConventions(TestCase):
+    """County matching is exact, and the right string differs per white label.
+
+    A county name in the wrong convention makes the override a silent no-op: no
+    error, no log line, just the default link everywhere. These tests pin the
+    behavior so a misconfiguration fails here instead of in production.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="IL Test", code="il_test", state_code="IL")
+        cls.program = Program.objects.new_program("il_test", "il_liheap_naming")
+        set_translation(cls.program.apply_button_link, DEFAULT_LIHEAP_LINK)
+
+    def _link_for_override_county(self, override_county: str, screen_county: str) -> str:
+        county = County.objects.create(name=override_county, white_label=self.white_label)
+        override = TranslationOverride.objects.new_translation_override("il_test", "_show", "apply_button_link")
+        override.program = self.program
+        override.save()
+        override.counties.set([county])
+        set_translation(override.translation, CEDA_LINK)
+
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="60004", county=screen_county, household_size=1, completed=False
+        )
+        program = Program.objects.get(pk=self.program.pk)
+        return get_translation_text(program.get_translation(screen, Dependencies(), "apply_button_link"))
+
+    def test_il_bare_county_name_resolves(self):
+        """Illinois stores bare county names, so "Cook" is the correct value."""
+        self.assertEqual(self._link_for_override_county("Cook", "Cook"), CEDA_LINK)
+
+    def test_il_county_suffix_silently_fails_to_resolve(self):
+        """ "Cook County" never matches an IL screen — the documented wrong value.
+
+        Matching is equality, not the substring test used for navigators, so the
+        suffix form yields the default link with no error.
+        """
+        self.assertEqual(self._link_for_override_county("Cook County", "Cook"), DEFAULT_LIHEAP_LINK)
+
+    def test_suffix_convention_resolves_where_screens_use_it(self):
+        """CO/NC/WA store the "X County" form, where the suffix is correct."""
+        self.assertEqual(
+            self._link_for_override_county("Denver County", "Denver County"),
+            CEDA_LINK,
+        )

--- a/translations/translation_override_form_tests.py
+++ b/translations/translation_override_form_tests.py
@@ -1,0 +1,147 @@
+"""
+Tests for the translation override create form in the translations portal.
+
+An override needs four things to actually work: a calculator, the program field
+it replaces, the program it belongs to, and (optionally) the counties it applies
+to. The form used to collect only the first two, so a new override was born
+pointing at no program and applying to every county, and the rest had to be
+finished in the Django admin. These tests cover the unified form.
+
+The white label is chosen in the same submission, so program and county choices
+cannot be narrowed before submit — cross-white-label combinations are rejected in
+clean() instead. That matters most for counties: matching is exact string
+equality against `Screen.county`, so a county from another white label can never
+match and the override silently never fires.
+"""
+
+from django.test import TestCase
+
+from authentication.models import User
+from programs.models import County, Program, TranslationOverride
+from screener.models import WhiteLabel
+from translations.views import TranslationOverrideTranslationAdmin
+
+
+class _Superuser:
+    is_superuser = True
+    is_active = True
+    is_staff = True
+
+
+class TranslationOverrideCreateFormTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.il = WhiteLabel.objects.create(name="IL Form Test", code="il_form_test", state_code="IL")
+        cls.co = WhiteLabel.objects.create(name="CO Form Test", code="co_form_test", state_code="CO")
+
+        cls.cook = County.objects.create(name="Cook", white_label=cls.il)
+        cls.dupage = County.objects.create(name="DuPage", white_label=cls.il)
+        cls.denver = County.objects.create(name="Denver County", white_label=cls.co)
+
+        cls.il_program = Program.objects.new_program("il_form_test", "il_liheap_form")
+        cls.co_program = Program.objects.new_program("co_form_test", "co_liheap_form")
+
+    def setUp(self):
+        self.view = TranslationOverrideTranslationAdmin()
+        self.Form = TranslationOverrideTranslationAdmin.Form
+
+    def _payload(self, **overrides):
+        payload = {
+            "white_label": "il_form_test",
+            "external_name": "il_liheap_cook_apply_link",
+            "calculator_name": "_show",
+            "field_name": "apply_button_link",
+            "program": str(self.il_program.id),
+            "counties": [str(self.cook.id)],
+        }
+        payload.update(overrides)
+        return payload
+
+    def _form(self, **overrides):
+        return self.Form(self._payload(**overrides), user=_Superuser())
+
+    def test_form_collects_program_and_counties(self):
+        form = self._form()
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["program"], self.il_program)
+        self.assertEqual(list(form.cleaned_data["counties"]), [self.cook])
+
+    def test_counties_are_optional(self):
+        """No counties means the override applies everywhere — a valid choice."""
+        form = self._form(counties=[])
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(list(form.cleaned_data["counties"]), [])
+
+    def test_program_is_required(self):
+        form = self._form(program="")
+        self.assertFalse(form.is_valid())
+        self.assertIn("program", form.errors)
+
+    def test_rejects_program_from_another_white_label(self):
+        form = self._form(program=str(self.co_program.id))
+        self.assertFalse(form.is_valid())
+        self.assertIn("program", form.errors)
+
+    def test_rejects_county_from_another_white_label(self):
+        """The silent-failure case: a CO county on an IL override never matches."""
+        form = self._form(counties=[str(self.denver.id)])
+        self.assertFalse(form.is_valid())
+        self.assertIn("counties", form.errors)
+
+    def test_rejects_unknown_field_name(self):
+        """field_name is a choice now, so a typo cannot reach the database."""
+        form = self._form(field_name="aply_button_link")
+        self.assertFalse(form.is_valid())
+        self.assertIn("field_name", form.errors)
+
+    def test_rejects_unknown_calculator(self):
+        form = self._form(calculator_name="_nope")
+        self.assertFalse(form.is_valid())
+        self.assertIn("calculator_name", form.errors)
+
+    def test_apply_button_link_is_an_offered_field(self):
+        """The field this ticket needs has to be selectable."""
+        choices = [c[0] for c in self.Form(user=_Superuser()).fields["field_name"].choices]
+        self.assertIn("apply_button_link", choices)
+
+    def test_show_calculator_is_offered(self):
+        choices = [c[0] for c in self.Form(user=_Superuser()).fields["calculator_name"].choices]
+        self.assertIn("_show", choices)
+
+    def test_non_superuser_choices_limited_to_their_white_labels(self):
+        """A user who cannot see CO must not be offered CO programs or counties."""
+        user = User.objects.create_user(email_or_cell="il-staff@example.org", password="x")
+        user.is_staff = True
+        user.save()
+        user.white_labels.set([self.il])
+
+        form = self.Form(user=user)
+        self.assertIn(self.il_program, list(form.fields["program"].queryset))
+        self.assertNotIn(self.co_program, list(form.fields["program"].queryset))
+        self.assertIn(self.cook, list(form.fields["counties"].queryset))
+        self.assertNotIn(self.denver, list(form.fields["counties"].queryset))
+
+    def test_new_object_persists_program_and_counties(self):
+        """End to end: the created row comes out fully configured."""
+        form = self._form(counties=[str(self.cook.id), str(self.dupage.id)])
+        self.assertTrue(form.is_valid(), form.errors)
+
+        override = self.view._new_object(form)
+        override.refresh_from_db()
+
+        self.assertEqual(override.program, self.il_program)
+        self.assertEqual(override.field, "apply_button_link")
+        self.assertEqual(override.calculator, "_show")
+        self.assertEqual(override.white_label, self.il)
+        self.assertCountEqual([c.name for c in override.counties.all()], ["Cook", "DuPage"])
+        self.assertIsNotNone(override.translation)
+
+    def test_new_object_without_counties_applies_everywhere(self):
+        form = self._form(counties=[], external_name="il_liheap_statewide")
+        self.assertTrue(form.is_valid(), form.errors)
+
+        override = self.view._new_object(form)
+        override.refresh_from_db()
+
+        self.assertEqual(list(override.counties.all()), [])
+        self.assertEqual(TranslationOverride.objects.filter(pk=override.pk).count(), 1)

--- a/translations/views.py
+++ b/translations/views.py
@@ -19,6 +19,7 @@ from django.db import models
 from sentry_sdk import capture_exception
 import traceback
 from programs.models import (
+    County,
     Program,
     Navigator,
     ProgramCategory,
@@ -29,6 +30,7 @@ from programs.models import (
     WarningMessage,
     TranslationOverride,
 )
+from programs.translation_overrides import warning_calculators
 from phonenumber_field.formfields import PhoneNumberField
 from django.contrib.auth.decorators import login_required
 from django.contrib.admin.views.decorators import staff_member_required
@@ -558,23 +560,95 @@ class WarningMessageTranslationAdmin(TranslationAdminViews):
         )
 
 
+def get_translation_override_field_choices():
+    return [(f, f) for f in Program.objects.translated_fields]
+
+
+def get_translation_override_calculator_choices():
+    return [(name, name) for name in sorted(warning_calculators)]
+
+
 class TranslationOverrideTranslationAdmin(TranslationAdminViews):
     name = "translation_overrides"
 
     class Form(WhiteLabelForm):
+        """Collects everything an override needs to work, including the program it
+        overrides and the counties it applies to.
+
+        Those last two used to be reachable only from the Django admin after
+        creating the row here, so a new override started out pointing at no program
+        and applying to every county.
+        """
+
         external_name = forms.CharField(max_length=120, widget=forms.TextInput(attrs={"class": "input"}))
-        calculator_name = forms.CharField(max_length=120, widget=forms.TextInput(attrs={"class": "input"}))
-        field_name = forms.CharField(max_length=120, widget=forms.TextInput(attrs={"class": "input"}))
+        calculator_name = forms.ChoiceField(
+            choices=get_translation_override_calculator_choices, widget=forms.Select(attrs={"class": "input"})
+        )
+        field_name = forms.ChoiceField(
+            choices=get_translation_override_field_choices, widget=forms.Select(attrs={"class": "input"})
+        )
+        program = forms.ModelChoiceField(queryset=Program.objects.none(), widget=forms.Select(attrs={"class": "input"}))
+        counties = forms.ModelMultipleChoiceField(
+            queryset=County.objects.none(),
+            required=False,
+            widget=forms.SelectMultiple(attrs={"class": "input"}),
+            help_text="Leave empty to apply to every county. County names must match the screener's "
+            "own spelling for this white label — Illinois uses 'Cook' where Colorado uses 'Denver County'.",
+        )
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            # The white label is picked in this same form, so the program and county
+            # choices can only be narrowed once it has been submitted. Until then
+            # offer every option the user is allowed to see, and let clean() reject
+            # combinations that cross white labels.
+            allowed = [code for code, _ in self.fields["white_label"].choices]
+            self.fields["program"].queryset = Program.objects.filter(white_label__code__in=allowed).order_by(
+                "white_label__code", "name_abbreviated"
+            )
+            self.fields["counties"].queryset = County.objects.filter(white_label__code__in=allowed).order_by(
+                "white_label__code", "name"
+            )
+
+        def clean(self):
+            """Reject a program or county belonging to a different white label.
+
+            A county from another white label can never equal the screen's county, so
+            the override would silently never fire.
+            """
+            cleaned_data = super().clean()
+            white_label = cleaned_data.get("white_label")
+            program = cleaned_data.get("program")
+            counties = cleaned_data.get("counties")
+
+            if white_label and program and program.white_label.code != white_label:
+                self.add_error("program", f"{program} does not belong to the {white_label} white label.")
+
+            if white_label and counties:
+                mismatched = [c.name for c in counties if c.white_label.code != white_label]
+                if mismatched:
+                    self.add_error(
+                        "counties",
+                        f"{', '.join(mismatched)} does not belong to the {white_label} white label.",
+                    )
+
+            return cleaned_data
 
     Model = TranslationOverride
 
     def _new_object(self, form: Form) -> models.Model:
-        return self.Model.objects.new_translation_override(
-            form["white_label"].value(),
-            form["calculator_name"].value(),
-            form["field_name"].value(),
-            form["external_name"].value(),
+        translation_override = self.Model.objects.new_translation_override(
+            form.cleaned_data["white_label"],
+            form.cleaned_data["calculator_name"],
+            form.cleaned_data["field_name"],
+            form.cleaned_data["external_name"],
         )
+        translation_override.program = form.cleaned_data["program"]
+        translation_override.save()
+        translation_override.counties.set(form.cleaned_data["counties"])
+
+        return translation_override
 
     def _filter_query_set(self, request):
         return self._model_white_label_query_set(request.user).filter(


### PR DESCRIPTION
## Summary

MFB-1336 asks for "Apply Now" links that vary by county, in two parts: build the capability, then configure IL LIHEAP so Cook County routes to CEDA.

**Part 1 needed no new capability — it already ships.** A `TranslationOverride` on `apply_button_link` with `calculator=_show` and a county set does exactly this. `Program.get_translation()` (`programs/models.py:830`) walks a program's overrides and returns the matching one; `county_eligible()` branches on `Screen.county`. Each Part 1 acceptance criterion is already satisfied by the existing design:

- *County branching* — the `counties` M2M on `TranslationOverride`.
- *Default/fallback* — not a configured row. No match falls through to the program's own `apply_button_link`.
- *Backward compatible* — the branch exists only if a row is added, so single-link programs cannot regress.

No frontend work: the API returns one resolved link and the button renders it.

What was missing was not capability but **the ability to configure it without an engineer, and any test coverage at all.**

## The county-naming trap

The ticket's acceptance criteria say counties "must exactly match `Screen.county`, e.g. 'Cook County' not 'Cook'". **That is backwards for Illinois and would ship a link nobody can reach.** `configuration/white_labels/il.py:404` stores bare names (`{"Cook": "Cook"}`); CO, NC, and WA use the `"X County"` form. Matching is exact equality, so `"Cook County"` never matches an IL screen — and the failure is silent, because a county miss is indistinguishable from an unscoped program and just returns the default link. The correct value is `"Cook"`. MFB-1645 flagged this; this PR confirms it with tests asserting both directions.

Related asymmetry worth knowing: navigator filtering (`screener/views.py:330`) uses a *substring* test, so `"Cook"` resolves both paths while `"Cook County"` resolves a navigator and silently fails an override.

## Configuring an override used to take two screens

The portal form (`translations/views.py:560`) asked for white label, name, calculator, and field, then handed back a row pointing at **no program** and applying to **every county**. The program and counties were editable only in the Django admin, on a page reachable through a link on the override's portal page — and Django admin refuses creation outright (`has_add_permission` → `False`), because creation has to build the `Translation` row. So the half of the work that made an override actually function was on a screen staff had no reason to find.

**Now one submission produces a working override.** The create form collects the program and counties too. Counties stay optional, since an empty set legitimately means "applies everywhere".

Two related hardening changes:

- **Calculator and field are dropdowns instead of free text.** Both were strings matched against a fixed registry and a fixed tuple of translated fields, so a typo produced a row that parsed fine and silently never fired.
- **Cross-white-label combinations are rejected.** The white label is chosen in the same submission, so choices cannot be narrowed before submit; `clean()` rejects a program or county from another white label instead. This matters most for counties, for the exact-match reason above.

## Changes

**`translations/views.py`** — the unified create form described above.

**`programs/admin.py`** — the Django admin remains where an existing override is edited. The changelist gains `field` and the county scope, so "applies everywhere" is distinguishable at a glance from "scoped to Cook", with `counties` prefetched to keep it one query.

The pickers there are already scoped to the override's own white label, but **not by anything in this PR** — `SecureAdmin.get_form` (`authentication/admin.py:60`) narrows every `ModelChoiceField` on a white-label-bearing model to `obj.white_label` when editing, and `ModelMultipleChoiceField` subclasses it, so counties is covered too. An earlier revision of this PR added `formfield_for_foreignkey`/`formfield_for_manytomany` overrides that duplicated this; they have been removed. Probing `get_form` with and without them returns identical querysets (33 of 242 programs, 102 of 951 counties — the IL subsets either way), and they cost an extra query per render by re-fetching a white label `get_form` already had via `obj`.

This admin's `white_label_filter_horizontal` is still dropped, since nothing in the codebase consumes that attribute — but to be precise, the scoping it *looks* like it provides is real and comes from `get_form`. Five other admins still declare it.

**Tests (31 total).**
- `programs/translation_overrides/test_county_overrides.py` (14) — `county_eligible()` in isolation (match, no match, empty list, blank county, multi-county), the end-to-end `get_translation()` path (Cook→CEDA, other→default, inactive override ignored, other fields untouched, programs without overrides unaffected), and the naming trap in both conventions.
- `translations/translation_override_form_tests.py` (12) — the create form: program and counties persisted, counties optional, unknown field/calculator rejected, cross-white-label program and county rejected, non-superuser choices limited to their own white labels.
- `programs/translation_override_admin_tests.py` (5) — the county column, the changelist prefetch, add-permission still denied, and one test through `get_form(request, obj=...)` pinning the white-label scoping described above.

## Verification

- `programs/` + `screener/` + `translations/`: **3210 passed**, 0 failed.
- `manage.py check`: no issues.
- Exercised the real HTTP flow, not just the form in isolation: `GET .../translation_overrides/create` renders all four fields, and one POST creates an override with program and county attached.
- Mutation-tested each suite rather than trusting green: disabling the county gate fails 5 of the override tests; disabling `SecureAdmin`'s `obj.white_label` filter fails the admin scoping test; disabling the cross-white-label check fails 2 of the form tests.
- The admin mutation test is deliberately routed through `get_form`. An earlier revision asserted against the `formfield_for_*` hooks directly, which only proved the new code ran — it would have kept passing if the real scoping broke.
- Confirmed collection actually sweeps the new files — `tests_*.py` is silently skipped by this repo's `python_files` config, so the new files use the supported `*_tests.py` / `test_*.py`.

## Local verification of Part 2

Both Part 2 acceptance criteria were configured on a local DB and verified through the real eligibility API, on two households identical except for county:

```
Cook    LIHEAP eligible=True $725  apply → cedaorg.net/en/find-services/gas-and-electric
                                   navigator → CEDA
DuPage  LIHEAP eligible=True $725  apply → dceo.illinois.gov/...helpillinoisfamilies.html
                                   navigator → ICNA Relief
```

## Deployment (staging, then prod)

**Nothing in this PR ships the IL LIHEAP config.** The code change is the admin/form work; the override and the navigator are data and have to be created in each environment. There is no config-file or migration path for either — `TranslationOverride` rows are only creatable through the translations portal, and navigator↔program links only through the Django admin.

Order matters: create the row first, then set its URL, then attach it. Do staging first and confirm on a real Cook County screen before touching prod.

### 1. Check whether an override already exists

Graciela commented on 2026-07-23 that this was configured, so **staging and/or prod may already have a row.** Go to `/admin/programs/translationoverride/`, filter to `field = apply_button_link`, and look for `il_liheap`.

- If one exists, verify its county reads **`Cook`** in the new Counties column, not `Cook County`. If it is the suffix form, fix it — matching is exact equality, so that override has never fired for anyone.
- If none exists, create it per step 2.

### 2. Create the "Apply Now" override

At `/api/translations/admin/translation_overrides/create`:

| Field | Value |
|---|---|
| White label | `Illinois` |
| External name | `il_liheap_cook_apply_link` |
| Calculator name | `_show` |
| Field name | `apply_button_link` |
| Program | `[Illinois] il_liheap` |
| Counties | `[Illinois] Cook` |

Submit, then on the resulting page click **Translation** and set the text to:

```
https://www.cedaorg.net/en/find-services/gas-and-electric
```

`apply_button_link` is in `no_auto_fields`, so it is never machine-translated — the URL is used as-is for every language. Creating the override auto-creates its `Translation` row, so no separate `add_translations` run is needed for this step.

### 3. Create the CEDA navigator

**Do not reuse the existing IL CEDA navigator.** There is already a CEDA navigator in IL scoped to Cook, but it is WIC-specific: `assistance_link` points at `cedaorg.net/find-services/wic/`, the description is about WIC clinics, and the contact is `wic@cedaorg.net`. Attaching it to `il_liheap` would show LIHEAP applicants a WIC referral. Create a separate one.

At `/api/translations/admin/navigators/create` — label `ceda_liheap`, phone `+18559422332`. That form collects only label and phone (the same gap the override form had, left out of scope here), so fill in the rest afterward:

- On the navigator's portal page, set the translated fields:
  - **name** — `CEDA (Community and Economic Development Association of Cook County)`
  - **assistance_link** — `https://www.cedaorg.net/en/find-services/gas-and-electric`
  - **email** — `info@cedaorg.net`
  - **description** — carries the sub-provider nuance from the partner feedback, since county-level routing cannot express it: *"CEDA administers LIHEAP for the City of Chicago and suburban Cook County. CEDA works through a network of local sub-providers, so you may be directed to a partner agency near you rather than applying with CEDA directly."*
- In the Django admin (`/admin/programs/navigator/<id>/change/`), set **Counties** to `Cook`.
- Attach it to the program from the **Program** side, not the navigator side: `NavigatorAdmin` excludes both `programs` and `programs_ordered`, so go to `/admin/programs/program/<il_liheap id>/change/` and add a row in the **Program navigators** inline (navigator `ceda_liheap`, order as desired).

Note there are two program relations on `Navigator`. The results endpoint reads `programs_ordered` (the `ProgramNavigator` through model), which is what the inline writes. The legacy `programs` M2M is separate and does not need to be set — a navigator can show correctly with `programs` empty.

### 4. Verify on a real screen

Complete a screener with a Cook County ZIP (e.g. `60602`) and confirm LIHEAP's **Apply Now** points at CEDA and the "Get Help Applying" box shows the CEDA navigator. Then repeat with a non-Cook IL ZIP (e.g. `60515`, DuPage) and confirm the state `dceo.illinois.gov` link and that county's own navigator.

LIHEAP's benefit is capped at the household's reported heating expense, so a screen with no heating/cooling expense resolves to $0 and drops out of eligible results. Include one when testing.

### Known rough edge when configuring

If a submission is rejected — a program or county from another white label, an unknown calculator or field — **Submit will appear to do nothing.** `_add_view` returns a bare `HttpResponseBadRequest()` with no body, and the form is HTMX-posted, so `clean()`'s error messages are never rendered. Nothing is written (verified: cross-white-label POST → 400, 0 rows created), so this is safe rather than silently corrupting, but it is confusing. This is pre-existing behavior of the shared `TranslationAdminViews` base, not new here; it newly matters because this PR introduces a rejection path a well-intentioned submission can plausibly hit.

Practical consequence: pick the `[Illinois]` entries in the Program and Counties lists. Because narrowing was deferred to `clean()`, a superuser's create form renders every program and all 951 counties in one flat multi-select. `County.__str__` prefixes the white label (`[Illinois] Cook`), which keeps it unambiguous, but the list is long. Rendering the errors, or narrowing the lists on white-label change, is the obvious follow-up.

## Caveat on the original partner request

Granularity is county-level only, so this cannot separate City of Chicago from suburban Cook. The "you may be routed to a sub-provider rather than CEDA directly" nuance has to live in description copy — routing alone will not express it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


