### PR TITLE
Add MO Food Assistance (SNAP) — mo_snap

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_snap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_snap_initial_config.json
@@ -1,0 +1,94 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_food",
+    "name": "Food and Nutrition",
+    "icon": "food"
+  },
+  "program": {
+    "name_abbreviated": "mo_snap",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_under18_no5",
+      "refugee"
+    ],
+    "name": "Food Assistance (SNAP)",
+    "description_short": "Monthly food benefits loaded onto an EBT card for low-income households",
+    "description": "Food Assistance is Missouri's name for the federal Supplemental Nutrition Assistance Program (SNAP). It helps low-income households buy food each month. The amount you get depends on your household's size, income, and certain expenses like rent, utilities, and child care.\n\nEach month your benefits load onto a Missouri EBT card, which works like a debit card. You can use it at grocery stores, farmers markets, and many online retailers. If you get Food Assistance, your children automatically qualify for free school meals, and you may also qualify for discounted internet and utility help.\n\nMissouri counts a few things in your favor that not every state does: child support you pay is subtracted from your income, and if you are self-employed your actual business expenses are deducted. Households with someone 60 or older, or with a disability, do not have to meet the gross income test and can deduct medical costs.\n\nAdults without children may need to work or train a set number of hours to keep benefits past three months, though many people are exempt. To apply, submit an application through myDSS, by mail, or at a Family Support Division Resource Center. You will have a phone or in-person interview after you apply. Most households hear back within 30 days; if your income and money on hand are very low, you may get benefits within 7 days.",
+    "learn_more_link": "https://mydss.mo.gov/food-assistance",
+    "apply_button_link": "https://mydss.mo.gov/food-assistance/apply-for-snap",
+    "apply_button_description": "",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "30 days",
+    "estimated_value": "",
+    "value_format": null,
+    "website_description": "Monthly food benefits loaded onto an EBT card for low-income households",
+    "base_program": "snap",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": true,
+    "active": true
+  },
+  "documents": [
+    {
+      "external_name": "mo_snap_photo_id",
+      "text": "Government-issued photo ID for the person applying (e.g. driver's license, state ID)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_snap_citizenship_status",
+      "text": "Proof of citizenship or immigration status for each household member applying (e.g. birth certificate, passport, immigration documents)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_snap_ssn",
+      "text": "Social Security Number for each household member applying",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_snap_proof_address",
+      "text": "Proof of your Missouri address (e.g. lease, utility bill, or mail with your name and address)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_snap_proof_income",
+      "text": "Proof of income for everyone in the household (e.g. recent pay stubs, award letters, or self-employment records)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_snap_proof_expenses",
+      "text": "Proof of monthly expenses that raise your benefit (e.g. rent or mortgage, utility bills, child care, child support you pay, and medical costs if someone is 60+ or has a disability)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_snap_proof_assets",
+      "text": "Recent bank statements and proof of any other resources (e.g. stocks, bonds, or a second vehicle)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "usda_national_hunger_hotline",
+      "name": "USDA National Hunger Hotline",
+      "email": "",
+      "description": "A federal hotline staffed to help callers with school meal applications and other food assistance programs. Live representatives are available Monday–Friday, 7am–10pm ET, with Spanish-language support. You can also text for automated help.",
+      "assistance_link": "https://www.fna.usda.gov/national-hunger-hotline",
+      "phone_number": "+18663486479",
+      "languages": [
+        "English",
+        "Spanish"
+      ]
+    }
+  ]
+}

--- a/programs/programs/cross_white_label/snap/mo.py
+++ b/programs/programs/cross_white_label/snap/mo.py
@@ -1,0 +1,36 @@
+"""MO SNAP."""
+
+from programs.programs.cross_white_label.snap.base import Snap
+import programs.framework.pe_dependencies as dependency
+
+
+class MoSnap(Snap):
+    """
+    Missouri Food Assistance (SNAP).
+
+    PolicyEngine's federal SNAP calculator carries eligibility and the benefit amount.
+    Missouri's variance is entirely state-keyed parameters inside that tree, so the state
+    code is the only input this class adds — the same shape as the other seven states.
+
+    What the state code turns on, and why none of it is ours to compute:
+
+    - Child-support gross-income exclusion, elected (2021-10-01+). Feeds ``snap_gross_income``,
+      so it moves the gross-income test. ``SnapChildSupportDependency`` on the base already
+      sends the amount it reads.
+    - Expense-based self-employment deduction, with the simplified deduction rate at 0%.
+      Changes net self-employment income, so it moves the net-income test.
+    - No BBCE. Missouri did not adopt broad-based categorical eligibility, so the ordinary
+      gross/net/asset tests apply rather than a categorical bypass. Absence of an election is
+      still keyed off the state code.
+    - State utility allowances (SUA/LUA/IUA), the $135 standard medical deduction for
+      elderly/disabled households, and the homeless standard shelter deduction. All three
+      feed the excess-shelter deduction and the benefit amount; the base already sends the
+      expense inputs each one reads.
+    """
+
+    program_code = "mo_snap"
+
+    pe_inputs = [
+        *Snap.pe_inputs,
+        dependency.household.MoStateCodeDependency,
+    ]

--- a/programs/programs/cross_white_label/snap/tests/cassettes/TestMoSnapResolves.test_single_parent_two_children_under_the_income_limit.yaml
+++ b/programs/programs/cross_white_label/snap/tests/cassettes/TestMoSnapResolves.test_single_parent_two_children_under_the_income_limit.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"child_support_expense": {"2026": 0.0},
+      "real_estate_taxes": {"2026": 0}, "age": {"2026": 34}, "other_medical_expenses":
+      {"2026": 0}, "is_disabled": {"2026": null}, "ssi": {"2026": null}, "receives_ssi":
+      {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "social_security_disability":
+      {"2026": 0.0}, "meets_ssi_disability_criteria": {"2026": null}, "is_full_time_college_student":
+      {"2026": false}, "is_part_time_college_student": {"2026": false}, "meets_snap_work_exception":
+      {"2026": false}, "is_snap_employment_training_or_work_incentive_student": {"2026":
+      false}}, "2": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
+      {"2026": 0}, "age": {"2026": 7}, "other_medical_expenses": {"2026": 0}, "is_disabled":
+      {"2026": null}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
+      {"2026": null}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
+      {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2026": false}}, "3": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
+      {"2026": 0}, "age": {"2026": 4}, "other_medical_expenses": {"2026": 0}, "is_disabled":
+      {"2026": null}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
+      {"2026": null}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
+      {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2026": false}}}, "tax_units": {"main_tax_unit": {"members": ["1", "2", "3"]}},
+      "families": {"family": {"members": ["1", "2", "3"]}}, "households": {"household":
+      {"members": ["1", "2", "3"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit":
+      {"members": ["1", "2", "3"], "snap_unearned_income": {"2026": 0.0}, "snap_earned_income":
+      {"2026": 18000.0}, "snap_assets": {"2026": 0}, "tanf": {"2026": null}, "receives_tanf":
+      {"2026": false}, "takes_up_tanf_if_eligible": {"2026": false}, "receives_snap":
+      {"2026": false}, "takes_up_snap_if_eligible": {"2026": false}, "snap_emergency_allotment":
+      {"2026": 0}, "housing_cost": {"2026": 0}, "has_phone_expense": {"2026": false},
+      "has_heating_cooling_expense": {"2026": false}, "heating_cooling_expense": {"2026":
+      0.0}, "childcare_expenses": {"2026": 0.0}, "water_expense": {"2026": 0.0}, "phone_expense":
+      {"2026": 0.0}, "homeowners_association_fees": {"2026": 0.0}, "homeowners_insurance":
+      {"2026": 0.0}, "snap_if_takes_up": {"2026-01": null}}}, "marital_units": {}},
+      "version": "1.794.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2800'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"child_support_expense":
+        {"2026": 0.0}, "real_estate_taxes": {"2026": 0}, "age": {"2026": 34}, "other_medical_expenses":
+        {"2026": 0}, "is_disabled": {"2026": false}, "ssi": {"2026": 0.0}, "receives_ssi":
+        {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "social_security_disability":
+        {"2026": 0.0}, "meets_ssi_disability_criteria": {"2026": false}, "is_full_time_college_student":
+        {"2026": false}, "is_part_time_college_student": {"2026": false}, "meets_snap_work_exception":
+        {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2026": false}}, "2": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
+        {"2026": 0}, "age": {"2026": 7}, "other_medical_expenses": {"2026": 0}, "is_disabled":
+        {"2026": false}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
+        {"2026": false}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
+        {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2026": false}}, "3": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
+        {"2026": 0}, "age": {"2026": 4}, "other_medical_expenses": {"2026": 0}, "is_disabled":
+        {"2026": false}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
+        {"2026": false}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
+        {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2026": false}}}, "tax_units": {"main_tax_unit": {"members": ["1", "2", "3"]}},
+        "families": {"family": {"members": ["1", "2", "3"]}}, "households": {"household":
+        {"members": ["1", "2", "3"], "state_code": {"2026": "MO"}}}, "spm_units":
+        {"spm_unit": {"members": ["1", "2", "3"], "snap_unearned_income": {"2026":
+        0.0}, "snap_earned_income": {"2026": 18000.0}, "snap_assets": {"2026": 0},
+        "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+        {"2026": false}, "snap_emergency_allotment": {"2026": 0}, "housing_cost":
+        {"2026": 0}, "has_phone_expense": {"2026": false}, "has_heating_cooling_expense":
+        {"2026": false}, "heating_cooling_expense": {"2026": 0.0}, "childcare_expenses":
+        {"2026": 0.0}, "water_expense": {"2026": 0.0}, "phone_expense": {"2026": 0.0},
+        "homeowners_association_fees": {"2026": 0.0}, "homeowners_insurance": {"2026":
+        0.0}, "snap_if_takes_up": {"2026-01": 487.69998}}}, "marital_units": {}},
+        "policyengine_bundle": {"model_version": "1.794.2", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '2907'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Tue, 25 Aug 2026 09:07:02 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-eab125cea88061011d5fde2d61ad7e74-6b81ac8edbe9491e-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - eab125cea88061011d5fde2d61ad7e74;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 553e1faa-0410-4e44-973f-5f508abef33e
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/snap/tests/cassettes/TestMoSnapResolves.test_single_parent_two_children_under_the_income_limit.yaml
+++ b/programs/programs/cross_white_label/snap/tests/cassettes/TestMoSnapResolves.test_single_parent_two_children_under_the_income_limit.yaml
@@ -7,31 +7,33 @@ interactions:
       {"2026": 0.0}, "meets_ssi_disability_criteria": {"2026": null}, "is_full_time_college_student":
       {"2026": false}, "is_part_time_college_student": {"2026": false}, "meets_snap_work_exception":
       {"2026": false}, "is_snap_employment_training_or_work_incentive_student": {"2026":
-      false}}, "2": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
-      {"2026": 0}, "age": {"2026": 7}, "other_medical_expenses": {"2026": 0}, "is_disabled":
-      {"2026": null}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      false}, "weekly_hours_worked_before_lsr": {"2026": 51.724137931034484}}, "2":
+      {"child_support_expense": {"2026": 0.0}, "real_estate_taxes": {"2026": 0}, "age":
+      {"2026": 7}, "other_medical_expenses": {"2026": 0}, "is_disabled": {"2026":
+      null}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
       {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
       {"2026": null}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
       {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
-      {"2026": false}}, "3": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
-      {"2026": 0}, "age": {"2026": 4}, "other_medical_expenses": {"2026": 0}, "is_disabled":
-      {"2026": null}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
-      {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
-      {"2026": null}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
-      {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
-      {"2026": false}}}, "tax_units": {"main_tax_unit": {"members": ["1", "2", "3"]}},
-      "families": {"family": {"members": ["1", "2", "3"]}}, "households": {"household":
-      {"members": ["1", "2", "3"], "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit":
-      {"members": ["1", "2", "3"], "snap_unearned_income": {"2026": 0.0}, "snap_earned_income":
-      {"2026": 18000.0}, "snap_assets": {"2026": 0}, "tanf": {"2026": null}, "receives_tanf":
-      {"2026": false}, "takes_up_tanf_if_eligible": {"2026": false}, "receives_snap":
-      {"2026": false}, "takes_up_snap_if_eligible": {"2026": false}, "snap_emergency_allotment":
-      {"2026": 0}, "housing_cost": {"2026": 0}, "has_phone_expense": {"2026": false},
-      "has_heating_cooling_expense": {"2026": false}, "heating_cooling_expense": {"2026":
-      0.0}, "childcare_expenses": {"2026": 0.0}, "water_expense": {"2026": 0.0}, "phone_expense":
-      {"2026": 0.0}, "homeowners_association_fees": {"2026": 0.0}, "homeowners_insurance":
-      {"2026": 0.0}, "snap_if_takes_up": {"2026-01": null}}}, "marital_units": {}},
-      "version": "1.815.1"}'
+      {"2026": false}, "weekly_hours_worked_before_lsr": {"2026": 0}}, "3": {"child_support_expense":
+      {"2026": 0.0}, "real_estate_taxes": {"2026": 0}, "age": {"2026": 4}, "other_medical_expenses":
+      {"2026": 0}, "is_disabled": {"2026": null}, "ssi": {"2026": null}, "receives_ssi":
+      {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "social_security_disability":
+      {"2026": 0.0}, "meets_ssi_disability_criteria": {"2026": null}, "is_full_time_college_student":
+      {"2026": false}, "is_part_time_college_student": {"2026": false}, "meets_snap_work_exception":
+      {"2026": false}, "is_snap_employment_training_or_work_incentive_student": {"2026":
+      false}, "weekly_hours_worked_before_lsr": {"2026": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["1", "2", "3"]}}, "families": {"family": {"members": ["1", "2",
+      "3"]}}, "households": {"household": {"members": ["1", "2", "3"], "state_code":
+      {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1", "2", "3"], "snap_unearned_income":
+      {"2026": 0.0}, "snap_earned_income": {"2026": 18000.0}, "snap_assets": {"2026":
+      0}, "tanf": {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+      {"2026": false}, "snap_emergency_allotment": {"2026": 0}, "housing_cost": {"2026":
+      0}, "has_phone_expense": {"2026": false}, "has_heating_cooling_expense": {"2026":
+      false}, "heating_cooling_expense": {"2026": 0.0}, "childcare_expenses": {"2026":
+      0.0}, "water_expense": {"2026": 0.0}, "phone_expense": {"2026": 0.0}, "homeowners_association_fees":
+      {"2026": 0.0}, "homeowners_insurance": {"2026": 0.0}, "snap_if_takes_up": {"2026-01":
+      null}}}, "marital_units": {}}, "version": "1.815.1"}'
     headers:
       Accept:
       - '*/*'
@@ -40,7 +42,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2800'
+      - '2958'
       Content-Type:
       - application/json
       User-Agent:
@@ -56,52 +58,54 @@ interactions:
         {"2026": 0.0}, "meets_ssi_disability_criteria": {"2026": false}, "is_full_time_college_student":
         {"2026": false}, "is_part_time_college_student": {"2026": false}, "meets_snap_work_exception":
         {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
-        {"2026": false}}, "2": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
-        {"2026": 0}, "age": {"2026": 7}, "other_medical_expenses": {"2026": 0}, "is_disabled":
+        {"2026": false}, "weekly_hours_worked_before_lsr": {"2026": 51.724137931034484}},
+        "2": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes": {"2026":
+        0}, "age": {"2026": 7}, "other_medical_expenses": {"2026": 0}, "is_disabled":
         {"2026": false}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
         {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
         {"2026": false}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
         {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
-        {"2026": false}}, "3": {"child_support_expense": {"2026": 0.0}, "real_estate_taxes":
-        {"2026": 0}, "age": {"2026": 4}, "other_medical_expenses": {"2026": 0}, "is_disabled":
-        {"2026": false}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
-        {"2026": false}, "social_security_disability": {"2026": 0.0}, "meets_ssi_disability_criteria":
-        {"2026": false}, "is_full_time_college_student": {"2026": false}, "is_part_time_college_student":
-        {"2026": false}, "meets_snap_work_exception": {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
-        {"2026": false}}}, "tax_units": {"main_tax_unit": {"members": ["1", "2", "3"]}},
-        "families": {"family": {"members": ["1", "2", "3"]}}, "households": {"household":
-        {"members": ["1", "2", "3"], "state_code": {"2026": "MO"}}}, "spm_units":
-        {"spm_unit": {"members": ["1", "2", "3"], "snap_unearned_income": {"2026":
-        0.0}, "snap_earned_income": {"2026": 18000.0}, "snap_assets": {"2026": 0},
-        "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
-        {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
-        {"2026": false}, "snap_emergency_allotment": {"2026": 0}, "housing_cost":
-        {"2026": 0}, "has_phone_expense": {"2026": false}, "has_heating_cooling_expense":
-        {"2026": false}, "heating_cooling_expense": {"2026": 0.0}, "childcare_expenses":
-        {"2026": 0.0}, "water_expense": {"2026": 0.0}, "phone_expense": {"2026": 0.0},
-        "homeowners_association_fees": {"2026": 0.0}, "homeowners_insurance": {"2026":
-        0.0}, "snap_if_takes_up": {"2026-01": 487.69998}}}, "marital_units": {}},
-        "policyengine_bundle": {"model_version": "1.815.1", "data_version": null,
-        "dataset": null}}'
+        {"2026": false}, "weekly_hours_worked_before_lsr": {"2026": 0}}, "3": {"child_support_expense":
+        {"2026": 0.0}, "real_estate_taxes": {"2026": 0}, "age": {"2026": 4}, "other_medical_expenses":
+        {"2026": 0}, "is_disabled": {"2026": false}, "ssi": {"2026": 0.0}, "receives_ssi":
+        {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "social_security_disability":
+        {"2026": 0.0}, "meets_ssi_disability_criteria": {"2026": false}, "is_full_time_college_student":
+        {"2026": false}, "is_part_time_college_student": {"2026": false}, "meets_snap_work_exception":
+        {"2026": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2026": false}, "weekly_hours_worked_before_lsr": {"2026": 0}}}, "tax_units":
+        {"main_tax_unit": {"members": ["1", "2", "3"]}}, "families": {"family": {"members":
+        ["1", "2", "3"]}}, "households": {"household": {"members": ["1", "2", "3"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1",
+        "2", "3"], "snap_unearned_income": {"2026": 0.0}, "snap_earned_income": {"2026":
+        18000.0}, "snap_assets": {"2026": 0}, "tanf": {"2026": 0.0}, "receives_tanf":
+        {"2026": false}, "takes_up_tanf_if_eligible": {"2026": false}, "receives_snap":
+        {"2026": false}, "takes_up_snap_if_eligible": {"2026": false}, "snap_emergency_allotment":
+        {"2026": 0}, "housing_cost": {"2026": 0}, "has_phone_expense": {"2026": false},
+        "has_heating_cooling_expense": {"2026": false}, "heating_cooling_expense":
+        {"2026": 0.0}, "childcare_expenses": {"2026": 0.0}, "water_expense": {"2026":
+        0.0}, "phone_expense": {"2026": 0.0}, "homeowners_association_fees": {"2026":
+        0.0}, "homeowners_insurance": {"2026": 0.0}, "snap_if_takes_up": {"2026-01":
+        487.69998}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.815.1", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
       Content-Length:
-      - '2907'
+      - '3065'
       access-control-allow-origin:
       - '*'
       content-type:
       - application/json
       date:
-      - Wed, 26 Aug 2026 09:22:12 GMT
+      - Wed, 26 Aug 2026 09:39:57 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-b7f7e8bfbc7da0332f22c38c6e4d39a3-47b78f5f68252ded-01
+      - 00-53843e541118dc6d8086153765187d37-404fb48f54800b89-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - b7f7e8bfbc7da0332f22c38c6e4d39a3;o=1
+      - 53843e541118dc6d8086153765187d37;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -109,7 +113,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 0bad94fc-c6d3-4da6-a689-f1170260ae92
+      - 46058642-9eaa-49dd-b2e0-4c2eca8510f6
       x-policyengine-route-channel:
       - frontier
     status:

--- a/programs/programs/cross_white_label/snap/tests/cassettes/TestMoSnapResolves.test_single_parent_two_children_under_the_income_limit.yaml
+++ b/programs/programs/cross_white_label/snap/tests/cassettes/TestMoSnapResolves.test_single_parent_two_children_under_the_income_limit.yaml
@@ -31,7 +31,7 @@ interactions:
       0.0}, "childcare_expenses": {"2026": 0.0}, "water_expense": {"2026": 0.0}, "phone_expense":
       {"2026": 0.0}, "homeowners_association_fees": {"2026": 0.0}, "homeowners_insurance":
       {"2026": 0.0}, "snap_if_takes_up": {"2026-01": null}}}, "marital_units": {}},
-      "version": "1.794.2"}'
+      "version": "1.815.1"}'
     headers:
       Accept:
       - '*/*'
@@ -81,7 +81,7 @@ interactions:
         {"2026": 0.0}, "water_expense": {"2026": 0.0}, "phone_expense": {"2026": 0.0},
         "homeowners_association_fees": {"2026": 0.0}, "homeowners_insurance": {"2026":
         0.0}, "snap_if_takes_up": {"2026-01": 487.69998}}}, "marital_units": {}},
-        "policyengine_bundle": {"model_version": "1.794.2", "data_version": null,
+        "policyengine_bundle": {"model_version": "1.815.1", "data_version": null,
         "dataset": null}}'
     headers:
       Alt-Svc:
@@ -93,15 +93,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 25 Aug 2026 09:07:02 GMT
+      - Wed, 26 Aug 2026 09:22:12 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-eab125cea88061011d5fde2d61ad7e74-6b81ac8edbe9491e-01
+      - 00-b7f7e8bfbc7da0332f22c38c6e4d39a3-47b78f5f68252ded-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - eab125cea88061011d5fde2d61ad7e74;o=1
+      - b7f7e8bfbc7da0332f22c38c6e4d39a3;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -109,9 +109,9 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 553e1faa-0410-4e44-973f-5f508abef33e
+      - 0bad94fc-c6d3-4da6-a689-f1170260ae92
       x-policyengine-route-channel:
-      - current
+      - frontier
     status:
       code: 200
       message: OK

--- a/programs/programs/cross_white_label/snap/tests/test_mo.py
+++ b/programs/programs/cross_white_label/snap/tests/test_mo.py
@@ -1,0 +1,42 @@
+"""MO tests."""
+
+from django.test import TestCase
+
+from programs.framework.pe_dependencies.household import MoStateCodeDependency
+from programs.programs.cross_white_label.snap.base import Snap
+from programs.programs.cross_white_label.snap.mo import MoSnap
+
+
+class TestMoSnap(TestCase):
+    """Tests for Missouri SNAP calculator."""
+
+    def test_exists_and_is_subclass_of_snap(self):
+        """Test that MoSnap is a subclass of federal Snap."""
+        self.assertTrue(issubclass(MoSnap, Snap))
+
+    def test_program_code_is_mo_snap(self):
+        self.assertEqual(MoSnap.program_code, "mo_snap")
+
+    def test_pe_name_is_the_ungated_federal_variable(self):
+        """Missouri adds no calculator of its own: the amount comes from the federal
+        variable, which is the ungated one so a household not yet enrolled sees what
+        applying would get them."""
+        self.assertEqual(MoSnap.pe_name, "snap_if_takes_up")
+
+    def test_pe_inputs_includes_mo_state_code_dependency(self):
+        """The state code is what selects Missouri's parameters — the child-support
+        exclusion, the expense-based self-employment method, the absence of BBCE, and the
+        state utility/medical/homeless-shelter allowances. Without it PolicyEngine runs the
+        household against another state's elections."""
+        self.assertIn(MoStateCodeDependency, MoSnap.pe_inputs)
+
+    def test_pe_inputs_includes_all_parent_inputs(self):
+        """Test that all parent Snap inputs are included."""
+        for parent_input in Snap.pe_inputs:
+            self.assertIn(parent_input, MoSnap.pe_inputs)
+
+    def test_adds_nothing_but_the_state_code(self):
+        """Missouri's variance is all state-keyed parameters inside PolicyEngine's federal
+        SNAP tree. An extra input here would mean something is being computed on our side
+        that PolicyEngine should be resolving."""
+        self.assertEqual(set(MoSnap.pe_inputs) - set(Snap.pe_inputs), {MoStateCodeDependency})

--- a/programs/programs/cross_white_label/snap/tests/test_mo_integration.py
+++ b/programs/programs/cross_white_label/snap/tests/test_mo_integration.py
@@ -25,7 +25,7 @@ from programs.programs.testing_fixtures.pe_integration import (
     screener_value,
 )
 
-PE_VERSION = "1.794.2"
+PE_VERSION = "1.815.1"
 YEAR = "2026"
 
 

--- a/programs/programs/cross_white_label/snap/tests/test_mo_integration.py
+++ b/programs/programs/cross_white_label/snap/tests/test_mo_integration.py
@@ -1,0 +1,67 @@
+"""
+Smoke test for MO SNAP.
+
+Missouri is a federal passthrough: ``MoSnap`` adds the state code and nothing else, so the
+eligibility rules and the benefit amount are PolicyEngine's federal SNAP calculator running
+against Missouri's state-keyed parameters. Federal SNAP math is already covered by the
+shared base and the other states' suites, so this does not re-test it per state — it proves
+one thing, which is the thing a new state can actually get wrong: that ``snap_if_takes_up``
+resolves for a Missouri household and comes back with a benefit.
+
+Asserted in **annual** dollars, which is what the screener reports (``estimated_value``);
+``Snap.household_value`` multiplies PolicyEngine's monthly figure by 12.
+"""
+
+import pytest
+
+from programs.programs.cross_white_label.snap.mo import MoSnap
+from programs.programs.testing_fixtures.pe_integration import (
+    PeIntegrationTestCase,
+    add_income,
+    add_member,
+    calc_pe_program,
+    make_program,
+    make_screen,
+    screener_value,
+)
+
+PE_VERSION = "1.794.2"
+YEAR = "2026"
+
+
+@pytest.mark.integration
+class TestMoSnapResolves(PeIntegrationTestCase):
+    """A Missouri household PolicyEngine should find eligible comes back with a benefit."""
+
+    pe_version = PE_VERSION
+
+    def test_single_parent_two_children_under_the_income_limit(self):
+        """Three-person St. Louis City household on $1,500/month in wages.
+
+        Well under Missouri's 130% FPL gross-income limit for a household of three, with no
+        assets, so the ordinary pathway applies — Missouri did not adopt BBCE, and nothing
+        here is categorically eligible.
+        """
+        screen = make_screen(
+            1,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=3,
+            zipcode="63101",
+            county="St. Louis City",
+        )
+        parent = add_member(screen, 1, "headOfHousehold", 34)
+        add_income(parent, amount=1_500)
+        add_member(screen, 2, "child", 7)
+        add_member(screen, 3, "child", 4)
+        program = make_program("mo", "mo_snap", YEAR)
+
+        eligibility = calc_pe_program(screen, MoSnap, program)
+
+        self.assertTrue(eligibility.eligible)
+        # $487/month. Missouri's FY2026 three-person max allotment less 30% of net income:
+        # $1,500 gross, less the 20% earned-income deduction and the household-of-three
+        # standard deduction, leaves ~$992 net. Asserted exactly so a re-record at a newer
+        # PolicyEngine version surfaces a value change instead of passing on any nonzero
+        # number. `household_value` truncates the monthly figure before annualizing it.
+        self.assertEqual(screener_value(eligibility), 487 * 12)


### PR DESCRIPTION
## Context & Motivation

Missouri needs Food Assistance (SNAP) for the MO Launch project. SNAP is the anchor program for the food category, and its receipt is load-bearing for other MO programs: `pe_dependencies/receipt.py` feeds PolicyEngine's `receives_snap` off `has_base_benefit("snap")`, and Head Start, LIHEAP, WIC and Weatherization all read that signal for categorical eligibility. Without a `mo_snap` row, no MO household can report SNAP receipt to any of them.

- Linear: [MFB-1210 — Program: MO Food Assistance (SNAP)](https://linear.app/myfriendben/issue/MFB-1210/program-mo-food-assistance-snap)
- Discovery: [MFB-1260](https://linear.app/myfriendben/issue/MFB-1260/discovery-mo-food-assistance-snap)
- Related PR: [#1713 — MO TANF](https://github.com/Gary-Community-Ventures/benefits-api/pull/1713) (the sibling MO Launch program, same shape)
- Depends on: [#1685 — actual-receipt contract](https://github.com/Gary-Community-Ventures/benefits-api/pull/1685) (merged), which is what makes the categorical-eligibility path work without MO-specific code

Tier is **Fed (value varies)**, so there is no `spec.md` — Missouri adds no policy of its own, only parameter selection.

## Changes Made

- **`programs/programs/cross_white_label/snap/mo.py`** — `MoSnap(Snap)`, `program_code = "mo_snap"`. Adds `MoStateCodeDependency` and nothing else, the same 4-line shape as the other seven states. Missouri's variance is entirely state-keyed parameters inside PolicyEngine's federal SNAP tree — the child-support gross-income exclusion, the expense-based self-employment deduction, the absence of BBCE, and the state utility / standard-medical / homeless-shelter allowances — so passing the state code is what selects it. No `member_value`/`household_value` override, no MFB-side eligibility or value logic.
- **`.../import_program_config_data/data/mo_snap_initial_config.json`** — Food and Nutrition category (`mo_food`), `base_program: snap`, `active: true`, `show_in_has_benefits_step: true`, 7 documents, 1 navigator.
- **`programs/programs/cross_white_label/snap/tests/test_mo.py`** — 6 wiring tests, including one asserting the class adds *nothing* but the state code, so a future hybrid override fails the suite.
- **`programs/programs/cross_white_label/snap/tests/test_mo_integration.py`** + cassette — one VCR smoke test recorded at PolicyEngine **1.794.2**.

**Spec scenarios covered: n/a — this is a federal passthrough with no spec.** Per the Fed-tier convention it gets one smoke test proving `snap_if_takes_up` resolves for a Missouri household, rather than re-testing federal SNAP math per state (the shared base and the other states already cover it).

## Testing

- **Migrations to run:** none.
- **Configuration updates needed:** yes — the program config must be imported before `mo_snap` appears:
  ```bash
  venv/bin/python manage.py import_program_config \
    programs/management/commands/import_program_config_data/data/mo_snap_initial_config.json
  ```
  Verified locally: created `mo_snap` (program ID 2590) with `active=True`, `show_in_has_benefits_step=True`, `base_program='snap'`. The navigator reused the existing `usda_national_hunger_hotline` row (ID 1639) rather than creating a duplicate.
- **Environment variables/settings to add:** none. Re-recording the cassette needs `POLICY_ENGINE_CLIENT_ID` / `POLICY_ENGINE_CLIENT_SECRET`, but replaying it needs nothing.
- **Manual testing steps:**
  ```bash
  # wiring + smoke test, strict replay (no network)
  VCR_MODE=none venv/bin/pytest programs/programs/cross_white_label/snap/tests/ -q

  # full suite
  VCR_MODE=none venv/bin/pytest programs/ -q
  ```
  Results on this branch: `31 passed` for the SNAP tests, `2852 passed, 5 skipped` for `programs/`. `black --check` clean. Registry resolves `mo_snap -> MoSnap`.

  End-to-end via the screener: run a MO screen with a 3-person household on $1,500/month wages and confirm Food Assistance (SNAP) returns ~$5,844/year, and that SNAP appears as a tile on the "I already have this" step.

## Deployment

- **Post-deployment scripts needed:** yes — run the program config import on Staging after merge, then on Production:
  ```bash
  heroku run "python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_snap_initial_config.json" -a <app>
  ```
  The config carries `"active": true`, so the program goes live as soon as it is imported. If MO is not meant to show SNAP yet, import with the flag flipped to `false` and activate separately.
- **Production config updates:** none beyond the import above.
- **Admin updates needed:** none. Consider adding MO-specific SNAP navigators — this config ships only the statewide USDA National Hunger Hotline, because I did not want to invent contact details or county lists for MO food-bank orgs. That is an additive admin/config follow-up, not a blocker.
- **Notify team/users of:** MO SNAP going live changes results for other MO programs — Head Start, LIHEAP, WIC and Weatherization read SNAP receipt for categorical eligibility, and SNAP receipt confers free school meals. Worth a heads-up to whoever is QAing the MO white label. Also relevant to [MFB-1628](https://linear.app/myfriendben/issue/MFB-1628) (re-QA of programs affected by the receipt contract).

## Notes for Reviewers

Two deliberate choices worth a look:

1. **`legal_status_required` follows `wa_snap`, not `ks_snap`.** This ships `[citizen, gc_5plus, gc_under18_no5, refugee]`. `ks_snap` includes `gc_5less`, which is arguably wrong — LPRs with under 5 years are generally not federally SNAP-eligible unless they are children, disabled, or refugees/asylees. Missouri funds no state-level food benefit for the groups the federal program excludes, so there is no `wa_fap`-style companion program to carry them. Push back if the KS set is intentional.
2. **`show_in_has_benefits_step: true` is evidence-based, not assumed.** `pe_dependencies/receipt.py:55` reads `has_base_benefit("snap")` to drive `receives_snap`, and `head_start/wa.py`, `liheap/ks.py`, `wic/wa.py` and `weatherization/wa.py` all read the same signal. Since the row's `base_program` is `snap`, MO SNAP receipt feeds them.

**The MFB-1260 discovery report is substantially stale — please don't review against it.** It proposes a `mo_snap.py` carrying 9 MFB-side overrides, which is the hybrid shape we no longer write. Nine of its thirteen items are already closed in the shared base *as PolicyEngine inputs rather than logic*: utility isolation, shelter aggregation (property tax / HOA / homeowners insurance), the student exemptions including below-half-time, the USDA-disabled routing, and the whole categorical-eligibility path. Notably the receipt contract (#1685) merged **2026-08-18**, six days *after* the report was written, so its "raw federal baseline" column is stale for the categorical-eligibility scenarios.

- **Known limitations:** six genuine PolicyEngine gaps remain, documented and handed to David to send upstream. None block this PR; they determine how closely `mo_snap` matches Missouri's own published numbers.
  - `meets_snap_parent_exception` restricts the caregiver student exemption to the tax-unit head/spouse, where 7 CFR 273.5(b)(11) keys it to responsibility for the child (~$239/mo, and an eligibility effect).
  - No one-adult cap when two adults each independently qualify as caregiver (moves the same household the opposite way — these two must be fixed as a pair).
  - Missouri rounds net income to the nearest dollar; PolicyEngine floors it (~$1/mo).
  - Missouri's low-dollar issuance adjustment ($1/$3/$5 → $2/$4/$6) and the categorical-eligibility issuance ceiling.
  - The self-employed student's 20-hour work exemption is missing the minimum-wage × 20 earnings floor (eligibility flip).
  - Missouri's telephone-allowance stacking with LUA/NHCS and the FY2026 utility values (largest reported delta, up to ~$220/mo).

  One discovery ask was **withdrawn after testing it**: the claim that the SGA gate withdraws USDA-disabled treatment does not reproduce. Measured live against `MoSnap` at 1.794.2 — household of one, age 45, self-reported disabled, $2,000/month wages (above both the 130% FPL gross limit and SGA), $500/month medical expenses — returns **eligible, $288/year**, where the identical non-disabled household returns **$0**. The disabled household clears a gross-income test the other fails and gets the medical deduction, so the treatment is applying in full. No PolicyEngine change needed.

- **Future considerations:**
  - The cassette is pinned to 1.794.2 and the smoke test asserts $487/month exactly, so a PolicyEngine bump fails loudly rather than passing silently. Re-recording and adopting a new version are the same act — update `PE_VERSION`, delete the cassette, re-record, review the diff.
  - The ticket's `mydss.mo.gov` links now 302 to `dss.mo.gov/fsd`. I kept the `mydss.mo.gov` URLs for consistency with `mo_tanf` since they are still the documented apply path, but MO DSS looks mid-reorganisation and `mo_tanf`'s links likely need the same check.
  - `rental` income is classified unearned repo-wide (`earned_income_types = ["wages", "selfEmployment"]`). Discovery wanted it earned for MO SNAP; federally it is earned only with 20+ hrs/week active management, which the screener does not collect. If we want to change it, it is a shared-classification ticket, not a MO SNAP override.
