### PR TITLE
MFB-1694: TX and WA TANF adopt tanf_income

### DIFF
--- a/programs/programs/cross_white_label/tanf/tx.py
+++ b/programs/programs/cross_white_label/tanf/tx.py
@@ -12,7 +12,7 @@ class TxTanf(Tanf):
     and benefit values. Inherits from federal TANF calculator and adds TX state
     code dependency and person-level income inputs.
 
-    Income is provided at the person level (via irs_gross_income) so PolicyEngine
+    Income is provided at the person level (via tanf_income) so PolicyEngine
     can compute tx_tanf_countable_earned_income correctly — applying the $120 work
     expense deduction and 1/3 earned income disregard per § 372.409. Passing gross
     income directly as tx_tanf_countable_earned_income (the previous approach) bypassed
@@ -27,7 +27,7 @@ class TxTanf(Tanf):
         *Tanf.pe_inputs,
         dependency.household.TxStateCodeDependency,
         dependency.member.TaxUnitDependentDependency,
-        *dependency.irs_gross_income,
+        *dependency.tanf_income,
     ]
 
     pe_outputs = [dependency.spm.TxTanf]

--- a/programs/programs/cross_white_label/tanf/wa.py
+++ b/programs/programs/cross_white_label/tanf/wa.py
@@ -36,8 +36,7 @@ class WaTanf(Tanf):
         dependency.member.PregnancyDependency,
         dependency.member.EmploymentIncomeBeforeLsrDependency,
         dependency.member.SelfEmploymentIncomeBeforeLsrDependency,
-        dependency.member.SocialSecurityIncomeDependency,
-        dependency.member.UnemploymentIncomeDependency,
+        *dependency.tanf_income,
         dependency.spm.CashAssetsDependency,
         dependency.spm.WaShowAllCashAssistanceProgramsDependency,
     ]


### PR DESCRIPTION
## Context & Motivation

- Linear: [MFB-1694](https://linear.app/myfriendben/issue/MFB-1694/ks-and-tx-tanf-drop-child-support-and-alimony-from-every-income-gate)

Finishes the gap [#1713](https://github.com/MyFriendBen/benefits-api/pull/1713) fixed for MO and KS. Both TX and WA read PolicyEngine's shared federal unearned-income source list, so both were dropping child support, alimony and gifts from every TANF income gate:

- `tx_tanf_gross_unearned_income` reads it directly
- `wa_tanf_countable_income` reads it through its `adds`

`irs_gross_income` is the *taxable* contract, and none of those three sources are taxable, so it correctly omits all three. TANF counts them (`gov.hhs.tanf.cash.income.sources.unearned`), which is what `tanf_income` supplies.

**WA was not named in the ticket.** It sends its income streams individually rather than via `irs_gross_income`, so it did not appear in the original audit; checking what its PE variable actually *reads* surfaced the same gap. The ticket title is being corrected.

## Changes Made

- `cross_white_label/tanf/tx.py` — `irs_gross_income` → `tanf_income`
- `cross_white_label/tanf/wa.py` — same, and drops its own `SocialSecurityIncomeDependency` / `UnemploymentIncomeDependency`, which `tanf_income` supplies. Its `before_lsr` earned inputs stay, since those feed WA's own disregard sequence.

**CO, IL and NC need nothing.** They send pre-aggregated state countable-income variables computed from `calc_gross_income(["unearned"])`, which already covers all three sources — verified.

## Testing

```bash
VCR_MODE=none venv/bin/pytest programs/programs/cross_white_label/tanf/ programs/framework/ -q
```

**475 passed, 5 skipped.** No duplicate fields in any TANF calculator's payload after the change (checked all seven).

## Deployment

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Post-deployment scripts needed: none

## Notes for Reviewers

**This reduces grants** for TX and WA households reporting child support, alimony or gifts — the correct direction, since that income should count.

Neither state has a PE integration suite, so only the wiring assertions cover this; there are no cassettes to re-record and nothing that would catch a value regression. Adding scenarios for both is worth doing, and is called out in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Texas TANF calculations now use reported TANF income for person-level income inputs.
  - Washington TANF calculations now include all applicable TANF income sources automatically.
  - Updated TANF documentation and required inputs to reflect these income calculation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->