### PR TITLE
MFB-1105: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/actions/deploy-to-heroku/action.yml
+++ b/.github/actions/deploy-to-heroku/action.yml
@@ -21,7 +21,7 @@ runs:
         curl https://cli-assets.heroku.com/install.sh | sh
 
     - name: Deploy to Heroku
-      uses: akhileshns/heroku-deploy@v3.14.15
+      uses: akhileshns/heroku-deploy@v3.15.15
       with:
         heroku_api_key: ${{ inputs.heroku-api-key }}
         heroku_app_name: ${{ inputs.heroku-app-name }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -58,6 +58,6 @@ runs:
 
     - name: Upload coverage to Codecov
       if: inputs.upload-coverage == 'true'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ inputs.codecov-token }}

--- a/.github/actions/setup-python-django/action.yml
+++ b/.github/actions/setup-python-django/action.yml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run tests
         uses: ./.github/actions/run-tests
@@ -51,7 +51,7 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: psf/black@stable
         with:
           options: --check --verbose
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy to Heroku
         uses: ./.github/actions/deploy-to-heroku

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -9,7 +9,7 @@ jobs:
     name: runner / black formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/oncall-rotation.yml
+++ b/.github/workflows/oncall-rotation.yml
@@ -37,9 +37,9 @@ jobs:
   rotate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
## Context & Motivation

GitHub is removing the Node.js 20 runtime from Actions runners on **2026-09-16**. JavaScript actions that still bundle Node 20 will fail after that date. This repo's CI pins `actions/checkout@v4`, `actions/setup-python@v5` and `codecov/codecov-action@v5`, all of which bundle Node 20.

The warning surfaced as a recurring `##[warning]` in the `.github/oncall/` weekly rotation workflow, but it applies repo-wide.

- Linear: [MFB-1105](https://linear.app/myfriendben/issue/MFB-1105/bump-github-actions-to-node-24-compatible-versions-before-sept-16-2026)
- Ref: [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- Companion PRs: MyFriendBen/benefits-calculator#2186 and MyFriendBen/data-queries#134 carry the same bump — the ticket names only `benefits-api`, but all three repos share the exposure.

## Changes Made

12 pins across 8 files. Version strings only — no other line in the diff.

| Action | From | To | Count |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | 8 |
| `actions/setup-python` | v5 | **v7** | 2 |
| `codecov/codecov-action` | v5 | **v7** | 1 |
| `akhileshns/heroku-deploy` | v3.14.15 | **v3.15.15** | 1 |

- `.github/workflows/` — `pr-validation.yaml`, `format.yaml`, `deploy-staging.yml`, `deploy-production.yml`, `oncall-rotation.yml`
- `.github/actions/` — `run-tests` (codecov), `setup-python-django` (setup-python), `deploy-to-heroku` (heroku-deploy)

Node 24 support actually landed at `checkout@v5`, `setup-python@v6` and `codecov@v6`, so the deadline only required a partial bump. Going to the current majors buys the longest runway before the next deprecation.

Composite actions `heroku-config`, `heroku-migrations`, `heroku-validations`, `run-django-checks`, `slack-notify` and `heroku-pull-validations` are pure shell — no `uses:`, no changes. `deploy-to-heroku` is the one composite that does wrap a third-party action, and it is now bumped.

**`akhileshns/heroku-deploy` v3.14.15 → v3.15.15 was added after review.** An earlier pass on this PR recorded it as having no `node24` release upstream and therefore unfixable by a version bump. **That was wrong.** `v3.15.15` was released 2026-04-14 — four months before this work — runs on `node24`, and changes no inputs, so `heroku_api_key` / `heroku_app_name` / `heroku_email` are unaffected. It sits on the production deploy path, which made it the highest-consequence `node20` action left in this repo.

**After this PR, every JavaScript action in this repo runs on `node24`.** Verified by resolving `runs.using` for all five `uses:` refs: `checkout@v7`, `setup-python@v7` and `heroku-deploy@v3.15.15` are `node24`; `codecov-action@v7` and `psf/black@stable` are **composite** actions and therefore outside the Node deprecation entirely.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:

**✅ Already verified — green on this PR.** Every action bumped in this repo has a passing real-world execution:

| Action | Verified by |
| --- | --- |
| `actions/checkout@v7` | `Run Tests with Coverage` (`fetch-depth: 2`) and `Check Formatting / black formatter` (`fetch-depth: 0`) |
| `actions/setup-python@v7` | `Run Tests with Coverage` — 11m4s, full Django suite, pip cache via `cache-dependency-path` |
| `codecov/codecov-action@v7` | `codecov/patch` reported successfully |

`pr-validation.yaml` exercises the entire non-deploy surface in one job, since `run-tests` transitively pulls `setup-python-django` → `run-django-checks` → codecov upload.

Breaking changes in the skipped majors were each checked against actual usage:

- `setup-python@v7` removed the `pip-install` input — this repo caches via `cache: 'pip'` + `cache-dependency-path`, never used `pip-install`.
- `checkout@v7` blocks fork checkout on `pull_request_target` / `workflow_run` — neither trigger exists in this repo.
- `checkout@v5+` requires runner ≥ v2.327.1 — all jobs are `runs-on: ubuntu-latest` (GitHub-hosted), so this is satisfied.

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: nothing required — but the verification sequence below matters, because **no deploy path has been exercised by this PR.**

**⚠️ Three workflows in this repo cannot run on a pull request and remain unverified:**

| Workflow | Trigger | Unverified exposure |
| --- | --- | --- |
| `oncall-rotation.yml` | `schedule` + `workflow_dispatch` | checkout + setup-python |
| `deploy-staging.yml` | `push: main` | 3 × checkout |
| `deploy-production.yml` | `release` | 2 × checkout, both `ref: ${{ github.event.release.tag_name }}` |

**Recommended sequence:**

1. **Before merge** — trigger `oncall-rotation.yml` via `workflow_dispatch` from this branch. Confirm it completes *and* that the Node 20 `##[warning]` is gone; that warning is what opened this ticket, so this is the check that proves the fix landed.
2. **On merge to main** — watch `deploy-staging.yml`. All three of its checkout steps run here for the first time.
3. **Only after staging is green** — cut the release that fires `deploy-production.yml`.

Step 3 must not be skipped ahead of step 2. The residual production risk is narrow — the deploy workflows changed only at their checkout steps, and of the composites on the deploy path (`deploy-to-heroku`, `heroku-config`, `heroku-migrations`, `heroku-validations`, `slack-notify`) all are pure shell and untouched **except `deploy-to-heroku`**, whose single third-party action is now `heroku-deploy@v3.15.15`. That bump has **no pre-merge verification path** — it runs only from the two deploy workflows, neither of which triggers on a pull request — so watching the staging deploy is what exercises it. Staging uses the same `deploy-to-heroku` composite as production, so a green staging run is meaningful coverage. The one open question is whether `checkout@v7` still resolves `ref: <release tag>` identically; nothing in the v5/v6/v7 notes changes `ref` handling.

## Notes for Reviewers

- **Known limitations:**
  - The deploy workflows cannot be verified pre-merge (see Deployment). Their only change is at the `checkout` step.
  - **Third-party actions were originally not covered by this PR; `heroku-deploy` now is** (see Changes Made). No action in this repo remains on `node20`. It stays pinned to an exact patch rather than a floating major, matching the existing convention here.
- **Future considerations:**
  - This repo has no `dependabot.yml`. Enabling the `github-actions` ecosystem would keep these pins current automatically and is the durable fix — otherwise we repeat this ticket at the next runtime deprecation.
  - `.github/actions/heroku-pull-validations` appears to be unreferenced by any workflow or composite action. Not touched here; worth a separate cleanup.

