### PR TITLE
Add MO LIHEAP (Energy Assistance) custom calculator

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_liheap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_liheap_initial_config.json
@@ -1,0 +1,81 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_housing",
+    "name": "Housing and Utilities",
+    "icon": "housing"
+  },
+  "program": {
+    "name_abbreviated": "mo_liheap",
+    "active": true,
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission"
+    ],
+    "name": "Low Income Home Energy Assistance Program (LIHEAP)",
+    "description": "LIHEAP helps Missouri households pay for home heating and cooling costs. Energy Assistance provides a one-time payment each year to help with your energy bill.\n\nThe payment usually goes to your energy company to help pay your bill. In some cases, it may be sent directly to you. MyFriendBen shows a conservative estimate, so your actual payment may be different.\n\nIf someone in your household is 60 or older or has a disability, you may be able to apply earlier in the season. There is also a $3,000 limit on certain household resources, like savings or investments.\n\nSelect \"Apply Now\" to complete and submit your LIHEAP application.",
+    "description_short": "Help paying home heating or cooling bills",
+    "learn_more_link": "https://mydss.mo.gov/utility-assistance/liheap",
+    "apply_button_link": "https://formsportal.mo.gov/content/forms/af/moa/my-dss/family-support-division/liheap/liheap/.html",
+    "apply_button_description": "",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "60 days",
+    "estimated_value": "",
+    "value_format": "lump_sum",
+    "website_description": "Help paying home heating or cooling bills",
+    "base_program": "liheap",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "warning_message": {
+    "external_name": "mo_liheap_application_window",
+    "calculator": "_show",
+    "message": "Energy Assistance has seasonal application dates. Households with someone age 60 or older or with a disability can apply starting October 1. All other households can apply starting November 1. Applications close May 31."
+  },
+  "navigators": [
+    {
+      "external_name": "mo_211"
+    },
+    {
+      "external_name": "mo_liheap_fsd_help",
+      "name": "Missouri Family Support Division - LIHEAP",
+      "email": "FSD.LIHEAP@dss.mo.gov",
+      "description": "Contact the Family Support Division for help with your LIHEAP application.",
+      "assistance_link": "https://mydss.mo.gov/fsd/intro",
+      "phone_number": "+18553734636"
+    }
+  ],
+  "documents": [
+    {
+      "external_name": "mo_liheap_ssn",
+      "text": "Social Security number proof for everyone in the household",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_liheap_utility_bill",
+      "text": "Recent utility, heating, or cooling bills and any disconnection notices",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_liheap_income",
+      "text": "Proof of last month's household income, unless the person gets SNAP",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_liheap_self_employment",
+      "text": "Most recent Form 1040 and Schedule 1 for anyone who is self-employed",
+      "link_url": "https://www.irs.gov/forms-pubs/about-form-1040",
+      "link_text": "Form 1040 and Schedule 1"
+    }
+  ]
+}

--- a/programs/management/commands/import_program_config_data/data/mo_liheap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_liheap_initial_config.json
@@ -41,7 +41,12 @@
   },
   "navigators": [
     {
-      "external_name": "mo_211"
+      "external_name": "mo_211",
+      "name": "Missouri 211",
+      "email": "",
+      "description": "Missouri 211 connects residents to local services and can help you find utility and energy assistance in your area.",
+      "assistance_link": "https://www.211helps.org/",
+      "phone_number": "+18004274626"
     },
     {
       "external_name": "mo_liheap_fsd_help",

--- a/programs/programs/cross_white_label/liheap/mo.py
+++ b/programs/programs/cross_white_label/liheap/mo.py
@@ -1,0 +1,197 @@
+from programs.framework.base import ProgramCalculator, Eligibility
+import programs.framework.eligibility_messages as messages
+from screener.models import HouseholdMember
+from typing import ClassVar
+
+
+class MoLiheap(ProgramCalculator):
+    """MO LIHEAP (Energy Assistance) — a one-time payment toward home heating
+    and cooling costs, administered by the Missouri Family Support Division.
+
+    Eligibility (see specs/mo.md):
+      * Criterion 1: countable monthly income at or below 60% of Missouri's State
+        Median Income for the household size. Missouri elected the SMI standard,
+        so this is a published dollar table rather than an FPL multiple. Countable
+        income is gross income less two exclusions (a member under 18's earned
+        income, and interest/dividend income) and four deductions (20% of earned
+        income, $100 once where the applicant or spouse is 65+ or has a
+        disability, child support paid out of the household, and the Medicare
+        Part B premium per Medicare-covered member).
+      * Criterion 2: the household must be responsible for its home energy costs.
+        Missouri requires an account in a member's name or a qualifying
+        renter/landlord arrangement; the screener has no such field, so this
+        follows the ks_lieap / nc_lieap precedent and infers responsibility from a
+        housing or utility expense. A household whose landlord bears the energy
+        cost with no pass-through has rent but no responsibility and is shown as
+        eligible.
+      * Criterion 5: at least one member aged 15 or older. Missouri expects an
+        applicant 18 or over but accepts a 15- to 17-year-old where the household
+        has no adult, so under-15 is the only outright denial.
+
+    Handled outside the calculator:
+      * Criterion 3 (citizenship) — the program's `legal_status_required` config.
+        Missouri disqualifies only on the *applicant's* status and merely drops
+        other non-qualifying members from the household count, which the screener
+        cannot reproduce (it collects no per-member status).
+      * Criterion 4 (Missouri residency) — enforced at intake: the MO screener
+        gates its ZIP step on `MoConfigurationData.counties_by_zipcode`, so a
+        non-Missouri ZIP never reaches this calculator.
+
+    Not modelled, per the spec's resolved implementation decisions:
+      * The $3,000 resource limit. `Screen.household_assets` is not Missouri's
+        countable figure in either direction, so applying it would exclude
+        households Missouri accepts. Surfaced in the program description instead.
+      * Primary heating fuel, which sets the real award, and the CARS recoupment
+        that can reduce it — neither is collected.
+      * The utilities-included renter payment (a share of annual rent). The
+        screener records no utilities-included tenancy, and the sources conflict
+        on its size. Those renters get the standard estimate below.
+
+    Benefit value is a flat $153 lump sum — Missouri's published minimum Energy
+    Assistance benefit, chosen as a deliberate conservative estimate because the
+    per-fuel figures Missouri publishes are maximums and the matrix that sets the
+    award within them is not.
+    """
+
+    program_code = "mo_liheap"
+
+    #: One-time payment. `value_format: lump_sum` on the program row, so this is
+    #: the award itself and not an annualized figure.
+    amount = 153
+
+    #: Monthly 60% SMI income limit by household size — MyDSS Benefit Program
+    #: Income Limits, as of 04/01/2026. The live screener caps household size at
+    #: 8, so rows 9 and 10 and the increment below are currently unreachable.
+    income_limits: ClassVar[dict[int, int]] = {
+        1: 2_840,
+        2: 3_714,
+        3: 4_588,
+        4: 5_461,
+        5: 6_335,
+        6: 7_209,
+        7: 7_373,
+        8: 7_537,
+        9: 7_701,
+        10: 7_864,
+    }
+    #: Added to the size-10 limit for each member past 10.
+    income_limit_increment = 164
+
+    #: A housing or utility expense stands in for energy-cost responsibility.
+    expenses = ("rent", "mortgage", "heating", "cooling", "otherUtilities")
+
+    #: Missouri's earned-income definition, which includes roomer-boarder income.
+    #: Drives both the 20% deduction and the under-18 exclusion.
+    earned_income_types = ("wages", "selfEmployment", "boarder")
+    #: Interest and dividend income, excluded outright. `deferredComp` is MFB's
+    #: "Withdrawals from Deferred Compensation (IRA, Keogh, etc.)", which
+    #: Missouri lists under the same exclusion.
+    excluded_income_types = ("investment", "deferredComp")
+    earned_income_deduction = 0.20
+    #: Earned income of a member below this age is excluded; their SSA income
+    #: still counts.
+    minor_age = 18
+
+    #: Granted once per household where the applicant or spouse is elderly or has
+    #: a disability, never once per qualifying member.
+    medical_deduction = 100
+    medical_deduction_min_age = 65
+    #: CMS standard 2026 Part B premium. Missouri deducts the member's actual
+    #: premium and only where they pay it rather than being in buy-in; neither is
+    #: screenable, so this over-deducts for buy-in households, which admits
+    #: households rather than excluding them.
+    medicare_premium = 202.90
+
+    #: Missouri denies an application from an applicant under 15 outright.
+    min_applicant_age = 15
+
+    dependencies: ClassVar[list[str]] = [
+        "income_frequency",
+        "income_amount",
+        "household_size",
+    ]
+
+    def household_eligible(self, e: Eligibility):
+        # Criterion 5: someone old enough to be the applicant
+        e.condition(self._has_eligible_applicant(), messages.older_than(self.min_applicant_age))
+
+        # Criterion 2: responsible for home energy costs (directly or via rent)
+        e.condition(self.screen.has_expense(self.expenses))
+
+        # Criterion 1: countable monthly income at or below 60% SMI
+        income = self._countable_income()
+        income_limit = self._income_limit()
+        e.condition(income <= income_limit, messages.income(income, income_limit))
+
+    def _income_limit(self) -> int:
+        """The size's row of Missouri's 60% SMI table, extended by
+        `income_limit_increment` past the largest published row."""
+        household_size = self.screen.household_size or 1
+        largest_published = max(self.income_limits)
+
+        if household_size >= largest_published:
+            return self.income_limits[largest_published] + (
+                household_size - largest_published
+            ) * self.income_limit_increment
+
+        return self.income_limits.get(household_size, self.income_limits[1])
+
+    def _countable_income(self) -> float:
+        """Monthly gross income less Missouri's exclusions and deductions.
+
+        Rounded to cents because the boundary cases turn on them: $3,551 of
+        earned income is $2,840.80 after the 20% deduction and must fail a
+        $2,840 limit, so truncating to whole dollars would wrongly admit it.
+        """
+        gross = 0.0
+        earned = 0.0
+
+        for member in self.screen.household_members.all():
+            exclude = list(self.excluded_income_types)
+            if self._is_minor(member):
+                exclude += list(self.earned_income_types)
+            else:
+                earned += member.calc_gross_income("monthly", list(self.earned_income_types))
+            gross += member.calc_gross_income("monthly", ["all"], exclude=exclude)
+
+        deductions = earned * self.earned_income_deduction
+        if self._medical_deduction_applies():
+            deductions += self.medical_deduction
+        deductions += self.screen.calc_expenses("monthly", ["childSupport"])
+        deductions += self.medicare_premium * self._medicare_member_count()
+
+        return round(max(0.0, gross - deductions), 2)
+
+    def _is_minor(self, member: HouseholdMember) -> bool:
+        """Whether `member`'s earned income is excluded. A member whose age is
+        unknown counts as an adult: Missouri grants the exclusion on proof of
+        age, so an unproven one is not assumed."""
+        age = member.calc_age()
+        return age is not None and age < self.minor_age
+
+    def _medical_deduction_applies(self) -> bool:
+        """Whether the $100 medical deduction is due. Missouri tests the
+        applicant and spouse only — a qualifying parent or child does not earn it
+        — and allows it once even when both qualify."""
+        for member in self.screen.household_members.all():
+            if not (member.is_head() or member.is_spouse()):
+                continue
+
+            age = member.calc_age()
+            if age is not None and age >= self.medical_deduction_min_age:
+                return True
+            if member.has_disability():
+                return True
+
+        return False
+
+    def _medicare_member_count(self) -> int:
+        return sum(1 for member in self.screen.household_members.all() if member.has_insurance("medicare"))
+
+    def _has_eligible_applicant(self) -> bool:
+        for member in self.screen.household_members.all():
+            age = member.calc_age()
+            if age is not None and age >= self.min_applicant_age:
+                return True
+
+        return False

--- a/programs/programs/cross_white_label/liheap/mo.py
+++ b/programs/programs/cross_white_label/liheap/mo.py
@@ -130,9 +130,10 @@ class MoLiheap(ProgramCalculator):
         largest_published = max(self.income_limits)
 
         if household_size >= largest_published:
-            return self.income_limits[largest_published] + (
-                household_size - largest_published
-            ) * self.income_limit_increment
+            return (
+                self.income_limits[largest_published]
+                + (household_size - largest_published) * self.income_limit_increment
+            )
 
         return self.income_limits.get(household_size, self.income_limits[1])
 

--- a/programs/programs/cross_white_label/liheap/specs/mo.md
+++ b/programs/programs/cross_white_label/liheap/specs/mo.md
@@ -1,0 +1,560 @@
+# Low Income Home Energy Assistance Program (LIHEAP) (MO) — Program Spec
+
+- **Program key**: `mo_liheap` (proposed — `programs/programs/cross_white_label/liheap/mo.py`, class `MoLiheap`)
+- **Base federal program**: LIHEAP (`base_program: "liheap"`)
+- **White label**: MO
+- **Engine**: MFB custom
+- **Added to MFB**: not implemented
+- **Spec last updated**: 2026-08-21
+- **Sources verified as of**: 2026-08-21
+
+## Covered Eligibility Criteria
+
+1. **Household countable monthly income is at or below 60% of Missouri's State Median Income for the household size**
+   - Evaluation scope: household
+   - Captured via: `Screen.household_size` (Screen, IntegerField); `Screen.calc_gross_income` (accessor) over countable income types, monthly.
+   - Limit table (monthly income, 60% SMI), carried as a program constant:
+
+     | Size | Limit | | Size | Limit |
+     |---|---|---|---|---|
+     | 1 | $2,840 | | 6 | $7,209 |
+     | 2 | $3,714 | | 7 | $7,373 |
+     | 3 | $4,588 | | 8 | $7,537 |
+     | 4 | $5,461 | | 9 | $7,701 |
+     | 5 | $6,335 | | 10 | $7,864 |
+
+     Above size 10: +$164 per additional member.
+   - Countable income = gross income less the exclusions and deductions below. The criterion is not evaluated when `household_size` is null.
+   - **MFB limitation — household-size cap.** The live MFB household-size field caps entries at 8 (`.lte(8)`), so sizes 9 and above cannot be entered through the current screener. Table rows 9 and 10, and the +$164 increment above 10, are consequently unreachable and unexercised by any scenario — a regression in either would go undetected until the intake cap changes. Sizes 1 through 8 remain fully reachable and are pinned below.
+   - **MFB limitation — income timing (Divergence D5, committed exception to the inclusive-gap rule).** Missouri budgets the calendar month **preceding** the application month — `Determine all gross earned and unearned income less the allowable income` exclusions for that month — while MFB evaluates currently-reported income. The screener records no income period at all, so the two cannot be reconciled: a household whose income rose this month is counted higher than Missouri would count it, and one whose income fell is counted lower.
+     - **Committed handling**: currently-reported income is used as the household's income, without adjustment. No inclusive handling exists short of abandoning the income test, because the screener holds no second income figure to fall back to and no date to compare against.
+     - This is a **platform-level MFB limitation** — it applies wherever MFB models a prior-month-budgeted benefit — and not a Missouri-specific policy assumption.
+   - Source: LIHEAP Policy and Procedure Manual, Income Determination — `Determine all gross earned and unearned income less the allowable income` exclusions for the month prior to the application month — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: MyDSS Benefit Program Income Limits, `As of 04/01/2026`, Low Income Home Energy Assistance Program row ($2,840 through $7,537 for household sizes 1–8 at State Median Income 60%) — [snapshot `2026-08-20--modss-benefit-program-income-limits`](../../../sources/mo/mo_liheap/2026-08-20--modss-benefit-program-income-limits/content.md), accessed 2026-08-20
+   - Source: FFY2026 application, revision MO 886-4576 (9-2025), Program Description — `0%-60% STATE MEDIAN INCOME (SMI)`, `1                             2,840`, `9                             7,701`, `10                            7,864`, and `more than 10 members, add $164` — [snapshot `2026-08-20--modss-liheap-application-form`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-application-form/content.md), accessed 2026-08-20
+   - Source: FFY2026 Model State Plan §2.1 — `All Household Sizes                                    State Median Income                                                 60.00%` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+   - **Source conflict — income limit figures.** The 2026 FPL Chart for all Programs PDF, linked from the MyDSS page, gives lower figures — `"Low Income Home Energy Assistance Program"           "$2,535"` — [snapshot `2026-08-20--modss-2026-fpl-chart-all-programs`](../../../sources/mo/mo_liheap/2026-08-20--modss-2026-fpl-chart-all-programs/content.md), accessed 2026-08-20. **Committed interpretation**: the MyDSS page's figures govern, because the FFY2026 application independently corroborates them.
+     - The MyDSS page's own note reads `add $163 to the maximum monthly income for each household member` for sizes over 6, but its table increments by $164 ($7,209 → $7,373) and the application states $164 — **$164 governs**.
+     - A second, deeper conflict sits in the regulation itself: 13 CSR 40-19.020(6)(D) requires each household to meet the `fied income guidelines based on their house-` hold size established in section (14) of that rule, and (14) sets Federal Poverty Level bands topping out at 126–135% — a materially lower standard than 60% SMI. **Committed interpretation**: the 2017 rule predates Missouri's current election; the FFY2026 Model State Plan, the FFY2026 application and the MyDSS page all carry 60% SMI, and 42 U.S.C. §8624(b)(2) authorises it, so the current 60% SMI standard governs — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20.
+
+   **Income exclusions** (applied before the deductions below).
+   - Earned income of any household member under 18 is excluded; their SSA income still counts. Captured via `HouseholdMember.calc_age` (accessor) with `Screen.calc_gross_income` restricted to members 18 and over for `["wages", "selfEmployment", "boarder"]` — the same set Deduction 1 uses, since Missouri's earned-income definition includes roomer-boarder income.
+   - Interest and dividend income is excluded. Captured via `Screen.calc_gross_income` excluding the `investment` and `deferredComp` income types.
+   - Missouri's other exclusions are narrow sub-cases of income types it otherwise counts — `gifts`, `cashAssistance` and `veteran` income are all countable here (the manual documents `Monetary assistance from family-friends or stipend`, `BP, SAB, and TANF:` and `Veterans Administration Disability Benefits` as countable income), so none of those types is excluded wholesale. The excluded sub-cases are recorded in data gap 7.
+   - The under-18 rule covers earned income only: Missouri's own sentence continues that unearned income from disability `should not be included but SSA income` should be, and MFB has no income type representing non-SSA disability income for a minor — `sSDisability` and `sSI` are both SSA income and stay countable. That residue is also in data gap 7.
+   - Source: LIHEAP Policy and Procedure Manual, Income Exclusions — `Earned income received from a household member under the age` of 18 should not be included as household income, and `Interest-Dividend Income` covering annuities, CDs, IRAs, Keoghs and deferred compensation plans, savings and checking accounts, bonds, and dividends from stocks or mutual funds — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+   **Deduction 1 — 20% of earned income.**
+   - Evaluation scope: household
+   - Captured via: `Screen.calc_gross_income` (accessor) over `["wages", "selfEmployment", "boarder"]`, monthly, × 0.20
+   - Source: LIHEAP Policy and Procedure Manual, Income Deductions, `Earned Income Deduction of 20%` — `This deduction applies to employment income including wages,` vacation pay, regular bonuses, overtime, tips, sick leave, maternity leave, roomer-boarder, and self-employment income — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+   **Deduction 2 — $100 medical deduction where the applicant or spouse is age 65 or older, or has a disability. Once per household.**
+   - Evaluation scope: household (tested against the head and spouse only)
+   - Captured via: `HouseholdMember.calc_age` (accessor), `HouseholdMember.has_disability` (accessor), `HouseholdMember.is_head` / `.is_spouse` (accessors)
+   - Age granularity: MFB collects birth year and month, not day, and treats a member as having reached 65 throughout their birth month. Missouri is stricter — `The member must turn 65 prior to the date the case` shows as registered — so MFB may grant the deduction slightly earlier. **Inclusive.**
+   - Disability definition: 13 CSR 40-19.020(2)(C) defines a disabled individual as one `vidual who is totally and permanently disabled` or blind **and** receiving one of a named list of benefits (Social Security Disability, SSI, Railroad Retirement Disability, State Aid to the Blind, VA Disability and others) — the manual restates this narrow definition operationally and limits documentation to a closed list of benefit evidence, so it is the rule in practice as well as on paper. `HouseholdMember.has_disability` is self-reported and carries no benefit-receipt condition, so MFB grants this deduction to households Missouri might not. **Inclusive.**
+   - Source: 13 CSR 40-19.020(2)(C) — `vidual who is totally and permanently disabled` or blind and receiving one or more of the listed benefits — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+   - Source: LIHEAP Policy and Procedure Manual, Medical Deduction for Elderly-Disabled — `applicant or spouse is elderly (age 65 or older) or disabled.` and `The system allows only one $100 deduction, even if both applicant` and spouse meet criteria — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+   **Deduction 3 — child support paid to someone outside the household.**
+   - Evaluation scope: household
+   - Captured via: `Screen.calc_expenses` (accessor) over `["childSupport"]`, monthly
+   - Source: LIHEAP Policy and Procedure Manual, Child Support Payments — `All child support payments (except for lump sum payments) paid by` any household member to someone not included in the LIHEAP household — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+   **Deduction 4 — $202.90 per month for each household member who has Medicare.**
+   - Evaluation scope: member
+   - Captured via: `HouseholdMember.has_insurance` (accessor) with `"medicare"`, backed by `Insurance.medicare` (Insurance, BooleanField)
+   - Missouri deducts the member's actual SMI premium, and only where the member pays it rather than being in Medicare buy-in. The screener captures neither the premium amount nor buy-in status, so this spec commits to the CMS standard 2026 Part B premium as a conservative approximation. It over-deducts for buy-in households, which admits households rather than excluding them; it is not a claim that any individual pays this amount.
+   - Missouri also conditions the deduction on case category — `Allowable for all household members of a B or C case who are` paying this premium, and only on a Category A case where income exceeds the maximum allowed. MFB applies it unconditionally, which is the same inclusive direction.
+   - Source: LIHEAP Policy and Procedure Manual, SMI Premium — `SMI is an additional health cost that is available to persons receiving` SS and RRB — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: CMS, Medicare Deductible, Coinsurance & Premium Rates CY 2026 Update (MM14279) — `Part B standard premium: $202.90 a month` — [snapshot `2026-08-20--cms-medicare-premium-rates-cy2026`](../../../sources/mo/mo_liheap/2026-08-20--cms-medicare-premium-rates-cy2026/content.md), accessed 2026-08-20
+
+2. **Household is responsible for its home energy costs**
+   - Evaluation scope: household
+   - Captured via: `Screen.has_expense` (accessor) over `["rent", "mortgage", "heating", "cooling", "otherUtilities"]`
+   - This is a proxy. Missouri requires an account in a household member's name, or a qualifying renter/landlord arrangement, plus actual heating or cooling costs. A housing or utility expense is broader — a household whose landlord bears the energy cost with no pass-through has rent but no responsibility, and will be shown as eligible. **Inclusive.**
+   - Source: 13 CSR 40-19.020(6)(C) — each household must have an account in their name or meet the definition of a renter/landlord household and be `incurring heat-` ing/cooling costs — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+   - Source: MyDSS LIHEAP page, Who is eligible — `Are responsible for paying the utilities for your home (including if you rent)` — [snapshot `2026-08-20--modss-liheap-overview`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-overview/content.md), accessed 2026-08-20
+
+3. **The applicant is a U.S. citizen or a qualified non-citizen**
+   - Evaluation scope: config
+   - Captured via: `legal_status_required` = `["citizen", "gc_5plus", "gc_5less", "refugee", "otherWithWorkPermission"]`
+   - Missouri checks qualifying status for household members, but only the applicant's non-qualifying status makes the case ineligible. Other non-qualifying members are excluded from the household count while their available income still counts — see data gap 6, since the screener collects no per-member immigration status.
+   - `gc_5less` is included because lawful permanent residents qualify regardless of how long they have held that status. `refugee` and `otherWithWorkPermission` carry the refugee, asylee and parolee classes Missouri documents via an annotated I-94, and COFA citizens, whom the manual names as qualified non-citizens.
+   - Source: LIHEAP Policy and Procedure Manual, Citizenship — `If the individual claiming they are not a citizen is the applicant, the case will be` determined ineligible, and `Exclude individuals not meeting these criteria from the household count.` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: ACF LIHEAP IM 1998-25 — `all qualified aliens, regardless of when they entered the U.S., continue` to be eligible to receive assistance and services under LIHEAP if they meet other program requirements — [snapshot `2026-08-20--acf-liheap-im-1998-25-federal-public-benefits`](../../../sources/mo/mo_liheap/2026-08-20--acf-liheap-im-1998-25-federal-public-benefits/content.md), accessed 2026-08-20
+   - **Source conflict — qualifying non-citizen classes.** 13 CSR 40-19.020(6)(A) names only two qualifying classes — `All household members must be a cit`izen of the United States or a legal permanent resident — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20. **Committed interpretation**: the manual's I-94 annotation list and COFA paragraph, backed by ACF IM 1998-25, supply the classes the regulation's two-class sentence omits.
+
+4. **Household resides in Missouri**
+   - Evaluation scope: household
+   - Captured via: `Screen.zipcode` (Screen, CharField) against `MoConfigurationData.counties_by_zipcode` (`configuration/white_labels/mo.py`, 1,126 Missouri ZIPs)
+   - An out-of-state mailing address does not disqualify a household whose physical residence is in Missouri; `Screen.zipcode` asks where the household lives, so it matches the rule. A null `zipcode` is treated as met rather than failing closed, consistent with the inclusive handling of every other unobservable condition here.
+   - **MFB limitation — platform-enforced, untestable.** The Missouri screener's own ZIP-entry step is gated on `MoConfigurationData.counties_by_zipcode` before submission, so a non-Missouri ZIP is rejected at intake and never reaches this criterion. Residency is therefore platform-enforced as well as modelled here; no calculator-negative scenario is possible, and a regression in this criterion's own check would not be caught by any scenario.
+   - Source: MyDSS LIHEAP page, Who is eligible — `Are a Missouri resident` — [snapshot `2026-08-20--modss-liheap-overview`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-overview/content.md), accessed 2026-08-20
+
+5. **The household includes a member old enough to be the applicant**
+   - Evaluation scope: household
+   - Captured via: `HouseholdMember.calc_age` (accessor) — at least one member aged 15 or older
+   - Missouri expects an applicant aged 18 or over, and allows a member aged 15 to 17 to apply where no adult is in the household. Only the under-15 case is an outright denial, so that is the line this criterion draws.
+   - Source: LIHEAP Policy and Procedure Manual, Application — `Applicants should be an individual that is age eighteen (18) or over` and residing in the household, with applicants between 15 and 18 accepted where there is no other member over 18, and `If the applicant is under the age of fifteen (15), the application will be denied.` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+## Missing Eligibility Criteria (Data Gaps)
+
+1. **Household resources may not exceed $3,000**
+   - **Why**: `Screen.household_assets` is not Missouri's countable-resource figure in either direction. It omits resources Missouri counts (certificates of deposit, IRAs, Keoghs and deferred compensation, money markets) and includes funds Missouri exempts (Medicare Set-Aside accounts, FEMA disaster relief) as well as resources documented as restricted or inaccessible.
+   - **Handling**: assumed met, and not evaluated. **Inclusive** — applying the field directly would exclude households Missouri would find eligible. The limit is surfaced in the program description.
+   - Source: MyDSS LIHEAP page, Who is eligible — `Have $3,000 or less in your bank accounts, retirement accounts, or investments` — [snapshot `2026-08-20--modss-liheap-overview`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-overview/content.md), accessed 2026-08-20
+   - Source: 13 CSR 40-19.020(6)(B) — resources may not `exceed three thousand dollars ($3,000);` — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+
+2. **Missouri's household definition — private living quarters, one meter and one bill, one residence per year**
+   - **Why**: the screener has no field for shared metering, private-entrance living quarters, or a second residence.
+   - **Handling**: assumed met. `Screen.household_size` is used as given. **Inclusive** — admits households that share a meter with another household. Missouri also limits a multiply-named fuel account to one recipient, which the screener cannot see either.
+   - Source: LIHEAP Policy and Procedure Manual, Household — `Household is defined as an individual(s) living in private living quarters` for which residential heat-cooling is purchased in common — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: LIHEAP Policy and Procedure Manual, Ineligible Individuals-Households — `Only one individual on a multiple named fuel bill account will be eligible` to receive LIHEAP benefits — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: FFY2026 application, revision MO 886-4576 (9-2025) — `1 bill + 1 meter = 1 Household` — [snapshot `2026-08-20--modss-liheap-application-form`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-application-form/content.md), accessed 2026-08-20
+
+3. **Living situations that make a household ineligible**
+   - **Why**: Missouri excludes households in a nursing or boarding home, a hotel, motel, dormitory or temporary shelter, or government-subsidized housing, unless the household pays an energy supplier or landlord directly for heating or cooling; households in transitional living whose energy is paid by the Department of Mental Health; and households in a recreational vehicle, travel trailer, tent or shed at the same address as, and sharing a meter or power source with, a household that has already received EA this fiscal year. `Screen.housing_situation` (Screen, CharField) distinguishes renting, owning and homelessness but carries no subsidy, institutional, or direct-payment dimension.
+   - **Handling**: assumed met. **Inclusive** — households in these situations are shown as eligible.
+   - Source: LIHEAP Policy and Procedure Manual, Ineligible Individuals-Households — `Consider households meeting the following conditions ineligible:` including `Resides in a professional, practical, or domiciliary nursing or boarding home`, `Resides in a hotel, motel, dormitory or temporary shelter and does not pay` a home energy supplier directly, `In a transitional living situation.`, and `Residing in a recreational vehicle, travel trailer, tent or shed residing at the` same address and sharing power — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: 13 CSR 40-19.020(7)(H) — an RV, travel trailer, tent or shed at the same address `as, and sharing the same meter or source of` power with a household that has already received EA in the current LIHEAP fiscal year — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+   - Source: FFY2026 Model State Plan §2.3 — `Only eligible if the client is paying an energy supplier out-of-pocket.` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+
+4. **A fuel-supplier credit balance over $500 makes a household ineligible, unless it pre-pays for fuel**
+   - **Why**: the screener collects no utility account balance, and no pre-payment arrangement.
+   - **Handling**: assumed met. **Inclusive.**
+   - Source: LIHEAP Policy and Procedure Manual, Ineligible Individuals-Households — `Has a credit balance with their fuel supplier in excess of $500.` and `This will not apply to households that pre-pay for their fuel.` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+5. **A household that cuts its own wood, where wood is its primary heating source, is ineligible**
+   - **Why**: the screener collects no primary heating fuel, so it cannot identify wood-heating households, let alone self-supplied ones.
+   - **Handling**: assumed met. **Inclusive.**
+   - Source: LIHEAP Policy and Procedure Manual, Ineligible Individuals-Households — `Cut their own wood.` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+   - Source: 13 CSR 40-19.020(7)(G) — a household that cuts its own wood, `when wood is the household` 's primary source of heating — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+
+6. **Individuals excluded from the household while their income still counts**
+   - **Why**: Missouri drops non-qualified non-citizens, incarcerated people, roomers, boarders and live-in attendants, the deceased, and people not living in the home at application from the household count, while still counting income they make available to the household. The screener collects no per-member immigration status, incarceration status, or roomer/boarder role, so neither the count adjustment nor the income treatment can be reproduced.
+   - **Handling**: `Screen.household_size` is used as given and all reported income is counted. Missouri drops excluded individuals from the count while MFB keeps them, so MFB's household size — and therefore its income limit — is the larger of the two. **Inclusive.**
+   - Source: LIHEAP Policy and Procedure Manual, Citizenship — `Exclude individuals not meeting these criteria from the household count.` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+7. **Narrow income exclusions that sit inside otherwise-countable income types**
+   - **Why**: each of these is a sub-case of an MFB income type whose ordinary content Missouri counts, so the screener cannot separate them:
+     - Birthday and Christmas gifts, and student cash gifts or awards — inside `gifts`
+     - Veteran's educational benefits — inside `veteran`
+     - Payments or allowances under Federal, State or Local law for Energy Assistance, including HUD rent-utility subsidies — inside `cashAssistance`
+     - Work study (the screener flags `HouseholdMember.student_has_work_study` but records no separate amount), Foster Grandparents/VISTA/AmeriCorps compensation, and income under Title V of the Older Americans Act — inside `wages`
+     - Unearned non-SSA disability income of a member under 18, for which MFB has no income type at all (`sSDisability` and `sSI` are SSA income, which Missouri counts)
+     - Lump-sum payments, relocation payments and Nazi-persecution victim payments — no MFB income type for any of these
+     - (Missouri's Interest-Dividend list also names IRAs and Keoghs, but those are already excluded — MFB's `deferredComp` type is labelled "Withdrawals from Deferred Compensation (IRA, Keogh, etc.)" and criterion 1 excludes it.)
+   - **Handling — committed, approved exception to the inclusive-gap rule (Divergence D6)**: all of these are counted, because excluding the whole enclosing type would remove income Missouri plainly counts — TANF, VA disability benefits, ordinary contributions and wages. **Exclusive** — a household living on Title V or AmeriCorps stipends, or a minor's non-SSA disability income, will show a higher countable income than Missouri would find. The inclusive alternative (excluding the whole enclosing income type) was considered and rejected, because it would drop income Missouri plainly counts and produce a larger, less predictable error in the other direction.
+   - Source: LIHEAP Policy and Procedure Manual, Miscellaneous Exclusions — `Compensation provided to volunteers in the Foster Grandparents` Program, VISTA, or the AmeriCorps Program, and `Income received under Title V of the Older Americans Act` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+8. **Energy Assistance is paid once per household per program year**
+   - **Why**: the screener records no prior LIHEAP receipt, and Missouri also excludes members already approved for EA elsewhere, or moving into a household that has already received EA this year at the same address.
+   - **Handling**: assumed no prior receipt. **Inclusive** — a household already paid this program year is still shown as eligible.
+   - Source: 13 CSR 40-19.020(4) — not more than one EA benefit per eligible household `during any LIHEAP fiscal year` — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+   - Source: LIHEAP Policy and Procedure Manual, Ineligible Individuals-Households — `Members that have already been approved and received EA` or individuals moving into a household that has already received EA in the current program year at the same address — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+9. **The excess-income crisis exception**
+   - **Why**: Missouri re-computes income, excluding a terminated income stream, for a household that is over the limit but in a documented crisis where a member's income has stopped entirely. The screener collects neither the service-termination status nor the income-termination date that Missouri's exception also requires, so the exception cannot be reproduced in full.
+   - **Handling**: treated inclusively. MFB records no income period (see criterion 1's income-timing note), and its questions ask what a household receives now, so a fully terminated stream is typically not reported and therefore not counted — which lands where Missouri's exception lands. The outcome is not guaranteed, because nothing prevents a household from reporting an ended stream. The additional crisis and service-termination conditions are not verified, which only widens the result in the applicant's favour.
+   - Source: LIHEAP Policy and Procedure Manual, `Excess Income-Crisis Situation` — all conditions must be met: prior-month income causes ineligibility, the household is documented in crisis with service threatened or terminated, and the member no longer has any income — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+10. **Zero-income households must explain how they manage**
+    - **Why**: where every member aged 18 or over reported no income for the prior month, Missouri contacts the applicant and denies the application if the household cannot explain how it manages. The screener collects no such explanation.
+    - **Handling**: assumed satisfied. **Inclusive** — a zero-income household is shown as eligible.
+    - Source: LIHEAP Policy and Procedure Manual, Zero Income — if the applicant cannot `adequately explain management of this household, deny the` application — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+## Priority Criteria
+
+- Households including a member aged 60 or older, or a member with a disability, may apply from October 1; all other households apply from November 1. This changes when a household may apply, never whether it qualifies.
+  - Captured: description text — the program description states the early October application period for households with someone 60 or older or with a disability.
+  - Missouri's regulatory definition of disability is narrower than the screener's self-reported one (see Deduction 2); the same inclusive direction applies here.
+  - Source: FFY2026 Model State Plan §2.3, which files this under its priority questions — `Older Adults (60 years or older)?` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+  - Source: LIHEAP Policy and Procedure Manual, Early Application Period — `For households with a person who is disabled or age 60 or older` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+  - Source: FFY2026 application, revision MO 886-4576 (9-2025) — `Send your application on or after October 1, 2025` — [snapshot `2026-08-20--modss-liheap-application-form`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-application-form/content.md), accessed 2026-08-20
+  - Source: LIHEAP Policy and Procedure Manual, Early Application Period — `all other households from November 1` – May 31 — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+
+## Related Programs
+
+- **Energy Crisis Intervention Program (ECIP)** — a separate crisis benefit with its own trigger, at the same 60% SMI threshold. Not modelled by this spec.
+  - Winter maximum $800, summer maximum $300.
+  - The manual opens the winter component on November 1 for elderly and disabled households and December 1 for all others; the application states the applicant-facing window as November 1 – May 31.
+  - Renter households whose heating is included in rent may receive EA but not ECIP.
+  - Source: MyDSS LIHEAP page — `Helps pay your energy bill when you have a` termination or disconnect notice indicating a specific disconnect date — [snapshot `2026-08-20--modss-liheap-overview`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-overview/content.md), accessed 2026-08-20
+  - Source: FFY2026 application, revision MO 886-4576 (9-2025) — `Up to $800 November 1 through May` 31 and `Up to $300 June 1 through September` 30 — [snapshot `2026-08-20--modss-liheap-application-form`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-application-form/content.md), accessed 2026-08-20
+  - Source: FFY2026 Model State Plan §2.3 — utilities-included renters receive a one-time payment and `The clients are also not eligible for ECIP benefits.` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+  - Source: FFY2026 Model State Plan §4.1, crisis component — `All Household Sizes                                   State Median Income                                                        60.00%` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+- **Weatherization assistance** — home energy conservation services on a different income threshold entirely (200% FPL). Not modelled by this spec.
+  - Source: FFY2026 Model State Plan §5.1 — `All Household Sizes                               HHS Poverty Guidelines                                                200.00%` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+  - Source: LIHEAP Clearinghouse, Missouri profile — `Weatherization: 200% Federal Poverty Guidelines` — [snapshot `2026-08-20--liheap-clearinghouse-missouri-profile`](../../../sources/mo/mo_liheap/2026-08-20--liheap-clearinghouse-missouri-profile/content.md), accessed 2026-08-20
+
+## Benefit Value
+
+- **Value: $153 one-time estimated value.** MFB's conservative flat estimate, set at Missouri's published minimum Energy Assistance benefit — the estimate for the households this spec models.
+  - Not offered as a floor for the unmodelled renter pathway below: those awards are computed from rent and capped, and no captured source establishes whether the $153 component minimum applies to them.
+  - Not a guaranteed floor for modelled households generally either: Missouri's CARS recoupment (below) can reduce a household's actual current-year payment, including to $0, independent of this estimate.
+- **`value_format`: `lump_sum`.** 13 CSR 40-19.020(3)(A) itself describes the Energy Assistance award as a `direct one (1) time lump sum payment`, matching the config. Missouri may add a supplemental payment in a year when it receives additional funding; that is contingent and not modelled.
+- **Variation axes: none modelled.** Missouri varies the award by household size, income range and fuel type, and pays utilities-included renters on a share-of-rent formula instead; MFB models none of these and returns $153 for every eligible household.
+- **Outstanding EA claim (CARS recoupment) — data gap.** Missouri checks an approved household's Social Security numbers against its Claims and Restitution System (CARS) for an outstanding prior EA claim and reduces the calculated EA benefit by the amount of that claim; if the claim equals or exceeds the benefit, the household's EA payment displays as $0.00. The screener collects no CARS claim balance.
+  - **Committed handling**: assume no outstanding claim and return the standard $153 estimate. No scenario models this, because the claim balance is not observable in the current screener.
+  - Source: LIHEAP Policy and Procedure Manual, Claims and Restitution — `If a CARS claim is outstanding and the application is determined eligible for EA, the calculated EA benefit will be reduced by the amount of the claim` and `If the CARS amount is equal to or greater than the EA benefit, the "EA Benefits" field will display $0.00` — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+- Source: FFY2026 Model State Plan §2.6 — `Minimum Benefit                              $153                            Maximum Benefit                                $495` — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+- Source: FFY2026 application, revision MO 886-4576 (9-2025), Program Description — `Below is the maximum payment amount your household can` receive, listing `Natural Gas                     $326`, `Tank Propane                     $495`, `Electric                      $318`, `Fuel Oil                      $326`, `Wood                         $219`, `Kerosene                       $153`, `Cylinder Propane                  $177` — [snapshot `2026-08-20--modss-liheap-application-form`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-application-form/content.md), accessed 2026-08-20
+- Source: FFY2026 Model State Plan §2.3, renter payment (not modelled) — `Clients receive a one-time direct payment equal to 16% of their annual rent, not to exceed` the maximum allowed EA benefit — [snapshot `2026-08-20--mo-liheap-model-state-plan-ffy2026`](../../../sources/mo/mo_liheap/2026-08-20--mo-liheap-model-state-plan-ffy2026/content.md), accessed 2026-08-20
+- Source: LIHEAP Policy and Procedure Manual, Renter Household Payment (not modelled) — a `direct cash payment equal to 16% of their annual rent not to exceed the maximum` EA benefit payment — [snapshot `2026-08-20--modss-liheap-policy-procedure-manual`](../../../sources/mo/mo_liheap/2026-08-20--modss-liheap-policy-procedure-manual/content.md), accessed 2026-08-20
+- Source: 13 CSR 40-19.020(13), the same payment stated as a ceiling (not modelled) — no `more than eight percent (8%) of their annual` rental charge — [snapshot `2026-08-20--13-csr-40-19-020`](../../../sources/mo/mo_liheap/2026-08-20--13-csr-40-19-020/content.md), accessed 2026-08-20
+- **Justification for $153**:
+  - Missouri's actual Energy Assistance award ranges from $153 to $495 and varies by income, household size and fuel type. The seven per-fuel figures Missouri publishes are maximum amounts, not the amounts every household receives, and the current payment matrix that sets the award within those maxima is not published. The MFB screener also collects no primary heating fuel, so the household's fuel row cannot be identified.
+  - This spec therefore commits to $153 — Missouri's published minimum benefit — as a deliberate conservative estimate, rather than an average that would overstate the award for households receiving less than the maximum. $153 is not a claim that Missouri pays every eligible household $153, and (per the CARS note above) it is not a guaranteed payment either.
+  - 13 CSR 40-19.020(14) does publish a fuel-type × income-band matrix with values as low as $45, but its figures predate and contradict the current $153–$495 range, so it is not used to reconstruct an award.
+  - **Renter payment (not modelled).** A separate award applies where heating is included in the rent — a share of annual rent rather than a fuel-based amount. Whether the $153 component minimum also applies to it is not established by anything captured here: the screener records no utilities-included tenancy, and inferring one from a rent expense with no itemised utility expense would misclassify ordinary renters.
+    - **Source conflict — size of the renter payment, unresolved, no scenario commits to either reading.** The model plan and manual both state a one-time payment equal to 16% of annual rent, not to exceed the maximum EA benefit; 13 CSR 40-19.020(13) states the same payment as a ceiling of no more than 8% of annual rental charge.
+
+## Test Scenarios
+
+**Coverage map**
+
+| Rule / variation axis | Scenarios |
+|---|---|
+| Income at or below 60% SMI | pass: 1; boundary: 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 |
+| Limit table, size 1 | boundary: 2, 3, 4, 8, 10, 13, 17, 22 |
+| Limit table, size 2 | boundary: 6, 7, 11, 12, 16, 18, 20, 21, 23 |
+| Limit table, size 4 | boundary: 15 |
+| Limit table, size 7 | boundary: 9 |
+| Limit table, size 8 | boundary: 14, 19 |
+| Deduction 1 — 20% earned income | boundary: 4 (rate not smaller), 22 (rate not larger); not applied to unearned: 3 |
+| Deduction 2 — $100, age 65 threshold | boundary: 6 (granted at exactly 65), 18 (denied at 64) |
+| Deduction 2 — disability branch | boundary: 10 |
+| Deduction 2 — once per household | boundary: 11 |
+| Deduction 2 — spouse qualifies | boundary: 21 |
+| Deduction 2 — non-spouse member does not qualify | boundary: 12 |
+| Deduction 3 — child support paid | boundary: 8 |
+| Deduction 4 — $202.90 per Medicare member | boundary: 7 |
+| Exclusion — earned income under 18 | boundary: 16 (17, excluded), 20 (18, counted) |
+| Minor's SSA income still counts | boundary: 23 |
+| Exclusion — interest and dividend income | boundary: 17 |
+| Income frequency conversion | boundary: 13 |
+| Energy-cost responsibility — rent + heating (golden path) | pass: 1 |
+| Energy-cost responsibility — heating | pass: 2, 6, 7, 13, 21 |
+| Energy-cost responsibility — none | fail: 5 |
+| Missouri residency | platform-enforced at ZIP/county intake; no core scenario |
+| Applicant age (member 15 or older) | fail: 24 |
+| Benefit value | every eligible scenario: $153 (CARS recoupment not modelled — data gap) |
+
+**Known scenario gaps**
+
+- Criterion 3 (citizenship) is config-scope and can't be varied by any scenario — the screener collects no per-member immigration status.
+- Data gap 1 (the $3,000 resource limit) has no dedicated scenario, because MFB cannot calculate Missouri's countable resources.
+- Data gaps 2–8 and 10 are unscreenable and unverified by scenario: Missouri's household definition, the ineligible living situations, the $500 credit balance, self-supplied wood, individuals excluded from the household count, the narrow income exclusions inside countable types, prior-year EA receipt, and zero-income explanation.
+- Data gap 9's substance is covered by ordinary income collection, not a dedicated scenario — a household whose income has stopped simply reports nothing to count.
+- The utilities-included renter payment and the 8%-versus-16% conflict have no scenario, because that pathway isn't modelled and the sources are unresolved.
+- The award doesn't vary by fuel type or income band in any scenario, because the value is flat by design.
+- CARS recoupment (Benefit Value) has no scenario, because the outstanding-claim balance isn't observable in the current screener.
+- Two null-handling paths are untested: criterion 1 skips evaluation when `household_size` is null, and criterion 4 treats a null `zipcode` as met.
+- Limit-table rows 3, 5 and 6 have no scenario and rest on the published table as constants.
+- Sizes 9 and 10, and the +$164 increment above 10, are untestable — the current screener caps household size at 8.
+- Criterion 4's own Missouri-ZIP check has no negative scenario, because the live MO screener's ZIP/county intake rejects a non-Missouri ZIP before the calculator runs.
+- Each deduction/exclusion set is exercised through one income type only: `wages` for the earned-income deduction set (`wages`, `selfEmployment`, `boarder`), and `investment` for the interest-and-dividend exclusion set.
+- `mortgage`, `cooling`, and `otherUtilities` are valid inputs to criterion 2 but have no dedicated scenarios; homeowners are covered only through the `heating` scenarios and criterion 2's implementation note.
+- Scenarios 2 and 13 are a deliberate near-pair: both are plain-monthly, at-the-limit controls that isolate a frequency-conversion failure from a boundary failure.
+
+### Scenario 1: Single adult, low income, renter — Eligible, $153
+**What we're checking**: the ordinary eligible path, with a direct heating expense establishing energy-cost responsibility.
+**Expected**: Eligible — $153 (earned $1,000 × 0.80 = $800 ≤ $2,840)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, earned income $1,000/month
+* Expenses: rent $600/month, heating $150/month
+**Why this matters**: confirms the base eligible path and the flat $153 value. The heating expense makes criterion 2 directly observable, not just inferred from the rent proxy.
+
+---
+
+### Scenario 2: Household of 1 exactly at the income limit — Eligible, $153
+**What we're checking**: the income boundary is inclusive at the limit.
+**Expected**: Eligible — $153 (unearned $2,840 = limit $2,840; no deductions apply)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $2,840/month
+* Expenses: heating $150/month
+**Why this matters**: confirms the income limit is inclusive — exactly at the limit is eligible.
+
+---
+
+### Scenario 3: Household of 1 one dollar over the limit — Ineligible
+**What we're checking**: the income boundary excludes above the limit, and the 20% deduction is not applied to unearned income.
+**Expected**: Ineligible (unearned $2,841 exceeds the size-1 limit of $2,840)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $2,841/month
+* Expenses: heating $150/month
+**Why this matters**: confirms the income limit excludes anything above it, pins the size-1 limit at exactly $2,840, and confirms the 20% deduction does not apply to unearned income — applying it here would wrongly give $2,272.80 and flip this to eligible.
+
+---
+
+### Scenario 4: Earned income at the limit after the 20% deduction — Eligible, $153
+**What we're checking**: the earned-income deduction rate.
+**Expected**: Eligible — $153 ($3,550 × 0.80 = $2,840.00 = size-1 limit $2,840)
+**Steps**:
+* Location: ZIP `64108`, county `Jackson County`
+* Person 1: born March 1986 (age 40), head of household, earned income $3,550/month
+* Expenses: rent $700/month, heating $50/month
+**Why this matters**: confirms the earned-income deduction rate is exactly 20% — a smaller rate (19% → $2,875.50) or no deduction ($3,550) would wrongly exceed the limit. A larger rate wouldn't be caught here, since the household is already at the limit; **scenario 22** covers that direction. Scenario 3 confirms the deduction doesn't apply to unearned income.
+
+---
+
+### Scenario 5: Eligible income but no housing or utility expense — Ineligible
+**What we're checking**: the energy-cost responsibility criterion.
+**Expected**: Ineligible (no rent, mortgage, heating, cooling or other-utilities expense)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, earned income $500/month
+* Expenses: none
+**Why this matters**: confirms the energy-cost responsibility check is enforced — income alone isn't enough.
+
+---
+
+### Scenario 6: Household of 2, head exactly 65, eligible only after the $100 deduction — Eligible, $153
+**What we're checking**: the $100 medical deduction is granted at exactly 65.
+**Expected**: Eligible — $153 ($3,814 − $100 = $3,714 = size-2 limit $3,714)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born August 1961 (age 65 as of 2026-08-20), head of household, unearned (`sSRetirement`) income $3,814/month
+* Person 2: born March 1963 (age 63), spouse, no income
+* Expenses: heating $200/month
+**Why this matters**: confirms the $100 deduction is granted starting in the birth month a member turns 65, not only after a full month has passed. The head reaches 65 in the reference month here (`age_from_date` treats `today.month >= birth.month` as reached); requiring a later date instead would deny the deduction and flip this to ineligible ($3,814 > $3,714). Scenario 18 covers the other side of the threshold.
+
+---
+
+### Scenario 7: Two Medicare members, eligible only after both deductions — Eligible, $153
+**What we're checking**: the Medicare deduction is applied per member, not once per household (the $202.90 constant is an MFB approximation, not verified policy — see Deduction 4).
+**Expected**: Eligible — $153 ($4,219.80 − $100 elderly − $405.80 Medicare (2 × $202.90) = $3,714.00 = size-2 limit $3,714)
+**Steps**:
+* Location: ZIP `64108`, county `Jackson County`
+* Person 1: born March 1959 (age 67), head of household, unearned (`sSRetirement`) income $4,219.80/month, insurance: Medicare
+* Person 2: born March 1958 (age 68), spouse, no income, insurance: Medicare
+* Expenses: heating $180/month
+**Why this matters**: confirms the Medicare deduction applies per member, not once per household — applying it only once would give $3,916.90 > $3,714 and wrongly flip this to ineligible.
+
+---
+
+### Scenario 8: Child support paid, eligible only after the deduction — Eligible, $153
+**What we're checking**: the child-support-paid deduction.
+**Expected**: Eligible — $153 ($3,005 − $165 = $2,840 = size-1 limit $2,840)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $3,005/month
+* Expenses: rent $650/month, heating $50/month, child support $165/month
+**Why this matters**: confirms child support paid is treated as a deduction, not as income, and that omitting it would wrongly flip this to ineligible.
+
+---
+
+### Scenario 9: Household of 7 at the size-7 limit — Eligible, $153
+**What we're checking**: the limit table above household size 6.
+**Expected**: Eligible — $153 (unearned $7,373 = size-7 limit $7,373)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $7,373/month
+* Persons 2–7: children born 2012–2022, no income
+* Expenses: rent $1,200/month, heating $50/month
+**Why this matters**: confirms the limit table extends past size 6 with its own published row ($7,373), rather than clamping at the size-6 row ($7,209, which would wrongly deny this household). This alone can't distinguish a correct size-7 row from a table that just falls through to the +$164 increment rule, since $7,209 + $164 happens to equal $7,373 — and that distinction, along with the increment rule's own $163-vs-$164 discrepancy at size 9→10, can no longer be tested at all, because the live MFB household-size field caps entries at 8.
+
+---
+
+### Scenario 10: Head under 65 with a disability — Eligible, $153
+**What we're checking**: the disability branch of the $100 medical deduction (tests MFB simplification, not verified policy — Missouri's regulatory definition also requires receipt of a qualifying benefit).
+**Expected**: Eligible — $153 ($2,940 − $100 = $2,840 = size-1 limit $2,840)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1976 (age 50), head of household, has a long-term disability, unearned (pension) income $2,940/month
+* Expenses: rent $700/month, heating $50/month
+**Why this matters**: confirms the disability branch of the $100 deduction — removing it would wrongly flip this to ineligible.
+
+---
+
+### Scenario 11: Two members aged 65 or older, one deduction only — Ineligible
+**What we're checking**: the $100 deduction is granted once per household, not per qualifying member.
+**Expected**: Ineligible ($3,914 − $100 = $3,814 exceeds the size-2 limit of $3,714)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1961 (age 65), head of household, unearned (pension) income $3,914/month
+* Person 2: born March 1959 (age 67), spouse, no income
+* Expenses: heating $200/month
+**Why this matters**: confirms the $100 deduction is applied once per household, not once per qualifying member — applying it twice would give $3,714 = the limit and wrongly flip this to eligible.
+
+---
+
+### Scenario 12: Qualifying age in a non-spouse member — Ineligible
+**What we're checking**: the $100 deduction applies only to the applicant or spouse.
+**Expected**: Ineligible (no deduction; unearned $3,800 exceeds the size-2 limit of $3,714)
+**Steps**:
+* Location: ZIP `64108`, county `Jackson County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $3,800/month
+* Person 2: born March 1956 (age 70), parent of the head, no income
+* Expenses: rent $800/month, heating $50/month
+**Why this matters**: confirms the $100 deduction is restricted to the applicant or spouse — extending it to any qualifying member would give $3,700 ≤ $3,714 and wrongly flip this to eligible.
+
+---
+
+### Scenario 13: Income reported yearly, at the monthly limit — Eligible, $153
+**What we're checking**: income frequency is normalised to monthly before comparison.
+**Expected**: Eligible — $153 (unearned $34,080/year ÷ 12 = $2,840.00/month = size-1 limit $2,840)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $34,080/year
+* Expenses: heating $150/month
+**Why this matters**: confirms yearly income is converted to monthly before the limit check. Every other scenario states income monthly, so this is the only one that catches a frequency-conversion error.
+
+---
+
+### Scenario 14: Household of 8 at the size-8 limit — Eligible, $153
+**What we're checking**: the size-8 row of the limit table — the highest household size the live MFB household-size field can enter.
+**Expected**: Eligible — $153 (unearned $7,537 = size-8 limit $7,537)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $7,537/month
+* Persons 2–8: children born 2008–2022, no income
+* Expenses: rent $1,300/month, heating $50/month
+**Why this matters**: confirms the size-8 row of the limit table — the largest household size the live screener allows. Sizes 9 and 10, and the +$164 increment beyond 10, can't be entered through the live screener and so aren't tested by any scenario.
+
+---
+
+### Scenario 15: Household of 4 at the size-4 limit — Eligible, $153
+**What we're checking**: a mid-table row of the limit table.
+**Expected**: Eligible — $153 (unearned $5,461 = size-4 limit $5,461)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $5,461/month
+* Person 2: born March 1988 (age 38), spouse, no income
+* Persons 3–4: children born 2015 and 2018, no income
+* Expenses: rent $1,100/month, heating $50/month
+**Why this matters**: confirms a mid-table row (size 4) of the limit table.
+
+---
+
+### Scenario 16: Household with a working 17-year-old — Eligible, $153
+**What we're checking**: earned income of a household member under 18 is excluded, at the boundary.
+**Expected**: Eligible — $153 (head unearned $3,714 = size-2 limit $3,714; the 17-year-old's $500 earned income is excluded)
+**Steps**:
+* Location: ZIP `64108`, county `Jackson County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $3,714/month
+* Person 2: born March 2009 (age 17), child, earned income $500/month
+* Expenses: rent $900/month, heating $50/month
+**Why this matters**: confirms earned income of a 17-year-old is excluded — counting it (even after the 20% deduction, adding $400) would give $4,114 > $3,714 and wrongly flip this to ineligible.
+
+---
+
+### Scenario 17: Household with investment income — Eligible, $153
+**What we're checking**: interest and dividend income is excluded.
+**Expected**: Eligible — $153 (unearned pension $2,840 = size-1 limit $2,840; $300 investment income excluded)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $2,840/month, investment income $300/month
+* Expenses: rent $700/month, heating $50/month
+**Why this matters**: confirms investment income is excluded — counting it would give $3,140 > $2,840 and wrongly flip this to ineligible.
+
+---
+
+### Scenario 18: Head aged 64, no medical deduction — Ineligible
+**What we're checking**: the $100 deduction is denied below 65.
+**Expected**: Ineligible (no deduction; unearned $3,814 exceeds the size-2 limit of $3,714)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1962 (age 64), head of household, unearned (`sSRetirement`) income $3,814/month
+* Person 2: born March 1964 (age 62), spouse, no income
+* Expenses: heating $200/month
+**Why this matters**: confirms the $100 deduction is denied below 65. The likeliest confusion is with age 60, which Missouri uses for the early-application period, not this deduction — using 60 here would give $3,714 = the limit and wrongly flip this to eligible.
+
+---
+
+### Scenario 19: Household of 8 one dollar over the size-8 limit — Ineligible
+**What we're checking**: the size-8 boundary excludes above the limit, at the highest household size the live screener can enter.
+**Expected**: Ineligible (unearned $7,538 exceeds the size-8 limit of $7,537)
+**Steps**:
+* Location: ZIP `65201`, county `Boone County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $7,538/month
+* Persons 2–8: children born 2008–2022, no income
+* Expenses: rent $1,300/month, heating $50/month
+**Why this matters**: confirms the size-8 limit excludes anything above it. Paired with scenario 14, this pins the top-of-table boundary the current MFB screener can actually reach.
+
+---
+
+### Scenario 20: Household with a working 18-year-old — Ineligible
+**What we're checking**: earned income of a member aged 18 is counted.
+**Expected**: Ineligible (head unearned $3,714 + the 18-year-old's $500 × 0.80 = $400, giving $4,114 > size-2 limit $3,714)
+**Steps**:
+* Location: ZIP `64108`, county `Jackson County`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $3,714/month
+* Person 2: born March 2008 (age 18), child, earned income $500/month
+* Expenses: rent $900/month, heating $50/month
+**Why this matters**: confirms earned income of an 18-year-old is counted, not excluded — excluding it would give $3,714 = the limit and wrongly flip this to eligible. With scenario 16, this pins the under-18 exclusion at exactly 18.
+
+---
+
+### Scenario 21: Qualifying age in the spouse, not the head — Eligible, $153
+**What we're checking**: the $100 deduction is granted when the *spouse* qualifies, not only the applicant.
+**Expected**: Eligible — $153 ($3,814 − $100 = $3,714 = size-2 limit $3,714)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, unearned (pension) income $3,814/month
+* Person 2: born March 1960 (age 66), spouse, no income
+* Expenses: heating $200/month
+**Why this matters**: confirms the $100 deduction is granted when the spouse qualifies, not only the head — restricting it to the head would give $3,814 > $3,714 and wrongly flip this to ineligible. Scenario 12 proves a non-spouse member does *not* qualify; this proves a spouse does.
+
+---
+
+### Scenario 22: Earned income one dollar past the deduction boundary — Ineligible
+**What we're checking**: the earned-income deduction rate is not larger than 20%.
+**Expected**: Ineligible ($3,551 × 0.80 = $2,840.80, which exceeds the size-1 limit of $2,840)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 1986 (age 40), head of household, earned income $3,551/month
+* Expenses: rent $700/month, heating $50/month
+**Why this matters**: confirms the earned-income deduction rate is not larger than 20%. A too-generous rate would pass every other scenario undetected — at 30% the countable figure is $2,485.70, comfortably under the limit — so this is the only scenario that catches it.
+
+---
+
+### Scenario 23: Minor with SSA income — Ineligible
+**What we're checking**: the under-18 exclusion covers earned income only; a minor's SSA income still counts.
+**Expected**: Ineligible (head unearned $3,714 + the 17-year-old's $100 SSI = $3,814, which exceeds the size-2 limit of $3,714)
+**Steps**:
+* Location: ZIP `64108`, county `Jackson County`
+* Person 1: born March 1986 (age 40), head of household, unearned (`sSRetirement`) income $3,714/month
+* Person 2: born March 2009 (age 17), child, unearned (`sSI`) income $100/month
+* Expenses: rent $900/month, heating $50/month
+**Why this matters**: confirms the under-18 income exclusion covers earned income only — excluding all income (including SSA) would give $3,714 = the limit and wrongly flip this to eligible. Scenario 16 pins the earned side of the same rule.
+
+---
+
+### Scenario 24: No household member aged 15 or older — Ineligible
+**What we're checking**: the applicant-age criterion.
+**Expected**: Ineligible (oldest member is 14; Missouri denies an application from an applicant under 15)
+**Steps**:
+* Location: ZIP `63101`, county `St. Louis City`
+* Person 1: born March 2012 (age 14), head of household, earned income $400/month
+* Person 2: born March 2016 (age 10), `sisterOrBrother`, no income
+* Expenses: rent $500/month, heating $50/month
+**Why this matters**: income and expenses both qualify, so this fails only on the applicant-age rule — dropping that criterion would wrongly flip it to eligible.
+
+---
+
+## Research Sources
+
+| Snapshot | Tier | Fidelity | Title | URL | Retrieved |
+|---|---|---|---|---|---|
+| `2026-08-20--13-csr-40-19-020` | 1 | raw | 13 CSR 40-19 — Missouri FSD energy assistance rules (incl. 40-19.020 LIHEAP and Utilicare) | https://www.sos.mo.gov/cmsimages/adrules/csr/current/13csr/13c40-19.pdf | 2026-08-20 |
+| `2026-08-20--42-usc-8624` | 1 | raw | 42 U.S.C. 8624 — LIHEAP applications and requirements | https://www.law.cornell.edu/uscode/text/42/8624 | 2026-08-20 |
+| `2026-08-20--acf-liheap-im-1998-25-federal-public-benefits` | 1 | rendered | LIHEAP IM 1998-25 — Interpretation of 'Federal Public Benefits' Under the Welfare Reform Law (ACF/OCS) | https://acf.gov/ocs/policy-guidance/liheap-im-1998-25-interpretation-federal-public-benefits-under-welfare-reform | 2026-08-20 |
+| `2026-08-20--mo-liheap-model-state-plan-ffy2026` | 2 | raw | Missouri LIHEAP Model State Plan, FFY2026 (active) | https://dss.mo.gov/fsd/energy-assistance/pdf/liheap-active-ffy2026.pdf | 2026-08-20 |
+| `2026-08-20--mo-liheap-model-state-plan-ffy2027` | 2 | raw | Missouri LIHEAP Model State Plan, FFY2027 (draft) | https://dss.mo.gov/fsd/energy-assistance/pdf/liheap-active-ffy2027.pdf | 2026-08-20 |
+| `2026-08-20--modss-liheap-policy-procedure-manual` | 2 | raw | The Low-Income Home Energy Assistance Program (LIHEAP) Policy and Procedure Manual — MO DSS FSD | https://dss.mo.gov/fsd/energy-assistance/pdf/liheap-policy-procedure-manual.pdf | 2026-08-20 |
+| `2026-08-20--modss-liheap-application-form` | 2 | raw | LIHEAP application (Financial Assistance for Home Energy Costs) — MO DSS FSD | https://dssmanuals.mo.gov/wp-content/uploads/2022/02/liheap-application.pdf | 2026-08-20 |
+| `2026-08-20--modss-liheap-overview` | 2 | raw | Low Income Home Energy Assistance Program (LIHEAP) — Missouri DSS | https://mydss.mo.gov/utility-assistance/liheap | 2026-08-20 |
+| `2026-08-20--modss-benefit-program-income-limits` | 2 | raw | Benefit Program Income Limits — Missouri DSS (MyDSS) | https://mydss.mo.gov/benefit-program-income-limits | 2026-08-20 |
+| `2026-08-20--modss-2026-fpl-chart-all-programs` | 2 | raw | 2026 FPL Chart for all Programs (rev. 3-31-26) — Missouri DSS | https://mydss.mo.gov/sites/mydss/files/media/pdf/2026/03/2026%20FPL%20Chart%20for%20all%20Programs_3-31-26_AOD.pdf | 2026-08-20 |
+| `2026-08-20--modss-benefit-program-limit-chart` | 2 | raw | Benefit Program Limit Chart — Missouri DSS | https://mydss.mo.gov/media/pdf/benefit-program-limit-chart | 2026-08-20 |
+| `2026-08-20--modss-liheap-state-plan-index` | 2 | raw | Missouri FFY LIHEAP Model State Plan index — MO DSS FSD | https://dss.mo.gov/fsd/energy-assistance/state-plan-liheap-lihwap-ffy.htm | 2026-08-20 |
+| `2026-08-20--modss-liheap-information-sheet` | 2 | raw | LIHEAP information sheet — MO DSS FSD | https://dss.mo.gov/fsd/energy-assistance/pdf/liheap-information.pdf | 2026-08-20 |
+| `2026-08-20--cms-medicare-premium-rates-cy2026` | 2 | raw | Medicare Deductible, Coinsurance & Premium Rates: CY 2026 Update (MM14279) — CMS | https://www.cms.gov/files/document/mm14279-medicare-deductible-coinsurance-premium-rates-cy-2026-update.pdf | 2026-08-20 |
+| `2026-08-20--liheap-clearinghouse-missouri-profile` | 3 | rendered | Missouri — LIHEAP Clearinghouse state profile (ACF) | https://liheapch.acf.gov/profiles/Missouri.htm | 2026-08-20 |
+| `2026-08-20--wcmcaa-energy-assistance` | 3 | raw | Low Income Home Energy Assistance Program (LIHEAP) — West Central Missouri Community Action Agency | https://wcmcaa.org/ea/ | 2026-08-20 |

--- a/programs/programs/cross_white_label/liheap/specs/mo.md
+++ b/programs/programs/cross_white_label/liheap/specs/mo.md
@@ -1,10 +1,10 @@
 # Low Income Home Energy Assistance Program (LIHEAP) (MO) — Program Spec
 
-- **Program key**: `mo_liheap` (proposed — `programs/programs/cross_white_label/liheap/mo.py`, class `MoLiheap`)
+- **Program key**: `mo_liheap` (`programs/programs/cross_white_label/liheap/mo.py`, class `MoLiheap`)
 - **Base federal program**: LIHEAP (`base_program: "liheap"`)
 - **White label**: MO
 - **Engine**: MFB custom
-- **Added to MFB**: not implemented
+- **Added to MFB**: implemented
 - **Spec last updated**: 2026-08-21
 - **Sources verified as of**: 2026-08-21
 

--- a/programs/programs/cross_white_label/liheap/tests/test_mo.py
+++ b/programs/programs/cross_white_label/liheap/tests/test_mo.py
@@ -1,0 +1,732 @@
+"""
+Unit tests for the MoLiheap calculator.
+
+Coverage maps to ``specs/mo.md`` — its five Covered Eligibility Criteria, its four
+deductions and two income exclusions, its Benefit Value section, and one test per
+entry in its 24-scenario Test Scenarios list.
+
+These are built on real ``Screen`` / ``HouseholdMember`` / ``IncomeStream`` /
+``Expense`` / ``Insurance`` rows rather than mocks. Nearly every rule here is a
+question about income-type filtering (``calc_gross_income`` with ``exclude``, the
+``all`` aggregation, monthly-vs-yearly conversion) or about an accessor
+(``calc_age``, ``is_head``, ``is_spouse``, ``has_disability``,
+``has_insurance``), so a mock standing in for those would be asserting the mock's
+own semantics rather than the calculator's.
+
+Ages are fixed integers derived against the spec's reference year, 2026 — a
+``birth_year_month`` would make every age a function of ``timezone.now()`` and
+break the suite on a calendar boundary. Scenario 6's claim is specifically about
+``age_from_date`` granting 65 during the birth month, so that one test does set
+``birth_year_month`` and pins the reference date to the spec's 2026-08-20.
+
+Not tested here, because the calculator does not implement them (see the class
+docstring):
+- Criterion 3 (citizenship) — the program's ``legal_status_required`` config.
+- Criterion 4 (Missouri residency) — enforced at the screener's ZIP step, which
+  rejects a non-Missouri ZIP before any calculator runs.
+- The $3,000 resource limit, primary heating fuel, CARS recoupment, and the
+  utilities-included renter payment — all unscreenable, all recorded as data gaps.
+
+Every eligible household is worth a flat $153.
+"""
+
+from datetime import date
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from programs.framework.base import Eligibility, ProgramCalculator
+from programs.framework.registry import build
+from programs.models import Program
+from programs.programs.cross_white_label.liheap.mo import MoLiheap
+from programs.programs.testing_fixtures.pe_integration import (
+    add_income,
+    add_member,
+    make_program,
+    make_screen,
+)
+from screener.models import Expense, Insurance, Screen
+
+YEAR = "2026"
+VALUE = 153
+
+
+class MoLiheapTestCase(TestCase):
+    """Household builder shared by every test below."""
+
+    # Distinct ids per household keep the members of one screen from colliding
+    # with another's when a test builds more than one.
+    next_screen_id = 1
+
+    def build(self, household_size, zipcode="63101", county="St. Louis City"):
+        screen = make_screen(
+            self.next_screen_id,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=household_size,
+            zipcode=zipcode,
+            county=county,
+        )
+        # Reused rather than recreated: a test that builds more than one
+        # household (every subTest loop below) would otherwise collide on the
+        # program row's unique (white_label, name_abbreviated).
+        existing = Program.objects.filter(white_label=screen.white_label, name_abbreviated="mo_liheap").first()
+        self.program = existing or make_program("mo", "mo_liheap", YEAR)
+        self.member_id = self.next_screen_id * 100
+        MoLiheapTestCase.next_screen_id += 1
+        return screen
+
+    def add_person(self, screen, relationship, birth_year, **kwargs):
+        """A member stated by the birth year the scenario gives, as a fixed age
+        against 2026 — see the module docstring on why the age is not derived
+        from a birth date."""
+        self.member_id += 1
+        return add_member(screen, self.member_id, relationship, int(YEAR) - birth_year, **kwargs)
+
+    def add_expense(self, screen, expense_type, monthly_amount):
+        return Expense.objects.create(
+            screen=screen,
+            type=expense_type,
+            amount=monthly_amount,
+            frequency="monthly",
+        )
+
+    def calculator(self, screen):
+        return MoLiheap(screen, self.program, {}, screen.missing_fields())
+
+    def household_eligible(self, screen):
+        e = Eligibility()
+        self.calculator(screen).household_eligible(e)
+        return e
+
+
+class TestMoLiheapClassAttributes(MoLiheapTestCase):
+    def test_is_subclass_of_program_calculator(self):
+        self.assertTrue(issubclass(MoLiheap, ProgramCalculator))
+
+    def test_registered_under_mo_liheap(self):
+        self.assertIs(build("programs.programs", ProgramCalculator).get("mo_liheap"), MoLiheap)
+
+    def test_amount_is_153_lump_sum(self):
+        self.assertEqual(MoLiheap.amount, VALUE)
+
+    def test_income_limit_table_matches_published_60_percent_smi(self):
+        self.assertEqual(
+            MoLiheap.income_limits,
+            {
+                1: 2_840,
+                2: 3_714,
+                3: 4_588,
+                4: 5_461,
+                5: 6_335,
+                6: 7_209,
+                7: 7_373,
+                8: 7_537,
+                9: 7_701,
+                10: 7_864,
+            },
+        )
+
+    def test_income_limit_increment_is_164(self):
+        # The MyDSS page's own note says $163, but its table and the FFY2026
+        # application both increment by $164 — see specs/mo.md Criterion 1.
+        self.assertEqual(MoLiheap.income_limit_increment, 164)
+
+    def test_earned_income_deduction_is_20_percent(self):
+        self.assertEqual(MoLiheap.earned_income_deduction, 0.20)
+
+    def test_earned_income_types_include_boarder(self):
+        self.assertEqual(set(MoLiheap.earned_income_types), {"wages", "selfEmployment", "boarder"})
+
+    def test_excluded_income_types_are_interest_and_dividend(self):
+        self.assertEqual(set(MoLiheap.excluded_income_types), {"investment", "deferredComp"})
+
+    def test_medical_deduction_is_100_at_65(self):
+        self.assertEqual(MoLiheap.medical_deduction, 100)
+        self.assertEqual(MoLiheap.medical_deduction_min_age, 65)
+
+    def test_medicare_premium_is_cms_2026_part_b_standard(self):
+        self.assertEqual(MoLiheap.medicare_premium, 202.90)
+
+    def test_min_applicant_age_is_15(self):
+        self.assertEqual(MoLiheap.min_applicant_age, 15)
+
+    def test_energy_expense_types(self):
+        self.assertEqual(
+            set(MoLiheap.expenses),
+            {"rent", "mortgage", "heating", "cooling", "otherUtilities"},
+        )
+
+    def test_income_fields_in_dependencies(self):
+        self.assertIn("income_amount", MoLiheap.dependencies)
+        self.assertIn("income_frequency", MoLiheap.dependencies)
+        self.assertIn("household_size", MoLiheap.dependencies)
+
+
+class TestMoLiheapIncomeLimit(MoLiheapTestCase):
+    """Criterion 1's limit table, including the rows and the increment the live
+    screener's ``.lte(8)`` household-size cap makes unreachable."""
+
+    def limit_for(self, household_size):
+        screen = self.build(household_size)
+        return self.calculator(screen)._income_limit()
+
+    def test_every_published_row(self):
+        for household_size, expected in MoLiheap.income_limits.items():
+            with self.subTest(household_size=household_size):
+                self.assertEqual(self.limit_for(household_size), expected)
+
+    def test_size_above_table_adds_the_increment(self):
+        self.assertEqual(self.limit_for(11), 7_864 + 164)
+        self.assertEqual(self.limit_for(13), 7_864 + 3 * 164)
+
+    def test_size_7_is_its_own_row_not_a_clamp_at_size_6(self):
+        self.assertNotEqual(self.limit_for(7), self.limit_for(6))
+
+    def test_null_household_size_falls_back_to_the_size_1_row(self):
+        # Unreachable in production: household_size is a declared dependency, so
+        # can_calc() drops the program first. Pinned so the guard stays honest.
+        screen = self.build(1)
+        screen.household_size = None
+        self.assertEqual(self.calculator(screen)._income_limit(), 2_840)
+
+
+class TestMoLiheapEnergyCostResponsibility(MoLiheapTestCase):
+    """Criterion 2 — a housing or utility expense stands in for responsibility."""
+
+    def screen_with_expense(self, expense_type=None):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1986)
+        if expense_type is not None:
+            self.add_expense(screen, expense_type, 100)
+        return screen
+
+    def test_each_qualifying_expense_type_passes(self):
+        for expense_type in MoLiheap.expenses:
+            with self.subTest(expense_type=expense_type):
+                self.assertTrue(self.household_eligible(self.screen_with_expense(expense_type)).eligible)
+
+    def test_no_expense_at_all_fails(self):
+        self.assertFalse(self.household_eligible(self.screen_with_expense()).eligible)
+
+    def test_a_non_energy_expense_does_not_qualify(self):
+        self.assertFalse(self.household_eligible(self.screen_with_expense("childCare")).eligible)
+
+
+class TestMoLiheapApplicantAge(MoLiheapTestCase):
+    """Criterion 5 — the household needs a member aged 15 or older."""
+
+    def screen_with_oldest(self, birth_year):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", birth_year)
+        self.add_expense(screen, "heating", 100)
+        return screen
+
+    def test_exactly_15_passes(self):
+        self.assertTrue(self.household_eligible(self.screen_with_oldest(2011)).eligible)
+
+    def test_14_fails(self):
+        self.assertFalse(self.household_eligible(self.screen_with_oldest(2012)).eligible)
+
+    def test_a_qualifying_member_need_not_be_the_head(self):
+        screen = self.build(2)
+        self.add_person(screen, "headOfHousehold", 2012)  # 14
+        self.add_person(screen, "sisterOrBrother", 2010)  # 16
+        self.add_expense(screen, "heating", 100)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_unknown_age_does_not_satisfy_the_criterion(self):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1986)
+        screen.household_members.update(age=None)
+        self.add_expense(screen, "heating", 100)
+        self.assertFalse(self.household_eligible(screen).eligible)
+
+    def test_fail_message_included(self):
+        self.assertTrue(len(self.household_eligible(self.screen_with_oldest(2012)).fail_messages) > 0)
+
+
+class TestMoLiheapMedicalDeduction(MoLiheapTestCase):
+    """Deduction 2 — $100, applicant or spouse only, once per household."""
+
+    def applies(self, screen):
+        return self.calculator(screen)._medical_deduction_applies()
+
+    def test_head_at_65_qualifies(self):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1961)  # 65
+        self.assertTrue(self.applies(screen))
+
+    def test_head_at_64_does_not_qualify(self):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1962)  # 64
+        self.assertFalse(self.applies(screen))
+
+    def test_spouse_at_65_qualifies(self):
+        screen = self.build(2)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "spouse", 1960)  # 66
+        self.assertTrue(self.applies(screen))
+
+    def test_domestic_partner_counts_as_spouse(self):
+        screen = self.build(2)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "domesticPartner", 1960)  # 66
+        self.assertTrue(self.applies(screen))
+
+    def test_a_qualifying_parent_does_not_earn_the_deduction(self):
+        screen = self.build(2)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "parent", 1956)  # 70
+        self.assertFalse(self.applies(screen))
+
+    def test_each_disability_flag_qualifies_the_head(self):
+        for flag in ("disabled", "visually_impaired", "long_term_disability"):
+            with self.subTest(flag=flag):
+                screen = self.build(1)
+                self.add_person(screen, "headOfHousehold", 1976, **{flag: True})
+                self.assertTrue(self.applies(screen))
+
+    def test_a_disabled_non_spouse_does_not_earn_the_deduction(self):
+        screen = self.build(2)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "child", 2010, disabled=True)
+        self.assertFalse(self.applies(screen))
+
+    def test_neither_elderly_nor_disabled(self):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.assertFalse(self.applies(screen))
+
+    def test_head_turning_65_during_the_birth_month_qualifies(self):
+        # Scenario 6's claim: MFB treats a member as 65 throughout their birth
+        # month, so a head born August 1961 has the deduction on 2026-08-20.
+        # Missouri requires the birthday to have passed, which is the inclusive
+        # direction — see specs/mo.md Deduction 2.
+        screen = self.build(1)
+        member = self.add_person(screen, "headOfHousehold", 1986)
+        member.age = None
+        member.birth_year_month = date(1961, 8, 1)
+        member.save()
+
+        with patch.object(Screen, "get_reference_date", return_value=date(2026, 8, 20)):
+            self.assertTrue(self.applies(screen))
+
+    def test_head_whose_birth_month_has_not_arrived_does_not_qualify(self):
+        screen = self.build(1)
+        member = self.add_person(screen, "headOfHousehold", 1986)
+        member.age = None
+        member.birth_year_month = date(1961, 9, 1)
+        member.save()
+
+        with patch.object(Screen, "get_reference_date", return_value=date(2026, 8, 20)):
+            self.assertFalse(self.applies(screen))
+
+
+class TestMoLiheapMedicareDeduction(MoLiheapTestCase):
+    """Deduction 4 — $202.90 per Medicare-covered member."""
+
+    def count(self, screen):
+        return self.calculator(screen)._medicare_member_count()
+
+    def test_counts_each_medicare_member(self):
+        screen = self.build(3)
+        for birth_year in (1959, 1958, 1986):
+            member = self.add_person(screen, "headOfHousehold" if birth_year == 1959 else "spouse", birth_year)
+            Insurance.objects.create(household_member=member, none=False, medicare=birth_year != 1986)
+        self.assertEqual(self.count(screen), 2)
+
+    def test_a_member_with_no_insurance_row_is_not_counted(self):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1959)
+        self.assertEqual(self.count(screen), 0)
+
+    def test_other_insurance_types_are_not_counted(self):
+        screen = self.build(1)
+        member = self.add_person(screen, "headOfHousehold", 1959)
+        Insurance.objects.create(household_member=member, none=False, medicaid=True, private=True)
+        self.assertEqual(self.count(screen), 0)
+
+
+class TestMoLiheapCountableIncome(MoLiheapTestCase):
+    """Criterion 1's exclusions and deductions, read off the countable figure
+    directly rather than through an eligibility boundary."""
+
+    def countable(self, screen):
+        return self.calculator(screen)._countable_income()
+
+    def test_gross_unearned_income_is_counted_whole(self):
+        screen = self.build(1)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 1_000, "pension")
+        self.assertEqual(self.countable(screen), 1_000)
+
+    def test_each_earned_income_type_takes_the_20_percent_deduction(self):
+        for income_type in MoLiheap.earned_income_types:
+            with self.subTest(income_type=income_type):
+                screen = self.build(1)
+                head = self.add_person(screen, "headOfHousehold", 1986)
+                add_income(head, 1_000, income_type)
+                self.assertEqual(self.countable(screen), 800)
+
+    def test_each_interest_and_dividend_type_is_excluded(self):
+        for income_type in MoLiheap.excluded_income_types:
+            with self.subTest(income_type=income_type):
+                screen = self.build(1)
+                head = self.add_person(screen, "headOfHousehold", 1986)
+                add_income(head, 1_000, "pension")
+                add_income(head, 300, income_type)
+                self.assertEqual(self.countable(screen), 1_000)
+
+    def test_gifts_cash_assistance_and_veteran_income_are_counted(self):
+        # An earlier draft excluded all three; the manual documents each as
+        # countable — see specs/mo.md data gap 7.
+        for income_type in ("gifts", "cashAssistance", "veteran"):
+            with self.subTest(income_type=income_type):
+                screen = self.build(1)
+                head = self.add_person(screen, "headOfHousehold", 1986)
+                add_income(head, 500, income_type)
+                self.assertEqual(self.countable(screen), 500)
+
+    def test_a_minors_earned_income_is_excluded_and_takes_no_deduction(self):
+        screen = self.build(2)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        child = self.add_person(screen, "child", 2009)  # 17
+        add_income(head, 1_000, "pension")
+        add_income(child, 500, "wages")
+        self.assertEqual(self.countable(screen), 1_000)
+
+    def test_a_minors_ssa_income_is_counted(self):
+        for income_type in ("sSI", "sSDisability"):
+            with self.subTest(income_type=income_type):
+                screen = self.build(2)
+                head = self.add_person(screen, "headOfHousehold", 1986)
+                child = self.add_person(screen, "child", 2009)  # 17
+                add_income(head, 1_000, "pension")
+                add_income(child, 100, income_type)
+                self.assertEqual(self.countable(screen), 1_100)
+
+    def test_a_member_of_unknown_age_is_treated_as_an_adult(self):
+        screen = self.build(2)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        child = self.add_person(screen, "child", 2009)
+        add_income(head, 1_000, "pension")
+        add_income(child, 500, "wages")
+        screen.household_members.filter(id=child.id).update(age=None)
+        # $500 earned, counted with the 20% deduction rather than excluded.
+        self.assertEqual(self.countable(screen), 1_400)
+
+    def test_child_support_paid_is_deducted(self):
+        screen = self.build(1)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 1_000, "pension")
+        self.add_expense(screen, "childSupport", 165)
+        self.assertEqual(self.countable(screen), 835)
+
+    def test_child_support_received_as_income_is_counted_not_deducted(self):
+        screen = self.build(1)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 1_000, "childSupport")
+        self.assertEqual(self.countable(screen), 1_000)
+
+    def test_the_medical_deduction_is_taken_once_for_two_qualifying_members(self):
+        screen = self.build(2)
+        head = self.add_person(screen, "headOfHousehold", 1961)  # 65
+        self.add_person(screen, "spouse", 1959)  # 67
+        add_income(head, 1_000, "pension")
+        self.assertEqual(self.countable(screen), 900)
+
+    def test_deductions_cannot_drive_the_figure_below_zero(self):
+        screen = self.build(1)
+        head = self.add_person(screen, "headOfHousehold", 1961)  # 65
+        add_income(head, 50, "pension")
+        self.assertEqual(self.countable(screen), 0)
+
+    def test_yearly_income_is_converted_to_monthly(self):
+        screen = self.build(1)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 34_080, "pension", frequency="yearly")
+        self.assertEqual(self.countable(screen), 2_840)
+
+    def test_all_four_deductions_stack(self):
+        screen = self.build(2)
+        head = self.add_person(screen, "headOfHousehold", 1959)  # 67
+        spouse = self.add_person(screen, "spouse", 1958)  # 68
+        add_income(head, 1_000, "wages")
+        add_income(head, 2_000, "pension")
+        Insurance.objects.create(household_member=head, none=False, medicare=True)
+        Insurance.objects.create(household_member=spouse, none=False, medicare=True)
+        self.add_expense(screen, "childSupport", 50)
+        # 3,000 gross - 200 earned - 100 medical - 50 child support - 405.80 Medicare
+        self.assertEqual(self.countable(screen), 2_244.20)
+
+
+class TestMoLiheapValue(MoLiheapTestCase):
+    def test_household_value_is_153(self):
+        screen = self.build(1)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.assertEqual(self.calculator(screen).household_value(), VALUE)
+
+    def test_ineligible_household_is_worth_nothing(self):
+        screen = self.build(1)
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 10_000, "pension")
+        self.add_expense(screen, "heating", 100)
+        eligibility = self.calculator(screen).calc()
+        self.assertFalse(eligibility.eligible)
+        self.assertEqual(eligibility.value, 0)
+
+    def test_no_member_value_is_added(self):
+        screen = self.build(3)
+        self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "spouse", 1988)
+        self.add_person(screen, "child", 2015)
+        self.add_expense(screen, "heating", 100)
+        eligibility = self.calculator(screen).calc()
+        self.assertTrue(eligibility.eligible)
+        # Flat per household — three members must not multiply it.
+        self.assertEqual(eligibility.value, VALUE)
+
+
+class TestMoLiheapScenarios(MoLiheapTestCase):
+    """One test per Test Scenario in specs/mo.md, run end to end through calc().
+
+    Scenario ZIP/county pairs are recorded as the spec states them even though
+    Criterion 4 is enforced at intake rather than here.
+    """
+
+    def assert_eligible(self, screen):
+        eligibility = self.calculator(screen).calc()
+        self.assertTrue(eligibility.eligible, eligibility.fail_messages)
+        self.assertEqual(eligibility.value, VALUE)
+
+    def assert_ineligible(self, screen):
+        eligibility = self.calculator(screen).calc()
+        self.assertFalse(eligibility.eligible)
+        self.assertEqual(eligibility.value, 0)
+
+    def test_scenario_1_single_adult_low_income_renter(self):
+        screen = self.build(1, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 1_000, "wages")
+        self.add_expense(screen, "rent", 600)
+        self.add_expense(screen, "heating", 150)
+        # 1,000 x 0.80 = 800 <= 2,840
+        self.assert_eligible(screen)
+
+    def test_scenario_2_household_of_1_exactly_at_the_limit(self):
+        screen = self.build(1, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 2_840, "pension")
+        self.add_expense(screen, "heating", 150)
+        self.assert_eligible(screen)
+
+    def test_scenario_3_household_of_1_one_dollar_over_the_limit(self):
+        screen = self.build(1, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 2_841, "pension")
+        self.add_expense(screen, "heating", 150)
+        # Also pins the 20% deduction to earned income only: applying it here
+        # would give 2,272.80 and wrongly flip this to eligible.
+        self.assert_ineligible(screen)
+
+    def test_scenario_4_earned_income_at_the_limit_after_the_deduction(self):
+        screen = self.build(1, zipcode="64108", county="Jackson County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 3_550, "wages")
+        self.add_expense(screen, "rent", 700)
+        self.add_expense(screen, "heating", 50)
+        # 3,550 x 0.80 = 2,840.00 = the size-1 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_5_eligible_income_but_no_housing_or_utility_expense(self):
+        screen = self.build(1, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 500, "wages")
+        self.assert_ineligible(screen)
+
+    def test_scenario_6_head_exactly_65_eligible_only_after_the_100_deduction(self):
+        screen = self.build(2, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1961)  # 65
+        self.add_person(screen, "spouse", 1963)  # 63
+        add_income(head, 3_814, "sSRetirement")
+        self.add_expense(screen, "heating", 200)
+        # 3,814 - 100 = 3,714 = the size-2 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_7_two_medicare_members_eligible_only_after_both_deductions(self):
+        screen = self.build(2, zipcode="64108", county="Jackson County")
+        head = self.add_person(screen, "headOfHousehold", 1959)  # 67
+        spouse = self.add_person(screen, "spouse", 1958)  # 68
+        add_income(head, 4_219.80, "sSRetirement")
+        Insurance.objects.create(household_member=head, none=False, medicare=True)
+        Insurance.objects.create(household_member=spouse, none=False, medicare=True)
+        self.add_expense(screen, "heating", 180)
+        # 4,219.80 - 100 - 405.80 (2 x 202.90) = 3,714.00 = the size-2 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_8_child_support_paid_eligible_only_after_the_deduction(self):
+        screen = self.build(1, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 3_005, "pension")
+        self.add_expense(screen, "rent", 650)
+        self.add_expense(screen, "heating", 50)
+        self.add_expense(screen, "childSupport", 165)
+        # 3,005 - 165 = 2,840 = the size-1 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_9_household_of_7_at_the_size_7_limit(self):
+        screen = self.build(7, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        for birth_year in (2012, 2014, 2016, 2018, 2020, 2022):
+            self.add_person(screen, "child", birth_year)
+        add_income(head, 7_373, "pension")
+        self.add_expense(screen, "rent", 1_200)
+        self.add_expense(screen, "heating", 50)
+        self.assert_eligible(screen)
+
+    def test_scenario_10_head_under_65_with_a_disability(self):
+        screen = self.build(1, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1976, long_term_disability=True)  # 50
+        add_income(head, 2_940, "pension")
+        self.add_expense(screen, "rent", 700)
+        self.add_expense(screen, "heating", 50)
+        # 2,940 - 100 = 2,840 = the size-1 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_11_two_members_65_or_older_one_deduction_only(self):
+        screen = self.build(2, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1961)  # 65
+        self.add_person(screen, "spouse", 1959)  # 67
+        add_income(head, 3_914, "pension")
+        self.add_expense(screen, "heating", 200)
+        # 3,914 - 100 = 3,814 > 3,714; a second deduction would wrongly admit it
+        self.assert_ineligible(screen)
+
+    def test_scenario_12_qualifying_age_in_a_non_spouse_member(self):
+        screen = self.build(2, zipcode="64108", county="Jackson County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "parent", 1956)  # 70
+        add_income(head, 3_800, "pension")
+        self.add_expense(screen, "rent", 800)
+        self.add_expense(screen, "heating", 50)
+        self.assert_ineligible(screen)
+
+    def test_scenario_13_income_reported_yearly_at_the_monthly_limit(self):
+        screen = self.build(1, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 34_080, "pension", frequency="yearly")
+        self.add_expense(screen, "heating", 150)
+        # 34,080 / 12 = 2,840.00 = the size-1 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_14_household_of_8_at_the_size_8_limit(self):
+        screen = self.build(8, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        for birth_year in (2008, 2010, 2012, 2014, 2016, 2018, 2022):
+            self.add_person(screen, "child", birth_year)
+        add_income(head, 7_537, "pension")
+        self.add_expense(screen, "rent", 1_300)
+        self.add_expense(screen, "heating", 50)
+        self.assert_eligible(screen)
+
+    def test_scenario_15_household_of_4_at_the_size_4_limit(self):
+        screen = self.build(4, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "spouse", 1988)
+        self.add_person(screen, "child", 2015)
+        self.add_person(screen, "child", 2018)
+        add_income(head, 5_461, "pension")
+        self.add_expense(screen, "rent", 1_100)
+        self.add_expense(screen, "heating", 50)
+        self.assert_eligible(screen)
+
+    def test_scenario_16_household_with_a_working_17_year_old(self):
+        screen = self.build(2, zipcode="64108", county="Jackson County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        child = self.add_person(screen, "child", 2009)  # 17
+        add_income(head, 3_714, "pension")
+        add_income(child, 500, "wages")
+        self.add_expense(screen, "rent", 900)
+        self.add_expense(screen, "heating", 50)
+        # The 17-year-old's earned income is excluded outright
+        self.assert_eligible(screen)
+
+    def test_scenario_17_household_with_investment_income(self):
+        screen = self.build(1, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 2_840, "pension")
+        add_income(head, 300, "investment")
+        self.add_expense(screen, "rent", 700)
+        self.add_expense(screen, "heating", 50)
+        self.assert_eligible(screen)
+
+    def test_scenario_18_head_aged_64_no_medical_deduction(self):
+        screen = self.build(2, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1962)  # 64
+        self.add_person(screen, "spouse", 1964)  # 62
+        add_income(head, 3_814, "sSRetirement")
+        self.add_expense(screen, "heating", 200)
+        # Using 60 (Missouri's early-application age) would wrongly admit this
+        self.assert_ineligible(screen)
+
+    def test_scenario_19_household_of_8_one_dollar_over_the_size_8_limit(self):
+        screen = self.build(8, zipcode="65201", county="Boone County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        for birth_year in (2008, 2010, 2012, 2014, 2016, 2018, 2022):
+            self.add_person(screen, "child", birth_year)
+        add_income(head, 7_538, "pension")
+        self.add_expense(screen, "rent", 1_300)
+        self.add_expense(screen, "heating", 50)
+        self.assert_ineligible(screen)
+
+    def test_scenario_20_household_with_a_working_18_year_old(self):
+        screen = self.build(2, zipcode="64108", county="Jackson County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        child = self.add_person(screen, "child", 2008)  # 18
+        add_income(head, 3_714, "pension")
+        add_income(child, 500, "wages")
+        self.add_expense(screen, "rent", 900)
+        self.add_expense(screen, "heating", 50)
+        # 3,714 + 500 x 0.80 = 4,114 > 3,714
+        self.assert_ineligible(screen)
+
+    def test_scenario_21_qualifying_age_in_the_spouse_not_the_head(self):
+        screen = self.build(2, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        self.add_person(screen, "spouse", 1960)  # 66
+        add_income(head, 3_814, "pension")
+        self.add_expense(screen, "heating", 200)
+        # 3,814 - 100 = 3,714 = the size-2 limit
+        self.assert_eligible(screen)
+
+    def test_scenario_22_earned_income_one_dollar_past_the_deduction_boundary(self):
+        screen = self.build(1, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        add_income(head, 3_551, "wages")
+        self.add_expense(screen, "rent", 700)
+        self.add_expense(screen, "heating", 50)
+        # 3,551 x 0.80 = 2,840.80 > 2,840 — the only scenario that catches a
+        # deduction rate larger than 20%
+        self.assert_ineligible(screen)
+
+    def test_scenario_23_minor_with_ssa_income(self):
+        screen = self.build(2, zipcode="64108", county="Jackson County")
+        head = self.add_person(screen, "headOfHousehold", 1986)
+        child = self.add_person(screen, "child", 2009)  # 17
+        add_income(head, 3_714, "sSRetirement")
+        add_income(child, 100, "sSI")
+        self.add_expense(screen, "rent", 900)
+        self.add_expense(screen, "heating", 50)
+        # 3,714 + 100 = 3,814 > 3,714 — the under-18 exclusion is earned only
+        self.assert_ineligible(screen)
+
+    def test_scenario_24_no_household_member_aged_15_or_older(self):
+        screen = self.build(2, zipcode="63101", county="St. Louis City")
+        head = self.add_person(screen, "headOfHousehold", 2012)  # 14
+        self.add_person(screen, "sisterOrBrother", 2016)  # 10
+        add_income(head, 400, "wages")
+        self.add_expense(screen, "rent", 500)
+        self.add_expense(screen, "heating", 50)
+        # Income and expenses both qualify; this fails only on applicant age
+        self.assert_ineligible(screen)


### PR DESCRIPTION
## Context & Motivation

Missouri launch needs LIHEAP (Energy Assistance) on the MO screener. PolicyEngine has no `gov/states/mo` energy module, so this is an MFB custom calculator built from the MFB-1222 discovery artifacts.

- Linear: [MFB-1222](https://linear.app/myfriendben/issue/MFB-1222/program-mo-low-income-home-energy-assistance-program-liheap) (Discovery: [MFB-1283](https://linear.app/myfriendben/issue/MFB-1283/discovery-mo-low-income-home-energy-assistance-program-liheap), Done)
- Related PR: none

## Changes Made

- **`programs/programs/cross_white_label/liheap/mo.py`** — new `MoLiheap` calculator, joining the existing LIHEAP family (`ks`, `tx`, `wa`, `il`, `co`, `ma`, `nc`, `cesn`). Picked up automatically by `programs/framework/registry.py` via `program_code = "mo_liheap"`, so no `__init__.py` edit.
  - **Criterion 1** — countable monthly income at or below **60% SMI**, carried as Missouri's published dollar table (sizes 1–10, +$164 per member beyond 10) rather than an FPL multiple. Missouri elected the SMI standard; the 13 CSR 40-19.020(14) FPL bands are stale (spec resolves the conflict).
  - Two income exclusions: earned income of a member under 18 (their SSA income still counts), and interest/dividend income (`investment`, `deferredComp`).
  - Four deductions: 20% of earned income (`wages`, `selfEmployment`, `boarder` — Missouri's definition includes roomer-boarder), $100 once per household where the **head or spouse** is 65+ or has a disability, child support paid out of the household, and $202.90 per Medicare-covered member.
  - **Criterion 2** — energy-cost responsibility, inferred from a `rent`/`mortgage`/`heating`/`cooling`/`otherUtilities` expense (the `ks_lieap` / `nc_lieap` proxy; the screener has no account-holder field).
  - **Criterion 5** — at least one member aged 15 or older (Missouri denies an under-15 applicant outright).
  - **Value** — flat `$153` `lump_sum`.
- **`programs/programs/cross_white_label/liheap/tests/test_mo.py`** — 78 tests. One per spec scenario plus unit coverage of every criterion, deduction, exclusion, and limit-table row.
- **`programs/programs/cross_white_label/liheap/specs/mo.md`** — the discovery spec, with its header updated from "proposed" to "implemented".
- **`programs/management/commands/import_program_config_data/data/mo_liheap_initial_config.json`** — the discovery config, with two deliberate edits called out under Notes for Reviewers.

## Testing

- **Migrations to run:** none.
- **Configuration updates needed:** `python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_liheap_initial_config.json`. The config carries `"active": true`, so the row imports enabled — no separate activation step. Add `--skip-translation` locally if `GOOGLE_APPLICATION_CREDENTIALS` is unavailable.
- **Environment variables/settings to add:** none.
- **Manual testing steps:**
  1. `venv/bin/python manage.py test programs.programs.cross_white_label.liheap.tests.test_mo --no-input` → 78 passing.
  2. Run the import above, then confirm the row: `active=True`, `has_calculator=True`, `value_format=lump_sum`, `base_program=liheap`, category `mo_housing`, 5 legal statuses, 1 warning message (`_show`), 4 documents, 2 navigators (`mo_211`, `mo_liheap_fsd_help`).
  3. Screener spot-check — MO, ZIP 63101, single head aged 40, $1,000/month wages, rent $600 + heating $150 → eligible, $153. ($1,000 × 0.80 = $800 ≤ the $2,840 size-1 limit.)

Full-suite state: `manage.py test programs` → 2908 tests, 75 errors, **all pre-existing** `PolicyEngineAPIError` (expired PE token plus a pinned version, 1.786.5, the API no longer serves). They are confined to PE-backed programs (`mo_wftc`, `mo_pts`, `mo_tanf`, the PE integration harness); one was reproduced on the base commit to confirm. Nothing in this PR touches PolicyEngine.

## Deployment

- **Post-deployment scripts needed:** run `import_program_config` for `mo_liheap_initial_config.json` on staging, then on production.
- **Production config updates:** none beyond that import. `"active": true` means the program goes live the moment it lands, so sequence the prod import for when MO LIHEAP should be visible.
- **Admin updates needed:** none. Worth knowing: `--reconcile` is additive-only and cannot change program fields, so any later correction to `active`, `value_format`, or a description needs `--override` or an admin edit.
- **Notify team/users of:** the $153 figure is Missouri's published **minimum**, not a typical award (see below) — worth flagging to whoever fields questions about displayed amounts.

## Notes for Reviewers

Three judgment calls, all following the spec and the `ks_lieap` precedent:

1. **Rounding, not truncation.** `_countable_income()` rounds to cents where `ks_lieap` casts to `int`. Truncating would wrongly admit spec scenario 22: $3,551 earned → $2,840.80 after the 20% deduction, against a $2,840 limit.
2. **MO residency is left platform-enforced.** The MO screener gates its ZIP step on `MoConfigurationData.counties_by_zipcode`, so a non-Missouri ZIP never reaches a calculator. The spec's own Criterion 4 records this as platform-enforced and untestable; re-checking it here would be dead code.
3. **Real DB rows in the tests, not mocks** — unlike the other four LIHEAP test modules. Nearly every rule here turns on `calc_gross_income`'s `exclude` handling or on an accessor (`calc_age`, `is_spouse`, `has_insurance`), so a mock would assert its own semantics rather than the calculator's.

Two edits to the discovery config, neither silent:

- **Added `"active": true`.** Omitting it imports the program disabled.
- **Gave `mo_211` its full field set.** The artifact referenced it by `external_name` alone, which only imports where the navigator already exists — `mo_cdcc_federal` creates it, so the bare reference worked in environments that ran that config first and failed on a clean database. Where the row is already present the importer leaves it untouched.

**Known limitations** (all sourced and deliberate in the spec, none a gap in this PR):

- **$153 is a floor, not a typical award.** Real awards run $153–$495 by fuel type and income band, and CARS recoupment can reduce an actual payment to $0. The screener collects no heating fuel, and the matrix that sets an award within the published per-fuel maxima is not published — so the spec commits to the minimum rather than a median that would overstate it. This is the item most likely to draw a question.
- **Not modelled:** the $3,000 resource limit (`Screen.household_assets` is not Missouri's countable figure in either direction — it omits CDs/IRAs/Keoghs and includes funds Missouri exempts, so applying it would exclude households Missouri accepts; surfaced in the program description instead), primary heating fuel, CARS recoupment, and the utilities-included renter payment (whose size the sources dispute, 16% vs. 8% of annual rent).
- **Household sizes 9–10 and the +$164 increment are unreachable** through the live screener, which caps household size at 8. The table rows are implemented and unit-tested, but no end-to-end scenario can exercise them.
- **`show_in_has_benefits_step: false`** is correct today — nothing in the codebase reads LIHEAP receipt and MO has no weatherization program for it to gate.

**Future considerations:**

- Federal WAP rules treat LIHEAP receipt as categorical income eligibility, and our `wa_wap` calculator already omits that link. If a MO weatherization program is added, revisit `show_in_has_benefits_step` here and the categorical list there.
- Annual re-verification: the $153 minimum, the 60% SMI table (MyDSS publishes an explicit "As of" date), and the $202.90 CMS Part B premium all move each program year.
- The spec's source citations are relative links to snapshot files (`../../../sources/mo/mo_liheap/...`) that don't exist in the repo, and no other spec uses that convention. Left verbatim so the quoted citation text survives; happy to strip them if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
