### PR TITLE
Add MO HealthNet Medicaid (mo)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_medicaid_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_medicaid_initial_config.json
@@ -1,0 +1,110 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_healthcare",
+    "name": "Health Care",
+    "icon": "health_care"
+  },
+  "program": {
+    "name_abbreviated": "mo_medicaid",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "refugee",
+      "gc_5plus",
+      "otherWithWorkPermission"
+    ],
+    "name": "MO HealthNet (Medicaid)",
+    "description": "MO HealthNet is Missouri's Medicaid program. It helps pay for things like doctor visits, hospital stays, and prescriptions. It also covers dental, vision, mental health care, nursing home care, and personal care services. There is little or no cost to you.\n\nMost people pick a MO HealthNet Managed Care health plan. Then you use your member ID card at the doctor, pharmacy, and other providers. You can manage your coverage and find a provider through My MO Health Portal.\n\nMissouri covers adults ages 19 through 64 with income up to 138% of the federal poverty level. Children, pregnant people, parents and caretakers, and people who are 65 or older, blind, or have a disability can qualify at other income levels. If you are 65 or older, blind, or have a disability, there may be a limit on your savings and property. There is no savings limit for children and families. If your income is above the limit but you have high medical bills, you may still qualify through a \"spend-down.\" There are other ways to qualify too. It is worth applying if you are not sure.\n\nTo apply, click Apply Now to start your application online. You can also apply by phone by calling 1-855-373-9994.",
+    "description_short": "Free or low-cost health coverage for eligible Missourians",
+    "learn_more_link": "https://dss.mo.gov/healthcare",
+    "apply_button_link": "https://dss.mo.gov/healthcare/apply",
+    "apply_button_description": "",
+    "estimated_application_time": "15 - 30 minutes",
+    "estimated_delivery_time": "45 - 90 days",
+    "estimated_value": "",
+    "value_format": "estimated_annual",
+    "website_description": "Free or low-cost health coverage for eligible Missourians",
+    "base_program": "medicaid",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false,
+    "active": true
+  },
+  "documents": [
+    {
+      "external_name": "mo_id_proof",
+      "text": "Proof of identity (ex: driver's license, state ID, passport)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ssn",
+      "text": "Social Security numbers for each person applying, if they have one",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_us_status",
+      "text": "Citizenship or immigration documents or numbers for each person applying, if needed",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_residency_proof",
+      "text": "Proof of Missouri residency, if requested (e.g., utility bill, lease agreement)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_income_proof",
+      "text": "Income records (ex: pay stubs, tax forms, or benefit letters)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_unearned_income",
+      "text": "Proof of unearned income, if requested (ex: child support, Social Security, unemployment)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_health_insurance",
+      "text": "Current health insurance information, if applicable",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_disability_proof",
+      "text": "Proof of disability, if applicable (ex: Social Security or VA letter)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_assets",
+      "text": "Proof of resources (ex: bank statements, investment accounts). Do not include your home, one vehicle, household goods, or a burial fund",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "mo_healthnet_participant_services",
+      "name": "MO HealthNet Participant Services",
+      "email": "Ask.MHD@dss.mo.gov",
+      "phone_number": "+18003922161",
+      "description": "The MO HealthNet Division's help line for people who have or are applying for MO HealthNet. Staff can explain what your coverage includes, help you find a doctor, dentist, or pharmacy that accepts MO HealthNet, answer questions about managed care health plans, and help with billing or coverage problems.",
+      "assistance_link": "https://dss.mo.gov/mhd"
+    },
+    {
+      "external_name": "mo_fsd_information_center",
+      "name": "Family Support Division Information Center",
+      "email": "",
+      "phone_number": "+18553734636",
+      "description": "The Family Support Division decides who qualifies for MO HealthNet. Call this line to apply by phone, check the status of an application, report a change, or ask what documents you still need to send in. Staff can also help with annual renewals.",
+      "assistance_link": "https://dss.mo.gov/healthcare/apply"
+    }
+  ]
+}

--- a/programs/programs/cross_white_label/medicaid/base.py
+++ b/programs/programs/cross_white_label/medicaid/base.py
@@ -71,4 +71,10 @@ class Medicaid(PolicyEngineMembersCalculator, abstract=True):
 
         medicaid_category = self.get_member_dependency_value(dependency.member.MedicaidCategory, member.id)
 
-        return self.medicaid_categories[medicaid_category] * 12
+        # .get rather than [] because medicaid_categories covers only the categories we price.
+        # PolicyEngine's enum is larger and grows: MEDICALLY_NEEDY, WORKING_DISABLED_BUY_IN,
+        # SECTION_1115_MEC_ADULT and SENIOR_OR_DISABLED have no key here, and a state whose
+        # covered-category list includes one of them would raise KeyError out of member_value -
+        # which fails the whole eligibility request, not just this program. Falling back to 0
+        # drops the program from results instead, the same as any other ineligible answer.
+        return self.medicaid_categories.get(medicaid_category, 0) * 12

--- a/programs/programs/cross_white_label/medicaid/mo.py
+++ b/programs/programs/cross_white_label/medicaid/mo.py
@@ -36,6 +36,14 @@ class MoHealthNet(Medicaid):
 
     pe_inputs = [
         *Medicaid.pe_inputs,
+        # PolicyEngine needs these to classify a member as SSI-disabled or blind, which is what
+        # gates the aged/disabled (MHABD) pathway. Declared here rather than relied on from a
+        # sibling program: PolicyEngine inputs are pooled per request, so while mo_ssi happens to
+        # send both today, a request without it would resolve
+        # is_optional_senior_or_disabled_for_medicaid to False and return $0 for a disabled
+        # applicant. Mirrors KsKanCare. Both only ever widen eligibility - they feed an OR.
+        dependency.member.MeetsSsiDisabilityCriteriaDependency,
+        dependency.member.IsBlindDependency,
         dependency.household.MoStateCodeDependency,
     ]
 

--- a/programs/programs/cross_white_label/medicaid/mo.py
+++ b/programs/programs/cross_white_label/medicaid/mo.py
@@ -1,0 +1,60 @@
+"""MO Medicaid."""
+
+from programs.programs.cross_white_label.medicaid.base import Medicaid
+import programs.framework.pe_dependencies as dependency
+
+
+class MoHealthNet(Medicaid):
+    """MO HealthNet is Missouri's Medicaid program (subclass of the federal ``medicaid`` calculator).
+
+    Missouri adopted ACA adult expansion, so PE covers adults 19-64 up to 138% FPL
+    (``adult/income_limit.yaml[MO] = 2021-10-01: 1.38``, current). Children, pregnant
+    people, parents/caretakers, and the aged/blind/disabled route through their own
+    PE categories.
+
+    Known PE divergences from Missouri's current FSD standards, all upstream parameter
+    issues rather than wiring gaps here. They affect band edges and specific
+    sub-populations, not the mainline MAGI pathways:
+
+    - The children's ceiling is frozen at 155% FPL; Missouri's current standard is 153%
+      (148% nominal + 5% MAGI disregard), so PE reports eligible slightly above the line.
+    - The parent/caretaker limit is stored as a percent of FPL (frozen at 23%), but
+      Missouri's standard is a flat 1996-AFDC dollar figure that isn't FPL-indexed.
+    - The pregnant/infant limit is frozen at 201%; the current MPW line is 196%.
+    - There is no blind-specific MHABD standard - one flat ~85% FPG rate covers both
+      blind and non-blind applicants.
+    - Adult-expansion eligibility carries no Medicare-enrollment or SSI-receipt
+      exclusion, and no Substantial Gainful Activity test gates the disability
+      pathways.
+
+    Fixes for these have been requested upstream. They are deliberately not patched
+    here: this calculator stays a wiring-only PE subclass, so PolicyEngine remains the
+    single source of the eligibility decision.
+    """
+
+    program_code = "mo_medicaid"
+
+    pe_inputs = [
+        *Medicaid.pe_inputs,
+        dependency.household.MoStateCodeDependency,
+    ]
+
+    # KFF Medicaid Spending per Full-Benefit Enrollee by Enrollment Group, MO, 2023,
+    # converted to monthly (the annual figure returned = value * 12):
+    #   children (18 and under) -> $4,576/yr  -> $381/mo
+    #   adults (19-64)          -> $6,379/yr  -> $532/mo
+    #   seniors (65+)           -> $21,857/yr -> $1,821/mo
+    #   people with disabilities -> $30,410/yr -> $2,534/mo
+    medicaid_categories = {
+        "NONE": 0,
+        "ADULT": 532,
+        "INFANT": 381,
+        "YOUNG_CHILD": 381,
+        "OLDER_CHILD": 381,
+        "PREGNANT": 532,
+        "YOUNG_ADULT": 532,
+        "PARENT": 532,
+        "SSI_RECIPIENT": 2_534,
+        "AGED": 1_821,
+        "DISABLED": 2_534,
+    }

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_expansion_adult_under_income_limit_is_eligible.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_expansion_adult_under_income_limit_is_eligible.yaml
@@ -7,6 +7,7 @@ interactions:
       {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
       {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null},
       "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+      "meets_ssi_disability_criteria": {"2026": null}, "is_blind": {"2026": false},
       "medicaid": {"2026": null}, "medicaid_category": {"2026": null}, "is_optional_senior_or_disabled_for_medicaid":
       {"2026": null}}}, "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families":
       {"family": {"members": ["1"]}}, "households": {"household": {"members": ["1"],
@@ -22,7 +23,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1138'
+      - '1216'
       Content-Type:
       - application/json
       User-Agent:
@@ -38,6 +39,7 @@ interactions:
         {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
         {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
         {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": false}, "is_blind":
         {"2026": false}, "medicaid": {"2026": 12559.627}, "medicaid_category": {"2026":
         "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}}},
         "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family":
@@ -51,21 +53,21 @@ interactions:
       Alt-Svc:
       - h3=":443"; ma=2592000
       Content-Length:
-      - '1246'
+      - '1325'
       access-control-allow-origin:
       - '*'
       content-type:
       - application/json
       date:
-      - Mon, 24 Aug 2026 20:24:10 GMT
+      - Tue, 25 Aug 2026 20:11:29 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-d0b3c1f25d9ffe1816ef3bdbe9a37c6b-6ccf0a1d0d1fc2fc-01
+      - 00-9321e0b7f7eea66423e243f434c1baf0-97cc7ee87dc99e0d-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - d0b3c1f25d9ffe1816ef3bdbe9a37c6b;o=1
+      - 9321e0b7f7eea66423e243f434c1baf0
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -73,7 +75,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 6fbc1513-dbac-439c-9371-a02a708837b9
+      - aa63fab8-c2c1-4e87-8568-59a5f1861c0e
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_expansion_adult_under_income_limit_is_eligible.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_expansion_adult_under_income_limit_is_eligible.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"age": {"2026": 34}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": null},
+      "employment_income": {"2026": 14400}, "self_employment_income": {"2026": 0},
+      "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null},
+      "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+      "medicaid": {"2026": null}, "medicaid_category": {"2026": null}, "is_optional_senior_or_disabled_for_medicaid":
+      {"2026": null}}}, "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families":
+      {"family": {"members": ["1"]}}, "households": {"household": {"members": ["1"],
+      "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"],
+      "tanf": {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+      {"2026": false}}}, "marital_units": {}}, "version": "1.794.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1138'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
+        {"2026": 34}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": false}, "employment_income": {"2026": 14400},
+        "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "medicaid": {"2026": 12559.627}, "medicaid_category": {"2026":
+        "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}}},
+        "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family":
+        {"members": ["1"]}}, "households": {"household": {"members": ["1"], "state_code":
+        {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026":
+        0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026":
+        false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026":
+        false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version": "1.794.2",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1246'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Mon, 24 Aug 2026 20:24:10 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-d0b3c1f25d9ffe1816ef3bdbe9a37c6b-6ccf0a1d0d1fc2fc-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - d0b3c1f25d9ffe1816ef3bdbe9a37c6b;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 6fbc1513-dbac-439c-9371-a02a708837b9
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/medicaid/tests/test_base.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_base.py
@@ -583,3 +583,51 @@ class TestMedicaidNoneCategory(TestCase):
         result = calculator.member_value(member)
 
         self.assertEqual(result, 0 * 12)
+
+
+class TestMedicaidUnknownCategory(TestCase):
+    """Tests for categories PolicyEngine can return that medicaid_categories does not price."""
+
+    def _create_calculator_with_mocks(self):
+        calculator = Medicaid(Mock(), Mock(), Mock())
+        calculator._sim = MagicMock()
+        calculator.get_member_variable = Mock()
+        calculator.get_member_dependency_value = Mock()
+        return calculator
+
+    def _create_member(self):
+        """A non-senior, non-disabled member, so member_value reaches the category lookup."""
+        member = Mock()
+        member.id = 1
+        member.age = 40
+        member.calc_age = Mock(return_value=40)
+        member.has_disability = Mock(return_value=False)
+        return member
+
+    def test_unpriced_category_returns_zero_instead_of_raising(self):
+        """An unrecognized category is worth 0, not a KeyError.
+
+        PolicyEngine's medicaid_category enum is larger than the set of categories we price
+        and it grows over time. A KeyError here propagates out of member_value and fails the
+        entire eligibility request rather than just this program, so an unknown category has
+        to degrade to "no value" the same way any other ineligible answer does.
+        """
+        calculator = self._create_calculator_with_mocks()
+        calculator.medicaid_categories = {"ADULT": 532}
+        calculator.get_member_variable.return_value = 12_559
+        calculator.get_member_dependency_value.return_value = "SECTION_1115_MEC_ADULT"
+
+        result = calculator.member_value(self._create_member())
+
+        self.assertEqual(result, 0)
+
+    def test_known_category_is_still_priced(self):
+        """The fallback doesn't swallow categories we do price."""
+        calculator = self._create_calculator_with_mocks()
+        calculator.medicaid_categories = {"ADULT": 532}
+        calculator.get_member_variable.return_value = 12_559
+        calculator.get_member_dependency_value.return_value = "ADULT"
+
+        result = calculator.member_value(self._create_member())
+
+        self.assertEqual(result, 532 * 12)

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo.py
@@ -3,6 +3,10 @@
 from django.test import TestCase
 
 from programs.framework.pe_dependencies.household import MoStateCodeDependency
+from programs.framework.pe_dependencies.member import (
+    IsBlindDependency,
+    MeetsSsiDisabilityCriteriaDependency,
+)
 from programs.programs.cross_white_label.medicaid.base import Medicaid
 from programs.programs.cross_white_label.medicaid.mo import MoHealthNet
 
@@ -31,9 +35,32 @@ class TestMoHealthNet(TestCase):
         for parent_input in Medicaid.pe_inputs:
             self.assertIn(parent_input, MoHealthNet.pe_inputs)
 
-    def test_pe_inputs_adds_exactly_one_input(self):
-        """Only MoStateCodeDependency is added beyond the parent inputs."""
-        self.assertEqual(len(MoHealthNet.pe_inputs), len(Medicaid.pe_inputs) + 1)
+    def test_pe_inputs_adds_only_state_code_and_disability_inputs(self):
+        """Exactly three inputs are added, all of them wiring rather than logic.
+
+        Pinning the count is what keeps this a wiring-only subclass: a new input here should be
+        a deliberate change with a reason, not something that accumulates.
+        """
+        added = [dep for dep in MoHealthNet.pe_inputs if dep not in Medicaid.pe_inputs]
+
+        self.assertEqual(
+            set(added),
+            {
+                MeetsSsiDisabilityCriteriaDependency,
+                IsBlindDependency,
+                MoStateCodeDependency,
+            },
+        )
+
+    def test_sends_ssi_disability_inputs_for_the_abd_pathway(self):
+        """MO declares the disability inputs instead of relying on mo_ssi to supply them.
+
+        PolicyEngine pools inputs per request, so a request without mo_ssi would resolve
+        is_optional_senior_or_disabled_for_medicaid to False and return $0 for a disabled
+        applicant who should qualify through MHABD.
+        """
+        self.assertIn(MeetsSsiDisabilityCriteriaDependency, MoHealthNet.pe_inputs)
+        self.assertIn(IsBlindDependency, MoHealthNet.pe_inputs)
 
     def test_pe_outputs_inherited_from_medicaid(self):
         """pe_outputs are unchanged from the federal parent."""

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo.py
@@ -1,0 +1,94 @@
+"""MO Medicaid tests."""
+
+from django.test import TestCase
+
+from programs.framework.pe_dependencies.household import MoStateCodeDependency
+from programs.programs.cross_white_label.medicaid.base import Medicaid
+from programs.programs.cross_white_label.medicaid.mo import MoHealthNet
+
+
+class TestMoHealthNet(TestCase):
+    """Tests for MoHealthNet calculator class wiring."""
+
+    def test_is_subclass_of_medicaid(self):
+        """MoHealthNet extends the federal Medicaid calculator."""
+        self.assertTrue(issubclass(MoHealthNet, Medicaid))
+
+    def test_program_code(self):
+        """program_code matches the Program row the config imports."""
+        self.assertEqual(MoHealthNet.program_code, "mo_medicaid")
+
+    def test_pe_name_is_medicaid(self):
+        """Eligibility comes from PolicyEngine's federal medicaid variable."""
+        self.assertEqual(MoHealthNet.pe_name, "medicaid")
+
+    def test_pe_inputs_includes_mo_state_code(self):
+        """MO state code is added on top of the federal Medicaid inputs."""
+        self.assertIn(MoStateCodeDependency, MoHealthNet.pe_inputs)
+
+    def test_pe_inputs_includes_all_parent_inputs(self):
+        """All federal Medicaid inputs flow through unchanged."""
+        for parent_input in Medicaid.pe_inputs:
+            self.assertIn(parent_input, MoHealthNet.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_one_input(self):
+        """Only MoStateCodeDependency is added beyond the parent inputs."""
+        self.assertEqual(len(MoHealthNet.pe_inputs), len(Medicaid.pe_inputs) + 1)
+
+    def test_pe_outputs_inherited_from_medicaid(self):
+        """pe_outputs are unchanged from the federal parent."""
+        self.assertEqual(MoHealthNet.pe_outputs, Medicaid.pe_outputs)
+
+    def test_does_not_override_member_value(self):
+        """MO adds no eligibility or value logic of its own.
+
+        MO HealthNet is a wiring-only PolicyEngine subclass: PolicyEngine stays the single
+        source of both the eligibility decision and the category. Overriding member_value
+        here would reintroduce the hybrid shape (a state gate or dollar figure decided in
+        our code) that the known PE parameter divergences are being fixed upstream instead.
+        """
+        self.assertIs(MoHealthNet.member_value, Medicaid.member_value)
+
+    def test_medicaid_categories_has_all_keys(self):
+        """All standard Medicaid category keys are present."""
+        expected_keys = {
+            "NONE",
+            "ADULT",
+            "INFANT",
+            "YOUNG_CHILD",
+            "OLDER_CHILD",
+            "PREGNANT",
+            "YOUNG_ADULT",
+            "PARENT",
+            "SSI_RECIPIENT",
+            "AGED",
+            "DISABLED",
+        }
+        self.assertEqual(set(MoHealthNet.medicaid_categories.keys()), expected_keys)
+
+    def test_medicaid_categories_are_kff_monthly_figures(self):
+        """Category values are the KFF 2023 MO per-full-benefit-enrollee figures, monthly.
+
+        Grouped the way KFF reports them: one rate for the MAGI adult categories, one for
+        children, and the higher aged and disabled rates.
+        """
+        cats = MoHealthNet.medicaid_categories
+
+        self.assertEqual(cats["NONE"], 0)
+        for adult_category in ("ADULT", "YOUNG_ADULT", "PARENT", "PREGNANT"):
+            self.assertEqual(cats[adult_category], 532)
+        for child_category in ("INFANT", "YOUNG_CHILD", "OLDER_CHILD"):
+            self.assertEqual(cats[child_category], 381)
+        self.assertEqual(cats["AGED"], 1_821)
+        self.assertEqual(cats["DISABLED"], 2_534)
+        self.assertEqual(cats["SSI_RECIPIENT"], cats["DISABLED"])
+
+    def test_aged_min_age_inherited(self):
+        """MO uses the federal 65+ cutoff for the aged pathway."""
+        self.assertEqual(MoHealthNet.aged_min_age, 65)
+
+    def test_registered_with_policyengine_registry(self):
+        """The calculator is discovered by program_code, so the Program row resolves to it."""
+        from integrations.clients.policyengine.registry import all_calculators
+
+        self.assertIs(all_calculators["mo_medicaid"], MoHealthNet)

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
@@ -1,0 +1,62 @@
+"""
+Smoke test for MO Medicaid — proves Missouri's ``medicaid`` pathway resolves end to end.
+
+MO HealthNet is a Fed-tier passthrough: ``MoHealthNet`` adds only Missouri's state code to
+the federal ``medicaid`` calculator, so there is no ``spec.md`` and no per-scenario suite
+here. The federal math is already covered by the other states' medicaid tests; re-testing
+it per state would only duplicate them.
+
+What this does pin is the one thing that is Missouri-specific and could silently break: that
+Missouri is read as an ACA expansion state, so a childless adult under 138% FPL comes back
+eligible in the ``ADULT`` category rather than $0. That is the distinction between MO and a
+non-expansion state like Kansas, and it is the whole reason the MO state code is wired in.
+
+The value asserted is the KFF per-enrollee ``ADULT`` rate × 12, so this also catches a
+category the calculator maps to the wrong rate.
+"""
+
+import pytest
+
+from programs.programs.cross_white_label.medicaid.mo import MoHealthNet
+from programs.programs.testing_fixtures.pe_integration import (
+    PeIntegrationTestCase,
+    add_income,
+    add_member,
+    calc_pe_program,
+    make_program,
+    make_screen,
+    screener_value,
+)
+
+PE_VERSION = "1.794.2"
+YEAR = "2026"
+
+
+@pytest.mark.integration
+class TestMoHealthNetSmoke(PeIntegrationTestCase):
+    """Cole County, ZIP 65101 — the same household shape MO PTS uses."""
+
+    pe_version = PE_VERSION
+
+    def test_expansion_adult_under_income_limit_is_eligible(self):
+        """Childless adult at $1,200/month (~92% FPL) → eligible via ACA expansion.
+
+        Missouri's adult limit is 138% FPL, so this household sits well inside it. A
+        non-expansion state would return $0 for the same household.
+        """
+        screen = make_screen(
+            screen_id=1,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=1,
+            zipcode="65101",
+            county="Cole County",
+        )
+        adult = add_member(screen, member_id=1, relationship="headOfHousehold", age=34)
+        add_income(adult, amount=1_200)
+        program = make_program("mo", "mo_medicaid", year=YEAR)
+
+        eligibility = calc_pe_program(screen, MoHealthNet, program)
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(screener_value(eligibility), 6_384)


### PR DESCRIPTION
## Context & Motivation

Missouri needs a Medicaid program for the MO launch. MO HealthNet is the last of the core health-coverage programs missing from the `mo` white label.

- Linear ticket: [MFB-1215 — + Program: MO HealthNet (Medicaid)](https://linear.app/myfriendben/issue/MFB-1215/program-mo-healthnet-medicaid)
- Discovery sub-issue: [MFB-1261](https://linear.app/myfriendben/issue/MFB-1261/discovery-mo-mo-healthnet-medicaid)

Tier is **Fed (elig varies)**, engine **PE**. Missouri adopted ACA adult expansion, so PolicyEngine's federal `medicaid` variable already covers the mainline MAGI pathways; this PR wires Missouri into it rather than reimplementing any of it.

Discovery surfaced seven upstream PolicyEngine parameter/logic gaps for MO and proposed a design in which MFB owned its own logic for each (MHDC parental-income deeming, SGA, the blind MHABD standard, the children's/MHF parameter shapes, relationship qualification, and spend-down). **That design was deliberately not implemented.** It would have made our code, not PolicyEngine, the source of the eligibility decision — the hybrid shape being retired (see `medicaid/wa.py` for the pattern we're moving away from). The scope decision was to ship the clean federal subclass now and fix the seven gaps upstream in PolicyEngine instead.

## Changes Made

- **New calculator** `programs/programs/cross_white_label/medicaid/mo.py` — `MoHealthNet(Medicaid)`, wiring only: `program_code`, three added `pe_inputs` (`MoStateCodeDependency`, `MeetsSsiDisabilityCriteriaDependency`, `IsBlindDependency`), and a `medicaid_categories` value table. No `member_value` override, no conditionals, no eligibility logic of our own. Same shape as `ks.py` / `nc.py` / `co.py` / `il.py`. Auto-discovered by `program_code`, so no registry edit.
- **`medicaid_categories`** are KFF *Medicaid Spending per Full-Benefit Enrollee by Enrollment Group*, MO, 2023, converted to monthly — the same source and vintage `wa.py` uses: children \$381, adults \$532, aged \$1,821, disabled \$2,534.
- **New config** `data/mo_medicaid_initial_config.json` — `name_abbreviated: mo_medicaid`, `base_program: medicaid`, category `mo_healthcare`, `active: true`, `value_format: estimated_annual`. Reuses 7 existing MO `Document` external names verbatim; adds 2 MO HealthNet navigators (MHD Participant Services, FSD Information Center).
- **No `spec.md`** — Fed-tier programs are config-only (the `ks_ssi` precedent), so there is also no Test Scenarios ticket comment.
- **Tests** — 13 wiring unit tests plus 1 VCR smoke test (see below).
- **Disability inputs** (`ae2778fd`) — the MHABD pathway needs `meets_ssi_disability_criteria` / `is_blind` to resolve `is_optional_senior_or_disabled_for_medicaid`. See *Notes for Reviewers* for why this was a real bug and not a cosmetic addition.
- **Base-class hardening** (`1156fbf0`) — `medicaid/base.py` now uses `medicaid_categories.get(category, 0)` instead of `[category]`. PolicyEngine's `medicaid_category` enum is larger than the set of categories we price, and an unrecognized one raised `KeyError` out of `member_value`, failing the whole eligibility request rather than just the program. Affects all six Medicaid states. Two tests cover it.
- The class docstring records all seven known PE divergences inline, so the next person to touch this doesn't rediscover them.

## Testing

- **Migrations to run:** none.
- **Configuration updates needed:** import the new program config —
  ```bash
  venv/bin/python manage.py import_program_config \
    programs/management/commands/import_program_config_data/data/mo_medicaid_initial_config.json
  ```
  Verified locally: creates `mo_medicaid` (`active: True`, `show_in_has_benefits_step: False`, category `mo_healthcare`), links 9 documents (7 reused, 2 created) and 2 navigators via `ProgramNavigator`.
- **Environment variables/settings to add:** none. Re-recording the cassette needs `POLICY_ENGINE_CLIENT_ID` / `POLICY_ENGINE_CLIENT_SECRET`, but replay does not.
- **Manual testing steps:**
  ```bash
  # Wiring + smoke test, strict replay, no network
  VCR_MODE=none venv/bin/pytest programs/programs/cross_white_label/medicaid/tests/ -q

  # Full suite
  VCR_MODE=none venv/bin/pytest programs/ -q
  ```
  Results on this branch: medicaid package **108 passed**; full `programs/` suite **2861 passed, 5 skipped, 0 failures**.

**API QA:** 8 scenarios run against a local screener API — expansion adult under/over 138% FPL, parent + 2 children, pregnant + spouse, senior under/over the MHABD limit, `already_has`, and a disabled adult. **8/8 pass**, every value matching the `medicaid_categories` table exactly. Written up in `qa/MFB-1215-mo_medicaid-api-results.md`. There is no `spec.md` to drive scenarios from, so these were derived from the pathways the calculator exercises using 2026 FPL read from the database — coverage of this PR's wiring, not a substitute for authored spec scenarios.

**Cassette:** recorded at PolicyEngine **1.794.2** (`current` at time of recording). One scenario is covered — a smoke test, not a scenario suite, because a Fed-tier passthrough has no `spec.md` and the federal math is already covered by the other states' medicaid tests. What the smoke test pins is the one genuinely MO-specific behavior: that Missouri is read as an ACA **expansion** state, so a childless adult at \$1,200/month (~92% FPL) comes back eligible in the `ADULT` category for \$6,384/yr rather than \$0. The recorded response confirms `medicaid_category = 'ADULT'`. A non-expansion state (KS) returns \$0 for the same household. The cassette contains exactly one `household.api.policyengine.org/us/calculate` interaction and no bearer token.

## Deployment

- **Post-deployment scripts needed:** run `import_program_config` for `mo_medicaid_initial_config.json` on staging, then production.
- **Production config updates:** none beyond the import. The config carries `"active": true`, so the program goes live on import — coordinate with the MO launch schedule if it should stay dark for now.
- **Admin updates needed:** none. Confirm the two new navigators (`mo_healthnet_participant_services`, `mo_fsd_information_center`) read correctly in admin after import.
- **Notify team/users of:** the seven upstream PolicyEngine fixes are still outstanding, so MO Medicaid ships with known edge-case divergences (listed below). Worth flagging to QA so they aren't reported as new bugs.

## Notes for Reviewers

**The disability-input fix is the most substantive thing here.** API QA passed 8/8 on the first run, but S8 (disabled adult) passed for the wrong reason. The MHABD pathway needs PolicyEngine's `meets_ssi_disability_criteria`; `MoHealthNet` wasn't sending it, and `mo_ssi` was supplying it incidentally because PolicyEngine inputs are pooled per request. Running the same household through a request containing *only* `MoHealthNet`'s inputs:

| | before | after |
|---|---|---|
| `is_optional_senior_or_disabled_for_medicaid` | `False` | `True` |
| `member_value` | **$0** | **$30,408** |

So a disabled Missourian who should qualify through MHABD would have returned $0 in any request where `mo_ssi` was absent or inactive. Fixed by declaring both inputs, mirroring `KsKanCare`. **`co`, `il`, `ma`, `nc` and `wa` still don't declare them and remain exposed to the same failure** — worth a separate ticket.

**Please look closely at the scope decision.** The discovery report on MFB-1261 describes the MFB-override design as "shipped in the mock, specified for the real calculator." This PR intentionally does not implement it. If you think any of the seven gaps must be closed before MO launch rather than upstream, that's the conversation to have here — the alternative is a full custom calculator (`/add-custom-program`, the `KsWorkingHealthy` precedent), not a partial override on top of this class.

**Known limitations** — all upstream PolicyEngine parameter issues, none patched here. They affect band edges and specific sub-populations, not the mainline MAGI pathways:

| Gap | Effect |
|---|---|
| Children's ceiling frozen at 155% FPL | Current MO standard is 153% (148% + 5% MAGI disregard); PE reports eligible slightly above the line |
| Parent/caretaker limit stored as % of FPL (frozen at 23%) | MO's standard is a flat 1996-AFDC dollar figure, not FPL-indexed — wrong parameter *shape*, not just a stale value |
| Pregnant/infant limit frozen at 201% | Current MPW line is 196% |
| No blind-specific MHABD standard | One flat ~85% FPG rate covers blind and non-blind alike |
| No Medicare-enrollment or SSI-receipt exclusion on adult expansion | Enrolled/receiving adults under the ceiling still return eligible |
| No Substantial Gainful Activity test on the disability pathways | Both blind and non-blind thresholds |
| No relationship/kinship check on the `PARENT` category | PE assigns `PARENT` regardless of actual relationship |

`show_in_has_benefits_step` is `false`, and that was verified rather than assumed: nothing keys off Medicaid via `has_benefit`/`has_base_benefit`, and Medicaid receipt is already captured through the screener's **insurance** question — `configuration/white_labels/mo.py` brands that option "MO HealthNet (Medicaid)". A tile would double-ask. This matches all four existing Medicaid configs.

One wiring test asserts `MoHealthNet.member_value is Medicaid.member_value`, so the hybrid shape can't creep back in silently.

**Review response — date-scoped `legal_status_required`:** a review comment asked for legal-status eligibility to be selected by application/effective date, with a dated rule set for the post-2026-10-01 rule. **Not implemented**, because the capability doesn't exist: `LegalStatus` has only `id`/`status`/`parent`, `legal_status_required` is a plain M2M with no effective-date column, `Program` has no date fields, and no config in the repo uses a dated rule set. Adding one means a schema migration, importer support, date resolution at eligibility time and a frontend contract change — across every program, not this config.

The underlying policy point may still be valid. `mo_medicaid`'s list (`citizen`, `gc_5plus`, `otherWithWorkPermission`, `refugee`) is **identical to `ks_medicaid`'s**, copied deliberately; WA's is broader. If the Oct 1 2026 federal change drops `refugee` from full-benefit eligibility, every Medicaid config is affected, not just MO — that's a policy decision plus a config sweep, so it's flagged rather than changed here. I did not independently verify the federal rule.

**Future considerations:**

- Two caveats on the discovery evidence, worth resolving before filing the seven fixes upstream: (1) it was verified against the **public** `api.policyengine.org`, which ignores the `version` field, so the findings aren't version-pinned and aren't directly comparable to ours; (2) its claim of "no SGA check anywhere in PE" sits awkwardly against `medicaid/ks.py`'s docstring, which says our SSI-criterion inputs deliberately leave "the SGA earnings test intact." Both may be true (SGA in the SSI chain but not gating `medicaid`), but it's worth confirming against the private API first.
- The `medicaid_categories` figures are KFF **2023**, which is the newest published vintage (KFF's analysis was refreshed October 2025); there is no 2024 or 2026 release. Same vintage as `wa.py` (KFF 2023) and `ks.py` (KHI FY2023).
- PolicyEngine returns a flat `medicaid` dollar value — $12,559.627 for every MO household regardless of age, income or category (verified across three). It's a per-capita cost constant, which is why the base class uses it only as a `> 0` eligibility gate and prices the result from the category table.
- **Correction, now fixed.** An earlier revision of this PR described a latent `KeyError` triggered by `SENIOR_OR_DISABLED`. That specific claim was wrong: I could not reproduce it, and the value looks unreachable — `has_disability()` reads the same three screener fields that feed PE's `meets_ssi_disability_criteria` / `is_blind`, so whenever PE would answer `SENIOR_OR_DISABLED` the base class has already intercepted the member, and PE ranks that category after `ADULT` anyway. What *is* real: `medicaid_categories` prices only 9 of PE's enum values, missing `SENIOR_OR_DISABLED`, `MEDICALLY_NEEDY`, `WORKING_DISABLED_BUY_IN`, `SECTION_1115_MEC_ADULT`, `HEALTHIER_MISSISSIPPI_WAIVER`. (`AGED`/`DISABLED` in our dict aren't PE values at all — synthetic keys the base class looks up directly.) A live sweep of 7 MO households returned only priced categories; `MEDICALLY_NEEDY` can't fire since we send no medical-expense input, and `WORKING_DISABLED_BUY_IN` needs disability so it's intercepted. The one route I couldn't rule out is `SECTION_1115_MEC_ADULT` in a state whose covered-category list keeps it. Hardened in `1156fbf0` regardless, since the failure mode was a 500 on the entire request.
- When the upstream fixes land, re-record this cassette at the new pin and re-check the smoke value.
- **Separate pre-existing bug, not fixed here:** every `mydss.mo.gov` path now 302s to `dss.mo.gov/fsd`, including the `learn_more_link` and `apply_button_link` already shipped in `mo_tanf_initial_config.json`. This PR uses `dss.mo.gov/healthcare` and `/healthcare/apply`, which resolve directly. Other MO configs need a link sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Missouri MO HealthNet Medicaid support for 2026.
  - Included Missouri-specific eligibility rules, application information, required documents, timing details, and participant assistance contacts.
  - Added support for Missouri household state information and Medicaid enrollment categories with estimated monthly values.

- **Bug Fixes**
  - Medicaid categories without defined values now return zero instead of causing errors.

- **Tests**
  - Added coverage for Missouri eligibility scenarios, program configuration, category values, and eligibility calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

