### PR TITLE
Repin MO WFTC and PTS tests to PolicyEngine 1.794.2

### DIFF
--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario01GoldenPathSeniorRenter.test_eligible_at_the_top_renter_band.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario01GoldenPathSeniorRenter.test_eligible_at_the_top_renter_band.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82011"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82011"]}}, "households": {"household": {"members":
       ["82011"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82011"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82011"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -43,7 +43,7 @@ interactions:
         {"2026": 1033.0}}}, "families": {"family": {"members": ["82011"]}}, "households":
         {"household": {"members": ["82011"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82011"]}}, "marital_units": {}}, "policyengine_bundle":
-        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+        {"model_version": "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -54,15 +54,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:12:43 GMT
+      - Fri, 21 Aug 2026 18:59:32 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-8b64d56156d9aea0148d9b8eda24a2bb-45028a1ee82bfc55-00
+      - 00-4475d9de62ed051b915a427e10cf2442-21cce20ce0cb6a3f-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 8b64d56156d9aea0148d9b8eda24a2bb
+      - 4475d9de62ed051b915a427e10cf2442
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -70,7 +70,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 8e7a0c6c-bc8f-47a7-ab2b-5761be315a52
+      - fc1364b8-ebe0-4de5-897f-107735b2ac2e
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario02SingleRenterAtTheLimit.test_eligible_at_the_income_boundary.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario02SingleRenterAtTheLimit.test_eligible_at_the_income_boundary.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82021"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82021"]}}, "households": {"household": {"members":
       ["82021"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82021"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82021"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,10 +44,10 @@ interactions:
         {"family": {"members": ["82021"]}}, "households": {"household": {"members":
         ["82021"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82021"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1154'
       access-control-allow-origin:
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:12:45 GMT
+      - Fri, 21 Aug 2026 18:59:34 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-e03388aa3c6dc3535f41116368ad7ac6-83f37e891b925f65-00
+      - 00-7a20825652fb12bf1cbc8124e86417f2-9df737e087640258-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - e03388aa3c6dc3535f41116368ad7ac6
+      - 7a20825652fb12bf1cbc8124e86417f2
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - c209e22e-86a2-4dfd-93ae-34fdc77cdc66
+      - 353ba823-d4fc-4268-be9f-d83cc45f6f9d
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario03SingleHomeownerAtTheLimit.test_eligible_at_the_owner_income_boundary.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario03SingleHomeownerAtTheLimit.test_eligible_at_the_owner_income_boundary.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82031"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82031"]}}, "households": {"household": {"members":
       ["82031"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82031"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82031"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,7 +44,7 @@ interactions:
         {"family": {"members": ["82031"]}}, "households": {"household": {"members":
         ["82031"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82031"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:12:51 GMT
+      - Fri, 21 Aug 2026 18:59:36 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-d226ea7fcd6dbaa278fa643623de8a15-ac62cd0b15952bff-01
+      - 00-9c9450feda7aba5d55ee2be32b73d8fe-925766ad4ab62d3b-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - d226ea7fcd6dbaa278fa643623de8a15;o=1
+      - 9c9450feda7aba5d55ee2be32b73d8fe
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - a192f57c-ac54-426c-8fc5-5db3bf01422e
+      - 4e4ed220-2a06-4db3-a6e9-c2e73a5c57ff
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario04SingleRenterOverTheLimit.test_one_dollar_over_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario04SingleRenterOverTheLimit.test_one_dollar_over_disqualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82041"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82041"]}}, "households": {"household": {"members":
       ["82041"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82041"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82041"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,7 +44,7 @@ interactions:
         {"family": {"members": ["82041"]}}, "households": {"household": {"members":
         ["82041"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82041"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:12:54 GMT
+      - Fri, 21 Aug 2026 18:59:38 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-bf1b769616f5036d1eba8abf182257c8-276c2ffda0959720-00
+      - 00-87b198a8e0062d9cc2012558e696c5f4-af2bd9c7b7f68a39-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - bf1b769616f5036d1eba8abf182257c8
+      - 87b198a8e0062d9cc2012558e696c5f4;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 75952b78-ef36-4cba-9223-e891457e3b81
+      - d915938b-225c-46dc-adf0-ef867f859939
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario05AtTheMinimumBase.test_no_phaseout_at_or_below_the_base.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario05AtTheMinimumBase.test_no_phaseout_at_or_below_the_base.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82051"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82051"]}}, "households": {"household": {"members":
       ["82051"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82051"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82051"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,10 +44,10 @@ interactions:
         {"family": {"members": ["82051"]}}, "households": {"household": {"members":
         ["82051"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82051"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1155'
       access-control-allow-origin:
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:12:56 GMT
+      - Fri, 21 Aug 2026 18:59:40 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-a6f4d01257b120f1377eb59520a0b33a-43659aa23c44bf19-00
+      - 00-67a83502226d6d8895b1892e6cd3083b-461a9c3afba71864-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - a6f4d01257b120f1377eb59520a0b33a
+      - 67a83502226d6d8895b1892e6cd3083b
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 72c3c590-63f7-4cb3-9cca-8e39dd455a0b
+      - 090627bd-0569-42a2-bbcb-e83d09b91a51
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario06TurnsSixtyFiveLaterInTheYear.test_end_of_year_age_qualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario06TurnsSixtyFiveLaterInTheYear.test_end_of_year_age_qualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82061"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82061"]}}, "households": {"household": {"members":
       ["82061"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82061"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82061"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,7 +44,7 @@ interactions:
         {"family": {"members": ["82061"]}}, "households": {"household": {"members":
         ["82061"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82061"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:12:58 GMT
+      - Fri, 21 Aug 2026 18:59:42 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-f54ca27c41f02f25629d0ea0546dfc52-1107be5df0882870-00
+      - 00-8014fec1c8e53ba678af5b07f7b38d2c-8e3afd866b3483c6-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - f54ca27c41f02f25629d0ea0546dfc52
+      - 8014fec1c8e53ba678af5b07f7b38d2c
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 1b0df778-be2c-4dab-9da2-ff7d4b85be19
+      - a037944c-83eb-4af0-88d7-f3589fcca889
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario07NoHomestead.test_no_homestead_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario07NoHomestead.test_no_homestead_disqualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82071"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82071"]}}, "households": {"household": {"members":
       ["82071"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82071"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82071"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,10 +44,10 @@ interactions:
         {"family": {"members": ["82071"]}}, "households": {"household": {"members":
         ["82071"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82071"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1152'
       access-control-allow-origin:
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:01 GMT
+      - Fri, 21 Aug 2026 18:59:43 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-5214f44e011b862772fd114365484feb-6b091c2a2f58d7cf-01
+      - 00-b5072dfd3f17e5b12e3e10d1b39c6098-56857883710c1364-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 5214f44e011b862772fd114365484feb;o=1
+      - b5072dfd3f17e5b12e3e10d1b39c6098
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 233c55a8-a3d1-48df-bbe7-697a807fc977
+      - 2b4fd206-0d97-49bf-b161-2eff42c251fd
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario08AdultChildIncomeExcluded.test_adult_child_income_is_excluded.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario08AdultChildIncomeExcluded.test_adult_child_income_is_excluded.yaml
@@ -30,7 +30,7 @@ interactions:
       {"household": {"members": ["82081", "82082", "82083"], "state_code": {"2026":
       "MO"}}}, "spm_units": {"spm_unit": {"members": ["82081", "82082", "82083"]}},
       "marital_units": {"82081-82082": {"members": ["82081", "82082"]}}}, "version":
-      "1.786.5"}'
+      "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -80,10 +80,10 @@ interactions:
         "82082", "82083"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit":
         {"members": ["82081", "82082", "82083"]}}, "marital_units": {"82081-82082":
         {"members": ["82081", "82082"]}}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '2674'
       access-control-allow-origin:
@@ -91,15 +91,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:04 GMT
+      - Fri, 21 Aug 2026 18:59:45 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-da4bf4c90fec982fec900dd99f136157-9816fe80cdafbd11-00
+      - 00-77d395f1d4f48972a480faa5a9c39b5a-72d988da36478600-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - da4bf4c90fec982fec900dd99f136157
+      - 77d395f1d4f48972a480faa5a9c39b5a
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -107,7 +107,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 53aae2cb-4958-4583-baa2-75da320226f9
+      - 17dfc5e6-322b-4696-acfa-a92bee39efdc
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario09MarriedHomeownersOverTheLimit.test_over_the_married_owner_limit.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario09MarriedHomeownersOverTheLimit.test_over_the_married_owner_limit.yaml
@@ -22,7 +22,7 @@ interactions:
       "families": {"family": {"members": ["82091", "82092"]}}, "households": {"household":
       {"members": ["82091", "82092"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82091", "82092"]}}, "marital_units": {"82091-82092":
-      {"members": ["82091", "82092"]}}}, "version": "1.786.5"}'
+      {"members": ["82091", "82092"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -64,7 +64,7 @@ interactions:
         {"members": ["82091", "82092"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82091", "82092"]}}, "marital_units": {"82091-82092":
         {"members": ["82091", "82092"]}}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -75,15 +75,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:06 GMT
+      - Fri, 21 Aug 2026 18:59:47 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-8344e1af143f37430d30fca8d9c8a8c3-c297a61199d9062f-00
+      - 00-9a1044850ae8cd8ce7183d3b4abb91c9-4dfacc71dd549c04-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 8344e1af143f37430d30fca8d9c8a8c3
+      - 9a1044850ae8cd8ce7183d3b4abb91c9
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -91,7 +91,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 68fcf2ed-dff7-4f70-8f5b-fadaa40d297d
+      - 283abfad-9768-4b76-9b35-7d4f26777d57
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario10ClaimantDisabilityPathway.test_disability_pathway_qualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario10ClaimantDisabilityPathway.test_disability_pathway_qualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82101"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82101"]}}, "households": {"household": {"members":
       ["82101"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82101"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82101"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -43,10 +43,10 @@ interactions:
         {"2026": 960.0}}}, "families": {"family": {"members": ["82101"]}}, "households":
         {"household": {"members": ["82101"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82101"]}}, "marital_units": {}}, "policyengine_bundle":
-        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+        {"model_version": "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1153'
       access-control-allow-origin:
@@ -54,15 +54,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:10 GMT
+      - Fri, 21 Aug 2026 18:59:49 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-338a811000ee2e21661ea6ebed431db7-72df7b7936f56a5b-00
+      - 00-7e89e0450e10fceee0f5db3f1682397a-8a33b5350ea44ed4-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 338a811000ee2e21661ea6ebed431db7
+      - 7e89e0450e10fceee0f5db3f1682397a;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -70,7 +70,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 14aa6ee0-e4c4-4b54-9a9f-81898bcfd47e
+      - 6e481401-3459-4d62-bbf1-abf99cefe60a
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario11NoQualifyingPathway.test_no_pathway_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario11NoQualifyingPathway.test_no_pathway_disqualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82111"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82111"]}}, "households": {"household": {"members":
       ["82111"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82111"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82111"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,10 +44,10 @@ interactions:
         {"family": {"members": ["82111"]}}, "households": {"household": {"members":
         ["82111"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82111"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1152'
       access-control-allow-origin:
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:11 GMT
+      - Fri, 21 Aug 2026 18:59:51 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-836717d38021897867e40300b0c1dc38-3bede6fa0f081f5c-00
+      - 00-fc30782d48fe1f4de15e291d6801fc01-027da813184fcccd-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 836717d38021897867e40300b0c1dc38
+      - fc30782d48fe1f4de15e291d6801fc01
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 89896c26-be0b-49e8-b3ff-74d5b363bba3
+      - 555be9d2-195b-4514-9440-269401c27171
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario12ClaimantSurvivorPathway.test_survivor_pathway_qualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario12ClaimantSurvivorPathway.test_survivor_pathway_qualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82121"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82121"]}}, "households": {"household": {"members":
       ["82121"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82121"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82121"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -43,7 +43,7 @@ interactions:
         {"2026": 1055.0}}}, "families": {"family": {"members": ["82121"]}}, "households":
         {"household": {"members": ["82121"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82121"]}}, "marital_units": {}}, "policyengine_bundle":
-        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+        {"model_version": "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -54,15 +54,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:13 GMT
+      - Fri, 21 Aug 2026 18:59:53 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-36ae7547bb80ca708c28e17680065861-5e16ae94822745c7-00
+      - 00-b49038afe4057754db05f2d14c5348b7-44bb05d46bcdce7b-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 36ae7547bb80ca708c28e17680065861
+      - b49038afe4057754db05f2d14c5348b7
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -70,7 +70,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - b36001d2-73ff-4074-9509-2b50c33784d4
+      - 44c56f35-c875-48ea-8f18-74f5111bd4ba
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario13ClaimantVeteranBenefitsExcluded.test_veterans_benefits_are_excluded.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario13ClaimantVeteranBenefitsExcluded.test_veterans_benefits_are_excluded.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82131"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82131"]}}, "households": {"household": {"members":
       ["82131"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82131"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82131"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,7 +44,7 @@ interactions:
         {"family": {"members": ["82131"]}}, "households": {"household": {"members":
         ["82131"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82131"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:16 GMT
+      - Fri, 21 Aug 2026 18:59:58 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-b2e8daac167b38027d6c8f2af1613b0e-bbf8a96101e33b59-00
+      - 00-917d22972f3c82bd37030688070960c1-8069b4022a33cb9b-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - b2e8daac167b38027d6c8f2af1613b0e
+      - 917d22972f3c82bd37030688070960c1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 3eafb1e6-d83b-4e39-bb6a-5883cb30dea5
+      - 5a4d9870-d584-4104-9005-e6afb7801fac
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario14MarriedRenterAtTheLimit.test_eligible_at_the_married_renter_boundary.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario14MarriedRenterAtTheLimit.test_eligible_at_the_married_renter_boundary.yaml
@@ -21,7 +21,7 @@ interactions:
       {"2026": null}}}, "families": {"family": {"members": ["82141", "82142"]}}, "households":
       {"household": {"members": ["82141", "82142"], "state_code": {"2026": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["82141", "82142"]}}, "marital_units":
-      {"82141-82142": {"members": ["82141", "82142"]}}}, "version": "1.786.5"}'
+      {"82141-82142": {"members": ["82141", "82142"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,10 +62,10 @@ interactions:
         "households": {"household": {"members": ["82141", "82142"], "state_code":
         {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["82141", "82142"]}},
         "marital_units": {"82141-82142": {"members": ["82141", "82142"]}}}, "policyengine_bundle":
-        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+        {"model_version": "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1943'
       access-control-allow-origin:
@@ -73,15 +73,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:19 GMT
+      - Fri, 21 Aug 2026 19:00:00 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-f6b3e396f384ad4b7c9ee54030d46187-666a26e040b5a5aa-00
+      - 00-0e8d11bf8c3cd97ada4edd078daa0e72-97bc6cc0dd042f06-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - f6b3e396f384ad4b7c9ee54030d46187
+      - 0e8d11bf8c3cd97ada4edd078daa0e72;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -89,7 +89,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 4c0eb348-562c-4f92-84ee-4973c04b4946
+      - 4e487c46-5a09-45b8-9d89-2cdc701c999d
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario15SpouseOnlyAgePathway.test_spouse_age_qualifies_the_household.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario15SpouseOnlyAgePathway.test_spouse_age_qualifies_the_household.yaml
@@ -21,7 +21,7 @@ interactions:
       "families": {"family": {"members": ["82151", "82152"]}}, "households": {"household":
       {"members": ["82151", "82152"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82151", "82152"]}}, "marital_units": {"82151-82152":
-      {"members": ["82151", "82152"]}}}, "version": "1.786.5"}'
+      {"members": ["82151", "82152"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,7 +62,7 @@ interactions:
         ["82151", "82152"]}}, "households": {"household": {"members": ["82151", "82152"],
         "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["82151",
         "82152"]}}, "marital_units": {"82151-82152": {"members": ["82151", "82152"]}}},
-        "policyengine_bundle": {"model_version": "1.786.5", "data_version": null,
+        "policyengine_bundle": {"model_version": "1.794.2", "data_version": null,
         "dataset": null}}'
     headers:
       Alt-Svc:
@@ -74,15 +74,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:21 GMT
+      - Fri, 21 Aug 2026 19:00:02 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-06a1785aeb0d6acf85874c031ed9c989-b9d159e207a19937-01
+      - 00-7c791a9a9c703295f3cf13eaa1e8b759-f066baa04c4bf122-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 06a1785aeb0d6acf85874c031ed9c989;o=1
+      - 7c791a9a9c703295f3cf13eaa1e8b759
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -90,7 +90,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - d407d882-f724-4d0f-ba03-4c63c947e8e3
+      - 5b462560-44ad-432a-96bd-1026d79a5ed4
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario16SpouseSurvivorDoesNotQualifyClaimant.test_survivor_pathway_does_not_pass_through_the_spouse.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario16SpouseSurvivorDoesNotQualifyClaimant.test_survivor_pathway_does_not_pass_through_the_spouse.yaml
@@ -21,7 +21,7 @@ interactions:
       "families": {"family": {"members": ["82161", "82162"]}}, "households": {"household":
       {"members": ["82161", "82162"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82161", "82162"]}}, "marital_units": {"82161-82162":
-      {"members": ["82161", "82162"]}}}, "version": "1.786.5"}'
+      {"members": ["82161", "82162"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,10 +62,10 @@ interactions:
         {"members": ["82161", "82162"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82161", "82162"]}}, "marital_units": {"82161-82162":
         {"members": ["82161", "82162"]}}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1935'
       access-control-allow-origin:
@@ -73,15 +73,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:24 GMT
+      - Fri, 21 Aug 2026 19:00:04 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-30b2f79a7df0c03c2febedb11be65c76-e70b985c28c5dede-00
+      - 00-d8829016305608c1dc29a149d1145b11-28b06b3ab68602dc-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 30b2f79a7df0c03c2febedb11be65c76
+      - d8829016305608c1dc29a149d1145b11
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -89,7 +89,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - b2d6df48-cf77-43ea-a739-903a19d4b5cc
+      - 56696671-7138-4ea5-9e24-7a5ac18cdcf9
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario17MinorChildIncomeIncluded.test_minor_child_ssi_is_counted.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario17MinorChildIncomeIncluded.test_minor_child_ssi_is_counted.yaml
@@ -21,7 +21,7 @@ interactions:
       "families": {"family": {"members": ["82171", "82172"]}}, "households": {"household":
       {"members": ["82171", "82172"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82171", "82172"]}}, "marital_units": {}}, "version":
-      "1.786.5"}'
+      "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -61,10 +61,10 @@ interactions:
         "families": {"family": {"members": ["82171", "82172"]}}, "households": {"household":
         {"members": ["82171", "82172"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82171", "82172"]}}, "marital_units": {}}, "policyengine_bundle":
-        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+        {"model_version": "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1890'
       access-control-allow-origin:
@@ -72,15 +72,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:26 GMT
+      - Fri, 21 Aug 2026 19:00:06 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-c9eaf8b3f7dd91597e2b200abb489c42-385957f7fe077150-00
+      - 00-9803ae6abae97f5a7a58393e6c8adc67-d6a3979e25c6b68b-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - c9eaf8b3f7dd91597e2b200abb489c42
+      - 9803ae6abae97f5a7a58393e6c8adc67
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -88,7 +88,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 7ccda809-fb62-4a0d-8279-f71ad2c38fcc
+      - a296cbf2-6f5b-4b17-bdb2-a17b1426f58c
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario18ZeroQualifyingPayment.test_zero_payment_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario18ZeroQualifyingPayment.test_zero_payment_disqualifies.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82181"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82181"]}}, "households": {"household": {"members":
       ["82181"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82181"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82181"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,7 +44,7 @@ interactions:
         {"family": {"members": ["82181"]}}, "households": {"household": {"members":
         ["82181"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82181"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:29 GMT
+      - Fri, 21 Aug 2026 19:00:07 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-6827ace0d2078dbc0d124ff9fa368e36-5f614a95e07767d5-00
+      - 00-7b7e3f9d323a510c22a3061d95116c19-af08f9b1a07b9d4a-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 6827ace0d2078dbc0d124ff9fa368e36
+      - 7b7e3f9d323a510c22a3061d95116c19
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 61efa348-d9cc-4ef8-bc5d-888dcc13d87b
+      - 8eb9d38d-f56d-4676-8925-0ea06a27575f
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario19ZeroFloorIsNotSurfaced.test_zero_credit_reports_ineligible.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario19ZeroFloorIsNotSurfaced.test_zero_credit_reports_ineligible.yaml
@@ -12,7 +12,7 @@ interactions:
       {"members": ["82191"], "mo_property_tax_credit": {"2026": null}}}, "families":
       {"family": {"members": ["82191"]}}, "households": {"household": {"members":
       ["82191"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
-      ["82191"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      ["82191"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -44,10 +44,10 @@ interactions:
         {"family": {"members": ["82191"]}}, "households": {"household": {"members":
         ["82191"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members":
         ["82191"]}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1151'
       access-control-allow-origin:
@@ -55,15 +55,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:32 GMT
+      - Fri, 21 Aug 2026 19:00:09 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-5a50d5e713b77a240efd15e308d9d9a5-66ff3d77e36b604c-00
+      - 00-d0e997818c6def2bcfcbb874a7e34d35-41137221b76ac9f8-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 5a50d5e713b77a240efd15e308d9d9a5
+      - d0e997818c6def2bcfcbb874a7e34d35
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -71,7 +71,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - e1620ab0-53ea-4d38-bdb5-7e967947bd0d
+      - 0fd39f75-bc7b-478a-a504-09da086db4e7
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario20SpouseDisabilityPathway.test_spouse_disability_qualifies_the_household.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario20SpouseDisabilityPathway.test_spouse_disability_qualifies_the_household.yaml
@@ -21,7 +21,7 @@ interactions:
       "families": {"family": {"members": ["82201", "82202"]}}, "households": {"household":
       {"members": ["82201", "82202"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82201", "82202"]}}, "marital_units": {"82201-82202":
-      {"members": ["82201", "82202"]}}}, "version": "1.786.5"}'
+      {"members": ["82201", "82202"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,7 +62,7 @@ interactions:
         {"members": ["82201", "82202"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82201", "82202"]}}, "marital_units": {"82201-82202":
         {"members": ["82201", "82202"]}}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -73,15 +73,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:34 GMT
+      - Fri, 21 Aug 2026 19:00:11 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-7367e1347e6547cf59a1e69a444b9526-6ca81fdd1f8e79ea-00
+      - 00-09318e32fb8159eb8af2154c5ca80957-675427ff9f91df05-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 7367e1347e6547cf59a1e69a444b9526
+      - 09318e32fb8159eb8af2154c5ca80957
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -89,7 +89,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - ed0f9eb3-a718-4efa-8022-916129c13064
+      - 6bed32d8-5fea-4e72-a960-7c922f28e653
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario21MarriedHomeownersAtTheLimit.test_eligible_at_the_married_owner_boundary.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario21MarriedHomeownersAtTheLimit.test_eligible_at_the_married_owner_boundary.yaml
@@ -21,7 +21,7 @@ interactions:
       "families": {"family": {"members": ["82211", "82212"]}}, "households": {"household":
       {"members": ["82211", "82212"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82211", "82212"]}}, "marital_units": {"82211-82212":
-      {"members": ["82211", "82212"]}}}, "version": "1.786.5"}'
+      {"members": ["82211", "82212"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,7 +62,7 @@ interactions:
         {"members": ["82211", "82212"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82211", "82212"]}}, "marital_units": {"82211-82212":
         {"members": ["82211", "82212"]}}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -73,15 +73,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:35 GMT
+      - Fri, 21 Aug 2026 19:00:13 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-76a7fb15f367cc03c026604b49f11bf8-c39cf53f5b3fe5d0-00
+      - 00-d091e5ce3f6e098500959abe445c0f2c-a2ea953b655f34d4-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 76a7fb15f367cc03c026604b49f11bf8
+      - d091e5ce3f6e098500959abe445c0f2c
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -89,7 +89,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 3aacaf6c-8299-4c0e-9998-1e5ae33915c8
+      - 059db6d5-7e7f-4433-aa83-25246935ff5f
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario22SpouseVeteranBenefitsExcluded.test_spouse_veterans_benefits_are_excluded.yaml
+++ b/programs/programs/white_labels/mo/pts/tests/cassettes/TestScenario22SpouseVeteranBenefitsExcluded.test_spouse_veterans_benefits_are_excluded.yaml
@@ -21,7 +21,7 @@ interactions:
       "families": {"family": {"members": ["82221", "82222"]}}, "households": {"household":
       {"members": ["82221", "82222"], "state_code": {"2026": "MO"}}}, "spm_units":
       {"spm_unit": {"members": ["82221", "82222"]}}, "marital_units": {"82221-82222":
-      {"members": ["82221", "82222"]}}}, "version": "1.786.5"}'
+      {"members": ["82221", "82222"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,10 +62,10 @@ interactions:
         {"members": ["82221", "82222"], "state_code": {"2026": "MO"}}}, "spm_units":
         {"spm_unit": {"members": ["82221", "82222"]}}, "marital_units": {"82221-82222":
         {"members": ["82221", "82222"]}}}, "policyengine_bundle": {"model_version":
-        "1.786.5", "data_version": null, "dataset": null}}'
+        "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1932'
       access-control-allow-origin:
@@ -73,15 +73,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Aug 2026 18:13:38 GMT
+      - Fri, 21 Aug 2026 19:00:15 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-0ec6764350b5afac58e274d50ad70551-aefb8acc2186b8e0-00
+      - 00-4b2171935d9a42eebe2539db1646a0a2-b96a2f2736984c22-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 0ec6764350b5afac58e274d50ad70551
+      - 4b2171935d9a42eebe2539db1646a0a2
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -89,7 +89,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 738eaa58-9903-4cb2-a86a-f15f630d018a
+      - acb95782-69f4-4a57-a3e8-2e29b9caeaa5
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/pts/tests/test_mo_pts.py
+++ b/programs/programs/white_labels/mo/pts/tests/test_mo_pts.py
@@ -32,7 +32,7 @@ from screener.models import Expense
 from programs.programs.white_labels.mo.pts.calculator import MoPts
 from programs.framework.pe_dependencies import member
 
-PE_VERSION = "1.786.5"
+PE_VERSION = "1.794.2"
 CLAIM_YEAR = 2026
 
 

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario01GoldenPath.test_eligible_at_full_twenty_percent.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario01GoldenPath.test_eligible_at_full_twenty_percent.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91011", "91012"]}}, "households":
       {"household": {"members": ["91011", "91012"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91011", "91012"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,7 +49,7 @@ interactions:
         {"2025": 333.46603}}}, "families": {"family": {"members": ["91011", "91012"]}},
         "households": {"household": {"members": ["91011", "91012"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91011", "91012"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:31 GMT
+      - Fri, 21 Aug 2026 18:58:51 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-de6e2bf55a42b03d2cd173abd3ac3191-39cc140ab7a3a371-01
+      - 00-e92f6bcb6cbc7b0ecd18fdbc71743134-1011be4e38d92667-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - de6e2bf55a42b03d2cd173abd3ac3191;o=1
+      - e92f6bcb6cbc7b0ecd18fdbc71743134;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - c51e899a-f1bf-4ea4-8279-812597e970d2
+      - 3c63991c-30cb-4ac2-b6d6-69ec211ab975
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario02TaxYear2023Rate.test_uses_ten_percent_rate.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario02TaxYear2023Rate.test_uses_ten_percent_rate.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2023": null}}}, "families": {"family": {"members": ["91021", "91022"]}}, "households":
       {"household": {"members": ["91021", "91022"], "state_code": {"2023": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91021", "91022"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         {"2023": 104.82881}}}, "families": {"family": {"members": ["91021", "91022"]}},
         "households": {"household": {"members": ["91021", "91022"], "state_code":
         {"2023": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91021", "91022"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1368'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:33 GMT
+      - Fri, 21 Aug 2026 18:59:02 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-a95a67bfb84a8719ecab9bda13bc72ad-6cb76fefa266ddc2-00
+      - 00-4b95c3c0e1415c5f5c2fb9e17db15b49-1320fb8c78ad60ea-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - a95a67bfb84a8719ecab9bda13bc72ad
+      - 4b95c3c0e1415c5f5c2fb9e17db15b49
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 20745cf8-192d-4454-aae0-37d6583c3d59
+      - b7db4235-0e1c-4d17-9e8a-59f80a8affa5
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario03InvestmentOverLimit.test_investment_income_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario03InvestmentOverLimit.test_investment_income_disqualifies.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91031", "91032"]}}, "households":
       {"household": {"members": ["91031", "91032"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91031", "91032"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         "mo_wftc": {"2025": 0.0}}}, "families": {"family": {"members": ["91031", "91032"]}},
         "households": {"household": {"members": ["91031", "91032"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91031", "91032"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1366'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:35 GMT
+      - Fri, 21 Aug 2026 18:59:04 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-fe0468843d4048e5b08f8bf61c49db3a-b4aba4f9bba7fbfa-00
+      - 00-50d9725d71d32350176e8298d97e9ce9-2a47eaee01fe93d4-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - fe0468843d4048e5b08f8bf61c49db3a
+      - 50d9725d71d32350176e8298d97e9ce9;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 36ca2597-6232-40dd-b30e-c3e4d26b457f
+      - 9ba6ff27-f3e7-475d-b8e7-13f4a6caea13
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario04NoRemainingLiability.test_zero_liability_means_not_eligible.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario04NoRemainingLiability.test_zero_liability_means_not_eligible.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91041", "91042"]}}, "households":
       {"household": {"members": ["91041", "91042"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91041", "91042"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,7 +49,7 @@ interactions:
         {"2025": 0.0}}}, "families": {"family": {"members": ["91041", "91042"]}},
         "households": {"household": {"members": ["91041", "91042"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91041", "91042"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:41 GMT
+      - Fri, 21 Aug 2026 18:59:07 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-4f22130cc4ff0c2bd4596ba396c674f3-b53cf44f27aac7e1-00
+      - 00-49ab95cbdcd706ddf257d219bc1fe74b-cc36a81ad1c040d2-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 4f22130cc4ff0c2bd4596ba396c674f3
+      - 49ab95cbdcd706ddf257d219bc1fe74b
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 66985f2e-7d34-4701-82bc-e5785ff7990a
+      - 5f0f88c4-1435-4e32-bfc0-81b5f557224a
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario05CappedCredit.test_liability_cap_binds.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario05CappedCredit.test_liability_cap_binds.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91051", "91052"]}}, "households":
       {"household": {"members": ["91051", "91052"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91051", "91052"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         {"2025": 292.883}}}, "families": {"family": {"members": ["91051", "91052"]}},
         "households": {"household": {"members": ["91051", "91052"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91051", "91052"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1367'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:44 GMT
+      - Fri, 21 Aug 2026 18:59:09 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-afd6936f58a90453add8a2a8510b5684-592728fd159de42a-01
+      - 00-68440bf3f7e0ceae529af598ceded1bf-d4b07933146cdf7f-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - afd6936f58a90453add8a2a8510b5684;o=1
+      - 68440bf3f7e0ceae529af598ceded1bf
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 733921d1-faa3-44c2-87e9-90a31cebd0a1
+      - 34e7ca33-edcf-4564-bcdb-ebfef222608e
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario06FederalEitcPhasedOut.test_no_federal_eitc_means_not_eligible.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario06FederalEitcPhasedOut.test_no_federal_eitc_means_not_eligible.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91061", "91062"]}}, "households":
       {"household": {"members": ["91061", "91062"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91061", "91062"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         {"2025": 0.0}}}, "families": {"family": {"members": ["91061", "91062"]}},
         "households": {"household": {"members": ["91061", "91062"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91061", "91062"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1363'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:46 GMT
+      - Fri, 21 Aug 2026 18:59:11 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-7e24d9983db0d865dd8bf15e68c01eda-39c60638e643d0e4-00
+      - 00-dc2683a91ba14e6356556eee7b7f5bc9-22311ec52c7e2aaf-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 7e24d9983db0d865dd8bf15e68c01eda
+      - dc2683a91ba14e6356556eee7b7f5bc9
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 37c2a30a-4db6-40fb-b959-2757ac854a2f
+      - 83910e6f-3cd6-404e-9a12-eacc6e9b50e2
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario07InvestmentAtThreshold.test_exactly_at_threshold_stays_eligible.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario07InvestmentAtThreshold.test_exactly_at_threshold_stays_eligible.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91071", "91072"]}}, "households":
       {"household": {"members": ["91071", "91072"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91071", "91072"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,7 +49,7 @@ interactions:
         "mo_wftc": {"2025": 192.84204}}}, "families": {"family": {"members": ["91071",
         "91072"]}}, "households": {"household": {"members": ["91071", "91072"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91071", "91072"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:48 GMT
+      - Fri, 21 Aug 2026 18:59:13 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-6faf952603ed8d105f156cdf658bc519-cc92b260fde47e3d-00
+      - 00-45a81889a720d9da8fc6aae1c05e434a-d25b748a7131e854-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 6faf952603ed8d105f156cdf658bc519
+      - 45a81889a720d9da8fc6aae1c05e434a
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - c19868af-9bcf-433d-a7cc-bbed33a91731
+      - 214d0bed-42d4-498e-9f86-d4bedbe2c774
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario08InvestmentOneOverThreshold.test_one_dollar_over_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario08InvestmentOneOverThreshold.test_one_dollar_over_disqualifies.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2025": null}}}, "families": {"family": {"members": ["91081", "91082"]}}, "households":
       {"household": {"members": ["91081", "91082"], "state_code": {"2025": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91081", "91082"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,7 +49,7 @@ interactions:
         "mo_wftc": {"2025": 0.0}}}, "families": {"family": {"members": ["91081", "91082"]}},
         "households": {"household": {"members": ["91081", "91082"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91081", "91082"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:50 GMT
+      - Fri, 21 Aug 2026 18:59:15 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-9a3c98935def79fab4184eb25a585e92-e7873ff44ef88502-00
+      - 00-c047c251360db331d5b0cbab589c013f-3e25495ff784154c-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 9a3c98935def79fab4184eb25a585e92
+      - c047c251360db331d5b0cbab589c013f;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 2f76145c-c833-47b1-a8c1-4121db18556e
+      - f6b69c81-5518-4399-ae61-90244833ddb5
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario09InvestmentAtThreshold2023.test_exactly_at_2023_threshold_stays_eligible.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario09InvestmentAtThreshold2023.test_exactly_at_2023_threshold_stays_eligible.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2023": null}}}, "families": {"family": {"members": ["91091", "91092"]}}, "households":
       {"household": {"members": ["91091", "91092"], "state_code": {"2023": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91091", "91092"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,7 +49,7 @@ interactions:
         "mo_wftc": {"2023": 40.109814}}}, "families": {"family": {"members": ["91091",
         "91092"]}}, "households": {"household": {"members": ["91091", "91092"], "state_code":
         {"2023": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91091", "91092"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:52 GMT
+      - Fri, 21 Aug 2026 18:59:17 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-a2d1f7120850998c2a6dfccb0d15818d-6e51ec26b795f678-00
+      - 00-964633ec473bf51ba92b4f70c811db4b-b9051da76fd9103f-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - a2d1f7120850998c2a6dfccb0d15818d
+      - 964633ec473bf51ba92b4f70c811db4b
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 370e6698-d127-4641-8397-142e9442f7e9
+      - e917317b-2a68-4f74-adbc-1c076071a01a
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario10InvestmentAtThreshold2024.test_exactly_at_2024_threshold_stays_eligible.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario10InvestmentAtThreshold2024.test_exactly_at_2024_threshold_stays_eligible.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2024": null}}}, "families": {"family": {"members": ["91101", "91102"]}}, "households":
       {"household": {"members": ["91101", "91102"], "state_code": {"2024": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91101", "91102"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         "mo_wftc": {"2024": 152.90323}}}, "families": {"family": {"members": ["91101",
         "91102"]}}, "households": {"household": {"members": ["91101", "91102"], "state_code":
         {"2024": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91101", "91102"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1371'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:54 GMT
+      - Fri, 21 Aug 2026 18:59:19 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-1475a04fb3faab3e4ab9d434eee9a04c-f43c326822e15da7-01
+      - 00-1885872274b104ef617e97e510dc14ac-a097eb5abd8fe86d-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 1475a04fb3faab3e4ab9d434eee9a04c;o=1
+      - 1885872274b104ef617e97e510dc14ac
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - bf2a7f32-4cd4-4f5d-8ad1-4cb158ac7aeb
+      - 4d2170ff-1882-463f-bc02-d40b4998ad9e
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario11InvestmentOneOverThreshold2024.test_one_dollar_over_2024_threshold_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario11InvestmentOneOverThreshold2024.test_one_dollar_over_2024_threshold_disqualifies.yaml
@@ -15,7 +15,7 @@ interactions:
       {"2024": null}}}, "families": {"family": {"members": ["91111", "91112"]}}, "households":
       {"household": {"members": ["91111", "91112"], "state_code": {"2024": "MO"}}},
       "spm_units": {"spm_unit": {"members": ["91111", "91112"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         "mo_wftc": {"2024": 0.0}}}, "families": {"family": {"members": ["91111", "91112"]}},
         "households": {"household": {"members": ["91111", "91112"], "state_code":
         {"2024": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91111", "91112"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      - h3=":443"; ma=2592000
       Content-Length:
       - '1365'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:56 GMT
+      - Fri, 21 Aug 2026 18:59:21 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-aec9c71651bbd4df6ca51ec71ca300ac-e9e675ffee9ac8f5-00
+      - 00-7c98a3d624b250d66fd4114b60c8b093-543937f527181f37-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - aec9c71651bbd4df6ca51ec71ca300ac
+      - 7c98a3d624b250d66fd4114b60c8b093
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 935a8f51-de35-4d98-9069-4a7eb4a448cd
+      - 6c8593a7-e2e1-4610-9ef5-b6a361a7b4b6
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario12SingleChildlessWorker.test_childless_filer_eligible_for_small_credit.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario12SingleChildlessWorker.test_childless_filer_eligible_for_small_credit.yaml
@@ -9,7 +9,7 @@ interactions:
       {"members": ["91121"], "mo_wftc": {"2025": null}}}, "families": {"family": {"members":
       ["91121"]}}, "households": {"household": {"members": ["91121"], "state_code":
       {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91121"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -37,7 +37,7 @@ interactions:
         ["91121"], "mo_wftc": {"2025": 16.886}}}, "families": {"family": {"members":
         ["91121"]}}, "households": {"household": {"members": ["91121"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91121"]}}, "marital_units":
-        {}}, "policyengine_bundle": {"model_version": "1.786.5", "data_version": null,
+        {}}, "policyengine_bundle": {"model_version": "1.794.2", "data_version": null,
         "dataset": null}}'
     headers:
       Alt-Svc:
@@ -49,15 +49,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:12:58 GMT
+      - Fri, 21 Aug 2026 18:59:23 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-12924353e9d5f9e13b0cd64e9bd19591-51a750e8c98ed394-00
+      - 00-380da2b2f9e4d6d5863f0a362ea52d29-ecd154e9711f3ab7-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 12924353e9d5f9e13b0cd64e9bd19591
+      - 380da2b2f9e4d6d5863f0a362ea52d29
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -65,7 +65,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 199c1724-9a5e-4831-bef2-f318b586febb
+      - ae005b06-a4b8-4dc1-9f82-520781a52a90
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario13MarriedFilingCombined.test_joint_household_eligible.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario13MarriedFilingCombined.test_joint_household_eligible.yaml
@@ -21,7 +21,7 @@ interactions:
       {"members": ["91131", "91132", "91133"]}}, "households": {"household": {"members":
       ["91131", "91132", "91133"], "state_code": {"2025": "MO"}}}, "spm_units": {"spm_unit":
       {"members": ["91131", "91132", "91133"]}}, "marital_units": {"91131-91132":
-      {"members": ["91131", "91132"]}}}, "version": "1.786.5"}'
+      {"members": ["91131", "91132"]}}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -62,7 +62,7 @@ interactions:
         {"household": {"members": ["91131", "91132", "91133"], "state_code": {"2025":
         "MO"}}}, "spm_units": {"spm_unit": {"members": ["91131", "91132", "91133"]}},
         "marital_units": {"91131-91132": {"members": ["91131", "91132"]}}}, "policyengine_bundle":
-        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
+        {"model_version": "1.794.2", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -73,15 +73,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:13:01 GMT
+      - Fri, 21 Aug 2026 18:59:25 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-0090012666f607f54126603bf34e66e1-6eec875e09dfaf0c-00
+      - 00-c1bfec56f9a31dc5e3d09cc12e508162-246318a414b44c38-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 0090012666f607f54126603bf34e66e1
+      - c1bfec56f9a31dc5e3d09cc12e508162
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -89,7 +89,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 4b1e1425-27a4-4d14-8613-899662abcf73
+      - 286510ad-1c3f-4578-8b9d-4578248c97c4
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario14PropertyTaxCreditAbsorbsLiability.test_ptc_absorbs_liability.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario14PropertyTaxCreditAbsorbsLiability.test_ptc_absorbs_liability.yaml
@@ -15,7 +15,7 @@ interactions:
       "mo_wftc": {"2025": null}}}, "families": {"family": {"members": ["91141", "91142"]}},
       "households": {"household": {"members": ["91141", "91142"], "state_code": {"2025":
       "MO"}}}, "spm_units": {"spm_unit": {"members": ["91141", "91142"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         {"2025": 0.0}}}, "families": {"family": {"members": ["91141", "91142"]}},
         "households": {"household": {"members": ["91141", "91142"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91141", "91142"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1366'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:13:07 GMT
+      - Fri, 21 Aug 2026 18:59:27 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-d8b283962ab767a31c63aecab4947981-d6222bdb5c65fe72-00
+      - 00-cb2424fd368843b5c9b91b48294a482a-ea04d001e9684336-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - d8b283962ab767a31c63aecab4947981
+      - cb2424fd368843b5c9b91b48294a482a;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - eb301e64-678c-4572-a85c-16a2e4ed3473
+      - d8a74d89-b240-4dee-aa8f-e83fc10815f5
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario15RentalCountsTowardInvestmentGate.test_rental_income_disqualifies.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario15RentalCountsTowardInvestmentGate.test_rental_income_disqualifies.yaml
@@ -15,7 +15,7 @@ interactions:
       ["91151", "91152"], "mo_wftc": {"2025": null}}}, "families": {"family": {"members":
       ["91151", "91152"]}}, "households": {"household": {"members": ["91151", "91152"],
       "state_code": {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91151",
-      "91152"]}}, "marital_units": {}}, "version": "1.786.5"}'
+      "91152"]}}, "marital_units": {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,11 +49,11 @@ interactions:
         {"2025": 0.0}}}, "families": {"family": {"members": ["91151", "91152"]}},
         "households": {"household": {"members": ["91151", "91152"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91151", "91152"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '1366'
       access-control-allow-origin:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:13:09 GMT
+      - Fri, 21 Aug 2026 18:59:28 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-f7f2709f4813dbd0c71a2b9a7875e4ae-9b465c56e510c0b2-01
+      - 00-9cbb0e3ad3fa1deaec68c226e069857d-56284d5f3e491a0d-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - f7f2709f4813dbd0c71a2b9a7875e4ae;o=1
+      - 9cbb0e3ad3fa1deaec68c226e069857d
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - df6cd21e-2f43-487c-9e0b-75c1b0593073
+      - 13a9fdc3-9c82-4360-a032-478b426c8a9d
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario16PropertyTaxCreditPartiallyReducesLiability.test_positive_credit_survives_ptc.yaml
+++ b/programs/programs/white_labels/mo/wftc/tests/cassettes/TestScenario16PropertyTaxCreditPartiallyReducesLiability.test_positive_credit_survives_ptc.yaml
@@ -15,7 +15,7 @@ interactions:
       "mo_wftc": {"2025": null}}}, "families": {"family": {"members": ["91161", "91162"]}},
       "households": {"household": {"members": ["91161", "91162"], "state_code": {"2025":
       "MO"}}}, "spm_units": {"spm_unit": {"members": ["91161", "91162"]}}, "marital_units":
-      {}}, "version": "1.786.5"}'
+      {}}, "version": "1.794.2"}'
     headers:
       Accept:
       - '*/*'
@@ -49,7 +49,7 @@ interactions:
         {"2025": 14.985001}}}, "families": {"family": {"members": ["91161", "91162"]}},
         "households": {"household": {"members": ["91161", "91162"], "state_code":
         {"2025": "MO"}}}, "spm_units": {"spm_unit": {"members": ["91161", "91162"]}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.786.5",
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
@@ -61,15 +61,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 18 Aug 2026 20:13:12 GMT
+      - Fri, 21 Aug 2026 18:59:30 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-ca9716a72d312228f4b99c3465dca7df-cbe0b509e1dcf50e-00
+      - 00-3d07fde64ec9915be14c887b920808e5-8a47f2278d5d0f46-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - ca9716a72d312228f4b99c3465dca7df
+      - 3d07fde64ec9915be14c887b920808e5
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -77,7 +77,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - c8197490-0a7a-4e6d-aa0e-a9198aeb6c81
+      - b3f9daaa-5bd4-45c9-866a-56236d73ac08
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/white_labels/mo/wftc/tests/test_mo_wftc.py
+++ b/programs/programs/white_labels/mo/wftc/tests/test_mo_wftc.py
@@ -23,7 +23,7 @@ from screener.models import Expense
 from programs.programs.white_labels.mo.wftc.calculator import MoWftc
 from programs.framework.pe_dependencies import member
 
-PE_VERSION = "1.786.5"
+PE_VERSION = "1.794.2"
 
 
 class MoWftcScenarioTestCase(PeIntegrationTestCase):


### PR DESCRIPTION
## Why

PolicyEngine retired package version `1.786.5`. Any request pinned to it now fails:

```
422 unsupported_version
"No active failover channel serves `us` package version `1.786.5`"
available_versions: {current: 1.794.2, frontier: 1.815.1}
```

MO WFTC and MO PTS were the only two programs pinned to `1.786.5`. Their cassettes still replayed fine (replay never calls PE), so the suite was green — but the pin was dead, and re-recording any scenario was impossible. Found while QAing MFB-1219 / MFB-1220 on staging.

## What changed

- `PE_VERSION` `1.786.5` → `1.794.2` in both test files
- All 38 cassettes re-recorded against 1.794.2 (16 WFTC, 22 PTS)

**No expected value changed.** The model version moves; the computed credits do not. Every assertion is untouched, so the only Python diff is the two pins (2 insertions, 2 deletions) and the rest is re-recorded fixtures — 249 insertions against 249 deletions.

## Verification

- `69 passed` — WFTC + PTS, replay only, no network
- Every cassette pins `1.794.2`; no `1.786.5` remains
- `black --check` clean
- Single commit off `main`; every changed path is under `white_labels/mo/{wftc,pts}`

## Notes for the reviewer

- Re-recording needs `PE_RECORD=1` (fetches a live bearer token; the auth0 host is in VCR's `ignore_hosts` so no token is written to a cassette). Without it the harness seeds a placeholder and a record attempt fails with `401 invalid_token`.
- `1.794.2` is PE's `current`, not `frontier` (`1.815.1`). Chosen so tests track what deployed environments actually resolve to.
- The four WFTC scenarios deliberately pinned to TY2023/TY2024 keep those years — only the model version moved.

## Follow-up (not in this PR)

WFTC's default `tax_year` is still `"2025"` while PTS uses `2026`. Now that the cassettes are current, that bump is a small separate change — deliberately kept out of here so a year-driven value change can't be confused with a version-driven one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
