### PR TITLE
MFB-1672: restrict the state dropdown per referrer and brand the UWGKC 2-1-1

### DIFF
--- a/configuration/management/commands/add_config.py
+++ b/configuration/management/commands/add_config.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from configuration.models import (
     Configuration,
 )
-from configuration.white_labels import white_label_config
+from configuration.white_labels import state_options, white_label_config
 from screener.models import NPSScore
 import argparse
 
@@ -88,6 +88,13 @@ class Command(BaseCommand):
                 name="results_survey",
                 white_label=white_label,
                 defaults={"data": WhiteLabelData.results_survey, "active": True},
+            )
+
+            # Save the state dropdown's options to database, derived from the white label registry
+            Configuration.objects.update_or_create(
+                name="state_options",
+                white_label=white_label,
+                defaults={"data": state_options(), "active": True},
             )
 
             # Save override_text to database

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -189,3 +189,36 @@ class TestLegalLinkConfiguration(SimpleTestCase):
                             f"absolute https URL: {link!r}. An empty string here renders as a link "
                             "with an empty href.",
                         )
+
+
+class TestStateOptionsConfiguration(SimpleTestCase):
+    """
+    Guards the referrer-scoped state dropdown config. The dropdown renders before a state is
+    chosen, so it only ever reads the "_default" white label, and a code that is not a real
+    white label silently falls back to the public state list — a typo here would look like the
+    feature was never configured.
+    """
+
+    def test_default_white_label_declares_state_options(self):
+        """The "_default" config is the only one the state dropdown reads."""
+        self.assertIn("stateOptions", white_label_config["_default"].referrer_data)
+
+    def test_state_options_codes_are_real_white_labels(self):
+        """Every state code offered to a referrer must be a white label the screener can route to."""
+        for code, white_label_data in white_label_config.items():
+            state_options = white_label_data.referrer_data.get("stateOptions", {})
+
+            for referrer, states in state_options.items():
+                for state in states:
+                    with self.subTest(white_label=code, referrer=referrer, state=state):
+                        self.assertIn(
+                            state,
+                            white_label_config,
+                            f'"{referrer}" in white label "{code}" offers state "{state}", which '
+                            "is not a white label. The dropdown would drop it.",
+                        )
+                        self.assertNotEqual(
+                            state,
+                            "_default",
+                            f'"{referrer}" in white label "{code}" offers "_default", which is not a state.',
+                        )

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from django.test import SimpleTestCase, TestCase
 from configuration.models import Configuration
 from configuration.serializers import ConfigurationSerializer
-from configuration.white_labels import white_label_config
+from configuration.white_labels import state_options, white_label_config
 from screener.models import WhiteLabel
 from screener.feature_flags import FeatureFlagConfig
 
@@ -192,33 +192,38 @@ class TestLegalLinkConfiguration(SimpleTestCase):
 
 
 class TestStateOptionsConfiguration(SimpleTestCase):
-    """
-    Guards the referrer-scoped state dropdown config. The dropdown renders before a state is
-    chosen, so it only ever reads the "_default" white label, and a code that is not a real
-    white label silently falls back to the public state list — a typo here would look like the
-    feature was never configured.
-    """
+    """Guards the state dropdown's derived catalog and the per-referrer overrides that select from it."""
+
+    def test_catalog_covers_every_state_white_label(self):
+        """Every state white label appears once, with a name to show in the dropdown."""
+        catalog = state_options()
+        codes = [state["code"] for state in catalog]
+
+        self.assertEqual(len(codes), len(set(codes)))
+        for code, white_label_data in white_label_config.items():
+            expected = white_label_data.is_state and not white_label_data.is_default
+            with self.subTest(white_label=code):
+                self.assertEqual(code in codes, expected)
+
+        for state in catalog:
+            with self.subTest(white_label=state["code"]):
+                self.assertTrue(state["name"], f'White label "{state["code"]}" has no state name to display.')
 
     def test_default_white_label_declares_state_options(self):
-        """The "_default" config is the only one the state dropdown reads."""
+        """The "_default" config is the only one the dropdown reads its referrer overrides from."""
         self.assertIn("stateOptions", white_label_config["_default"].referrer_data)
 
-    def test_state_options_codes_are_real_white_labels(self):
-        """Every state code offered to a referrer must be a white label the screener can route to."""
-        for code, white_label_data in white_label_config.items():
-            state_options = white_label_data.referrer_data.get("stateOptions", {})
+    def test_referrer_overrides_name_states_in_the_catalog(self):
+        """An override naming a state outside the catalog would render an empty dropdown."""
+        codes = {state["code"] for state in state_options()}
 
-            for referrer, states in state_options.items():
+        for code, white_label_data in white_label_config.items():
+            for referrer, states in white_label_data.referrer_data.get("stateOptions", {}).items():
                 for state in states:
                     with self.subTest(white_label=code, referrer=referrer, state=state):
                         self.assertIn(
                             state,
-                            white_label_config,
-                            f'"{referrer}" in white label "{code}" offers state "{state}", which '
-                            "is not a white label. The dropdown would drop it.",
-                        )
-                        self.assertNotEqual(
-                            state,
-                            "_default",
-                            f'"{referrer}" in white label "{code}" offers "_default", which is not a state.',
+                            codes,
+                            f'"{referrer}" in white label "{code}" offers "{state}", which the state '
+                            "dropdown has no entry for.",
                         )

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -194,20 +194,53 @@ class TestLegalLinkConfiguration(SimpleTestCase):
 class TestStateOptionsConfiguration(SimpleTestCase):
     """Guards the state dropdown's derived catalog and the per-referrer overrides that select from it."""
 
-    def test_catalog_covers_every_state_white_label(self):
-        """Every state white label appears once, with a name to show in the dropdown."""
+    # Pinned rather than re-derived from is_state/publicly_launched: computing the expectation with
+    # the same predicate state_options() filters on would only restate the implementation. A new
+    # state has to be added here deliberately, which is the point — that edit is where someone
+    # decides whether it belongs in the public dropdown yet.
+    EXPECTED_CATALOG = {
+        "co": True,
+        "il": True,
+        "ks": False,
+        "ma": True,
+        "mo": False,
+        "nc": True,
+        "tx": True,
+        "wa": True,
+    }
+
+    def test_catalog_matches_the_expected_states(self):
+        """The dropdown offers exactly these states, with exactly these launched flags."""
         catalog = state_options()
         codes = [state["code"] for state in catalog]
 
-        self.assertEqual(len(codes), len(set(codes)))
-        for code, white_label_data in white_label_config.items():
-            expected = white_label_data.is_state and not white_label_data.is_default
-            with self.subTest(white_label=code):
-                self.assertEqual(code in codes, expected)
+        self.assertEqual(len(codes), len(set(codes)), f"The catalog repeats a state: {codes}.")
+        self.assertEqual(
+            {state["code"]: state["public"] for state in catalog},
+            self.EXPECTED_CATALOG,
+            "The state dropdown's contents changed. If that was intended, update EXPECTED_CATALOG; "
+            'a state added with "publicly_launched" unset is offered only by link and to referrers '
+            "that name it.",
+        )
 
         for state in catalog:
             with self.subTest(white_label=state["code"]):
                 self.assertTrue(state["name"], f'White label "{state["code"]}" has no state name to display.')
+
+    def test_catalog_excludes_non_state_white_labels(self):
+        """A sub-brand like "cesn" routes to a state screener but is not itself a state choice."""
+        codes = {state["code"] for state in state_options()}
+
+        for code, white_label_data in white_label_config.items():
+            if white_label_data.is_state and not white_label_data.is_default:
+                continue
+
+            with self.subTest(white_label=code):
+                self.assertNotIn(
+                    code,
+                    codes,
+                    f'White label "{code}" is not a state screener but is offered as a state.',
+                )
 
     def test_default_white_label_declares_state_options(self):
         """
@@ -240,6 +273,17 @@ class TestStateOptionsConfiguration(SimpleTestCase):
                     continue
 
                 for state in states:
+                    # The code is unvalidated referrer config, so indexing it directly would raise
+                    # a bare KeyError naming neither the referrer nor the white label it came from
+                    # — and this test runs before the one written to diagnose exactly that typo.
+                    if state not in white_label_config:
+                        with self.subTest(referrer=referrer, configured_in=code, offered_state=state):
+                            self.fail(
+                                f'"{referrer}" in white label "{code}" offers "{state}", which is '
+                                "not a white label at all."
+                            )
+                        continue
+
                     state_referrer_data = white_label_config[state].referrer_data
                     offered_by_state = state_referrer_data.get("stateOptions", {})
 

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -210,8 +210,21 @@ class TestStateOptionsConfiguration(SimpleTestCase):
                 self.assertTrue(state["name"], f'White label "{state["code"]}" has no state name to display.')
 
     def test_default_white_label_declares_state_options(self):
-        """The "_default" config backs the dropdown for entry without a state (/?referrer=code)."""
-        self.assertIn("stateOptions", white_label_config["_default"].referrer_data)
+        """
+        The "_default" config backs the state-agnostic /select-state route, so it stays the
+        generic every-public-state list. A partner narrowing the dropdown belongs in the config
+        for the state path it is handed out under, where the screener actually reads it.
+        """
+        state_options_config = white_label_config["_default"].referrer_data.get("stateOptions")
+
+        self.assertIsNotNone(state_options_config, '"_default" must declare "stateOptions".')
+        self.assertEqual(
+            state_options_config,
+            {"default": []},
+            '"_default" should offer every publicly launched state and nothing partner-specific. '
+            f"Found {state_options_config!r}; move any referrer entry to that referrer's state "
+            "config.",
+        )
 
     def test_multi_state_referrers_are_configured_in_every_state_they_offer(self):
         """

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -210,8 +210,34 @@ class TestStateOptionsConfiguration(SimpleTestCase):
                 self.assertTrue(state["name"], f'White label "{state["code"]}" has no state name to display.')
 
     def test_default_white_label_declares_state_options(self):
-        """The "_default" config is the only one the dropdown reads its referrer overrides from."""
+        """The "_default" config backs the dropdown for entry without a state (/?referrer=code)."""
         self.assertIn("stateOptions", white_label_config["_default"].referrer_data)
+
+    def test_multi_state_referrers_are_configured_in_every_state_they_offer(self):
+        """
+        A referrer whose dropdown offers several states is handed out under each of those state
+        paths, and each path loads its own config. Configuring it in only one of them leaves the
+        others on generic branding with an unscoped dropdown.
+        """
+        branding_keys = ("theme", "logoSource", "logoClass", "stateOptions")
+
+        for code, white_label_data in white_label_config.items():
+            for referrer, states in white_label_data.referrer_data.get("stateOptions", {}).items():
+                if referrer == "default" or code not in states:
+                    continue
+
+                for state in states:
+                    state_referrer_data = white_label_config[state].referrer_data
+
+                    for key in branding_keys:
+                        with self.subTest(referrer=referrer, configured_in=code, missing_from=state, key=key):
+                            self.assertIn(
+                                referrer,
+                                state_referrer_data.get(key, {}),
+                                f'"{referrer}" is configured in white label "{code}" and offers '
+                                f'"{state}", but white label "{state}" has no "{referrer}" entry '
+                                f'for "{key}".',
+                            )
 
     def test_referrer_overrides_name_states_in_the_catalog(self):
         """An override naming a state outside the catalog would render an empty dropdown."""

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -232,15 +232,35 @@ class TestStateOptionsConfiguration(SimpleTestCase):
         paths, and each path loads its own config. Configuring it in only one of them leaves the
         others on generic branding with an unscoped dropdown.
         """
-        branding_keys = ("theme", "logoSource", "logoClass", "stateOptions")
+        branding_keys = ("theme", "logoSource", "logoClass")
 
         for code, white_label_data in white_label_config.items():
             for referrer, states in white_label_data.referrer_data.get("stateOptions", {}).items():
-                if referrer == "default" or code not in states:
+                if referrer == "default" or len(states) < 2:
                     continue
 
                 for state in states:
                     state_referrer_data = white_label_config[state].referrer_data
+                    offered_by_state = state_referrer_data.get("stateOptions", {})
+
+                    with self.subTest(referrer=referrer, configured_in=code, offered_state=state):
+                        self.assertIn(
+                            referrer,
+                            offered_by_state,
+                            f'"{referrer}" is configured in white label "{code}" and offers '
+                            f'"{state}", but white label "{state}" has no "{referrer}" entry for '
+                            '"stateOptions", so entering from that path falls back to the '
+                            "publicly launched states.",
+                        )
+                        # Membership has to match, or the dropdown contradicts itself depending on
+                        # which state's screener the referrer was entered from. Order is free,
+                        # since a state may reasonably list itself first.
+                        self.assertCountEqual(
+                            offered_by_state[referrer],
+                            states,
+                            f'"{referrer}" offers {sorted(states)} in white label "{code}" but '
+                            f'{sorted(offered_by_state[referrer])} in white label "{state}".',
+                        )
 
                     for key in branding_keys:
                         with self.subTest(referrer=referrer, configured_in=code, missing_from=state, key=key):

--- a/configuration/white_labels/README.md
+++ b/configuration/white_labels/README.md
@@ -239,11 +239,15 @@ referrer_data = {
 publicly launched state, while a non-empty list per referrer code names the states that referrer
 sees, launched publicly or not.
 
-The dropdown reads whichever config is loaded, so where the entry belongs depends on how the
-referrer is reached. `_default.py` covers entry without a state (`/?referrer=code`); a referrer
-handed out under a state path (`/ks/step-1?referrer=code`) also needs the entry in that state's
-config. A referrer spanning several states, as `uwgkc` does for the Kansas City metro, needs the
-same entry in each of them — see `ks.py` and `mo.py`.
+The dropdown reads whichever config is loaded, so the entry belongs in the config for the state
+path the referrer is handed out under — `/ks/step-1?referrer=code` reads `ks.py`, not `_default.py`.
+A referrer spanning several states, as `uwgkc` does for the Kansas City metro, needs the same entry
+in each of them; see `ks.py` and `mo.py`.
+
+Keep partner entries out of `_default.py`. It stays the generic every-public-state list, since it
+backs the state-agnostic `/select-state` route rather than any one partner. The tradeoff is that a
+bare `/?referrer=code` link cannot narrow the dropdown — a referrer that needs one should be given
+state-scoped links instead.
 
 The dropdown's catalog of states is not hand-maintained — `add_config` derives the `state_options`
 config from the white label registry, using each state's `state["name"]`, `is_state` and

--- a/configuration/white_labels/README.md
+++ b/configuration/white_labels/README.md
@@ -226,13 +226,20 @@ referrer_data = {
 }
 ```
 
-`stateOptions` is the exception: it belongs in `_default.py` only, because the state dropdown
-renders before a state is chosen. An empty list means every publicly launched state; a non-empty
-list per referrer code names the states that referrer sees, launched publicly or not.
+`stateOptions` behaves differently from the other referrer keys: an empty list means every
+publicly launched state, while a non-empty list per referrer code names the states that referrer
+sees, launched publicly or not.
+
+The dropdown reads whichever config is loaded, so where the entry belongs depends on how the
+referrer is reached. `_default.py` covers entry without a state (`/?referrer=code`); a referrer
+handed out under a state path (`/ks/step-1?referrer=code`) also needs the entry in that state's
+config. A referrer spanning several states, as `uwgkc` does for the Kansas City metro, needs the
+same entry in each of them — see `ks.py` and `mo.py`.
 
 The dropdown's catalog of states is not hand-maintained — `add_config` derives the `state_options`
 config from the white label registry, using each state's `state["name"]`, `is_state` and
-`publicly_launched`. A new state appears once its config exists and `add_config` runs.
+`publicly_launched`. Because the catalog is written to the `_default` row, a new state appears
+only once its config exists and `add_config --all` (or `add_config _default`) runs.
 
 ### 5. Experiments (A/B Testing)
 

--- a/configuration/white_labels/README.md
+++ b/configuration/white_labels/README.md
@@ -226,6 +226,11 @@ referrer_data = {
 }
 ```
 
+`stateOptions` is the exception: it belongs in `_default.py` only. The state dropdown renders
+before a state is chosen, so only the `_default` config is loaded there. An empty list shows the
+frontend's public state list; a non-empty list per referrer code restricts the dropdown to those
+white labels, launched publicly or not.
+
 ### 5. Experiments (A/B Testing)
 
 Controls A/B test variant assignment. The frontend reads the variants list and uses a UUID hash to deterministically assign each user a variant.

--- a/configuration/white_labels/README.md
+++ b/configuration/white_labels/README.md
@@ -226,10 +226,13 @@ referrer_data = {
 }
 ```
 
-`stateOptions` is the exception: it belongs in `_default.py` only. The state dropdown renders
-before a state is chosen, so only the `_default` config is loaded there. An empty list shows the
-frontend's public state list; a non-empty list per referrer code restricts the dropdown to those
-white labels, launched publicly or not.
+`stateOptions` is the exception: it belongs in `_default.py` only, because the state dropdown
+renders before a state is chosen. An empty list means every publicly launched state; a non-empty
+list per referrer code names the states that referrer sees, launched publicly or not.
+
+The dropdown's catalog of states is not hand-maintained — `add_config` derives the `state_options`
+config from the white label registry, using each state's `state["name"]`, `is_state` and
+`publicly_launched`. A new state appears once its config exists and `add_config` runs.
 
 ### 5. Experiments (A/B Testing)
 

--- a/configuration/white_labels/README.md
+++ b/configuration/white_labels/README.md
@@ -251,8 +251,10 @@ state-scoped links instead.
 
 The dropdown's catalog of states is not hand-maintained — `add_config` derives the `state_options`
 config from the white label registry, using each state's `state["name"]`, `is_state` and
-`publicly_launched`. Because the catalog is written to the `_default` row, a new state appears
-only once its config exists and `add_config --all` (or `add_config _default`) runs.
+`publicly_launched`. It writes an identical copy of that catalog to **every** white label's row,
+and the frontend reads the row for whichever label is loaded (`GET /api/configuration/ks/`), so
+`add_config --all` is required. A single-label run leaves every other row stale, which renders the
+dropdown from out-of-date data — or empty, if the row was never written.
 
 ### 5. Experiments (A/B Testing)
 

--- a/configuration/white_labels/__init__.py
+++ b/configuration/white_labels/__init__.py
@@ -24,3 +24,18 @@ white_label_config: dict[str, ConfigurationData] = {
     "tx": TxConfigurationData,
     "wa": WaConfigurationData,
 }
+
+
+def state_options() -> list[dict]:
+    """Every state the state dropdown can offer, in display order, flagged by whether it is public."""
+    states = [
+        {
+            "code": code,
+            "name": data.state["name"],
+            "public": data.publicly_launched,
+        }
+        for code, data in white_label_config.items()
+        if data.is_state and not data.is_default
+    ]
+
+    return sorted(states, key=lambda state: state["name"])

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -52,9 +52,11 @@ class DefaultConfigurationData(ConfigurationData):
             ]
         },
         "uiOptions": {"default": []},
-        # The KS and MO 2-1-1s serve the Kansas City metro on both sides of the state line, so their
-        # links offer exactly those two states; empty means every publicly launched state.
-        "stateOptions": {"default": [], "211ks": ["ks", "mo"], "211mo": ["ks", "mo"]},
+        # United Way of Greater Kansas City's 2-1-1 serves the metro on both sides of the state
+        # line, so its links offer exactly those two states; empty means every publicly launched
+        # state. The same referrer is used from /ks and /mo, which read their own configs, so this
+        # entry only covers entry without a state (screener.myfriendben.org/?referrer=uwgkc).
+        "stateOptions": {"default": [], "uwgkc": ["ks", "mo"]},
         "noResultMessage": {
             "default": {
                 "_label": "noResultMessage",

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -52,11 +52,9 @@ class DefaultConfigurationData(ConfigurationData):
             ]
         },
         "uiOptions": {"default": []},
-        # United Way of Greater Kansas City's 2-1-1 serves the metro on both sides of the state
-        # line, so its links offer exactly those two states; empty means every publicly launched
-        # state. The same referrer is used from /ks and /mo, which read their own configs, so this
-        # entry only covers entry without a state (screener.myfriendben.org/?referrer=uwgkc).
-        "stateOptions": {"default": [], "uwgkc": ["ks", "mo"]},
+        # Empty means every publicly launched state. Referrers that narrow the dropdown declare it
+        # in the config for the state path they are handed out under, not here.
+        "stateOptions": {"default": []},
         "noResultMessage": {
             "default": {
                 "_label": "noResultMessage",

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -52,9 +52,8 @@ class DefaultConfigurationData(ConfigurationData):
             ]
         },
         "uiOptions": {"default": []},
-        # The Kansas City metro spans the state line, so the KS and MO 2-1-1s serve callers on
-        # both sides of it. Their links land on the state dropdown offering exactly KS and MO,
-        # which the public list leaves out until those states launch. Empty = public list.
+        # The KS and MO 2-1-1s serve the Kansas City metro on both sides of the state line, so their
+        # links offer exactly those two states; empty means every publicly launched state.
         "stateOptions": {"default": [], "211ks": ["ks", "mo"], "211mo": ["ks", "mo"]},
         "noResultMessage": {
             "default": {

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -52,6 +52,10 @@ class DefaultConfigurationData(ConfigurationData):
             ]
         },
         "uiOptions": {"default": []},
+        # The Kansas City metro spans the state line, so the KS and MO 2-1-1s serve callers on
+        # both sides of it. Their links land on the state dropdown offering exactly KS and MO,
+        # which the public list leaves out until those states launch. Empty = public list.
+        "stateOptions": {"default": [], "211ks": ["ks", "mo"], "211mo": ["ks", "mo"]},
         "noResultMessage": {
             "default": {
                 "_label": "noResultMessage",

--- a/configuration/white_labels/_template.py
+++ b/configuration/white_labels/_template.py
@@ -296,6 +296,14 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     #     * "white_multi_select_tile_icon" - White icons on multi-select tiles
     #     * "dont_show_category_values" - Hide dollar amounts on category headings
     #
+    # stateOptions: State codes offered in the "What is your state?" dropdown
+    #   - Only read from the "_default" white label, since the dropdown is shown
+    #     before a state is chosen; leave it out of state configs
+    #   - Empty list = show the frontend's public state list
+    #   - A non-empty list restricts the dropdown to those white labels, and may
+    #     include states that are not publicly launched (e.g. {"211ks": ["ks", "mo"]}
+    #     for a referrer whose service area spans the KS/MO line)
+    #
     # noResultMessage: Message shown when user has no eligible programs
     #   - Format: {"_label": "translation.key", "_default_message": "Message text"}
     #

--- a/configuration/white_labels/_template.py
+++ b/configuration/white_labels/_template.py
@@ -313,8 +313,8 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     #   - A non-empty list may name states that are not public yet, e.g.
     #     {"uwgkc": ["ks", "mo"]} for a referrer serving both sides of the KS/MO line
     #   - The dropdown reads whichever config is loaded, so a referrer reachable from more than
-    #     one state path needs the same entry in each of those states' configs, plus "_default"
-    #     for the no-state entry point
+    #     one state path needs the same entry in each of those states' configs. Keep partner
+    #     entries out of "_default", which stays the generic every-public-state list
     #
     # noResultMessage: Message shown when user has no eligible programs
     #   - Format: {"_label": "translation.key", "_default_message": "Message text"}

--- a/configuration/white_labels/_template.py
+++ b/configuration/white_labels/_template.py
@@ -40,6 +40,9 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     # ==========================================================================================
 
     # TODO: Set your state/region name
+    # Set to False while the state is reachable by link but should stay out of the public dropdown.
+    publicly_launched = True
+
     state = {"name": "{{name}}"}
 
     # Banner messages (optional - uncomment if needed)
@@ -296,13 +299,11 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     #     * "white_multi_select_tile_icon" - White icons on multi-select tiles
     #     * "dont_show_category_values" - Hide dollar amounts on category headings
     #
-    # stateOptions: State codes offered in the "What is your state?" dropdown
-    #   - Only read from the "_default" white label, since the dropdown is shown
-    #     before a state is chosen; leave it out of state configs
-    #   - Empty list = show the frontend's public state list
-    #   - A non-empty list restricts the dropdown to those white labels, and may
-    #     include states that are not publicly launched (e.g. {"211ks": ["ks", "mo"]}
-    #     for a referrer whose service area spans the KS/MO line)
+    # stateOptions: State codes this referrer's "What is your state?" dropdown offers
+    #   - Empty list = every publicly launched state (see publicly_launched below)
+    #   - A non-empty list may name states that are not public yet, e.g.
+    #     {"211ks": ["ks", "mo"]} for a referrer serving both sides of the KS/MO line
+    #   - Only the "_default" config is read, since the dropdown precedes the state choice
     #
     # noResultMessage: Message shown when user has no eligible programs
     #   - Format: {"_label": "translation.key", "_default_message": "Message text"}

--- a/configuration/white_labels/_template.py
+++ b/configuration/white_labels/_template.py
@@ -261,7 +261,8 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     #
     # theme: CSS theme name (usually "default")
     #   - Used to apply custom styling/themes
-    #   - Available themes: "default", "twoOneOne", "twoOneOneNC", "nc_lanc"
+    #   - Available themes: "default", "twoOneOne", "twoOneOneNC", "co_energy", "nc_lanc",
+    #     "nc_ccla", "cu_denver", "uwgkc" (defined in the frontend's styleController.ts)
     #
     # logoSource: Logo filename from public/locales folder
     #   - Displayed in header throughout screener
@@ -302,8 +303,10 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     # stateOptions: State codes this referrer's "What is your state?" dropdown offers
     #   - Empty list = every publicly launched state (see publicly_launched below)
     #   - A non-empty list may name states that are not public yet, e.g.
-    #     {"211ks": ["ks", "mo"]} for a referrer serving both sides of the KS/MO line
-    #   - Only the "_default" config is read, since the dropdown precedes the state choice
+    #     {"uwgkc": ["ks", "mo"]} for a referrer serving both sides of the KS/MO line
+    #   - The dropdown reads whichever config is loaded, so a referrer reachable from more than
+    #     one state path needs the same entry in each of those states' configs, plus "_default"
+    #     for the no-state entry point
     #
     # noResultMessage: Message shown when user has no eligible programs
     #   - Format: {"_label": "translation.key", "_default_message": "Message text"}

--- a/configuration/white_labels/_template.py
+++ b/configuration/white_labels/_template.py
@@ -40,8 +40,9 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     # ==========================================================================================
 
     # TODO: Set your state/region name
-    # Set to False while the state is reachable by link but should stay out of the public dropdown.
-    publicly_launched = True
+    # TODO: Flip to True only when the state is ready for the public dropdown. Until then it stays
+    # reachable by direct link and by any referrer that names it in "stateOptions".
+    publicly_launched = False
 
     state = {"name": "{{name}}"}
 
@@ -269,8 +270,8 @@ class {{code_capitalize}}ConfigurationData(ConfigurationData):
     #
     # theme: CSS theme name (usually "default")
     #   - Used to apply custom styling/themes
-    #   - Available themes: "default", "twoOneOne", "twoOneOneNC", "co_energy", "nc_lanc",
-    #     "nc_ccla", "cu_denver", "uwgkc" (defined in the frontend's styleController.ts)
+    #   - The available names are the keys of `themes` in the frontend's
+    #     src/Assets/styleController.ts; an unlisted name silently falls back to "default"
     #
     # logoSource: Logo filename from public/locales folder
     #   - Displayed in header throughout screener

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -18,8 +18,11 @@ class ConfigurationData:
     # Whether this white label is a state screener the state dropdown can offer.
     is_state = True
 
-    # Whether this state appears in the public state dropdown, as opposed to being reachable only by link.
-    publicly_launched = True
+    # Whether this state appears in the public state dropdown, as opposed to being reachable only
+    # by link. Opt in, so a state under construction cannot reach the public dropdown by omission:
+    # a launched state missing from the dropdown is reported quickly, while a pre-launch state
+    # exposed there sends real users into an unfinished screener.
+    publicly_launched = False
 
     @classmethod
     def get_white_label(self) -> WhiteLabel:

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -15,6 +15,12 @@ For detailed documentation on how to configure each section, see:
 class ConfigurationData:
     is_default = False
 
+    # Whether this white label is a state screener the state dropdown can offer.
+    is_state = True
+
+    # Whether this state appears in the public state dropdown, as opposed to being reachable only by link.
+    publicly_launched = True
+
     @classmethod
     def get_white_label(self) -> WhiteLabel:
         raise NotImplemented()
@@ -525,11 +531,7 @@ class ConfigurationData:
             ],
         },
         "uiOptions": {"default": []},
-        # State codes offered in the "What is your state?" dropdown. Empty means "use the
-        # frontend's public state list"; a non-empty list restricts the dropdown to those
-        # white labels, including ones that are not publicly launched yet. Only the
-        # "_default" white label config is read here, because the dropdown is shown before
-        # a state is chosen.
+        # State codes this referrer's dropdown offers; empty means every publicly launched state.
         "stateOptions": {"default": []},
         "defaultLanguage": {"default": "en-us"},
         "stateName": {"default": ""},

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -525,6 +525,12 @@ class ConfigurationData:
             ],
         },
         "uiOptions": {"default": []},
+        # State codes offered in the "What is your state?" dropdown. Empty means "use the
+        # frontend's public state list"; a non-empty list restricts the dropdown to those
+        # white labels, including ones that are not publicly launched yet. Only the
+        # "_default" white label config is read here, because the dropdown is shown before
+        # a state is chosen.
+        "stateOptions": {"default": []},
         "defaultLanguage": {"default": "en-us"},
         "stateName": {"default": ""},
         "noResultMessage": {

--- a/configuration/white_labels/cesn.py
+++ b/configuration/white_labels/cesn.py
@@ -7,6 +7,9 @@ class CesnConfigurationData(ConfigurationData):
     def get_white_label(self) -> WhiteLabel:
         return WhiteLabel.objects.get(code="cesn")
 
+    # A Colorado sub-brand rather than a state screener, so it never appears in the state dropdown.
+    is_state = False
+
     state = {"name": "Colorado"}
 
     public_charge_rule = {

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -7,6 +7,9 @@ class CoConfigurationData(ConfigurationData):
     def get_white_label(self) -> WhiteLabel:
         return WhiteLabel.objects.get(code="co")
 
+    # Live in production and offered in the public state dropdown.
+    publicly_launched = True
+
     state = {"name": "Colorado"}
 
     # System banner messages

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -7,6 +7,9 @@ class IlConfigurationData(ConfigurationData):
     def get_white_label(self) -> WhiteLabel:
         return WhiteLabel.objects.get(code="il")
 
+    # Live in production and offered in the public state dropdown.
+    publicly_launched = True
+
     state = {"name": "Illinois"}
 
     public_charge_rule = {

--- a/configuration/white_labels/ks.py
+++ b/configuration/white_labels/ks.py
@@ -1086,22 +1086,34 @@ class KsConfigurationData(ConfigurationData):
     # override only the keys KS customizes.
     referrer_data = {
         **ConfigurationData.referrer_data,
-        "theme": {"default": "default"},
-        "logoSource": {"default": "MFB_Logo"},
+        # "uwgkc" is United Way of Greater Kansas City, whose 2-1-1 covers the metro on both sides
+        # of the state line. The same referrer code is configured identically in mo.py, since each
+        # state path loads its own config.
+        "theme": {"default": "default", "uwgkc": "uwgkc"},
+        "logoSource": {"default": "MFB_Logo", "uwgkc": "KS211_MFBLogo"},
         "logoAlt": {
             "default": {
                 "id": "referrerHook.logoAlts.default",
                 "defaultMessage": "MyFriendBen home page button",
             },
+            "uwgkc": {
+                "id": "referrerHook.logoAlts.ks211",
+                "defaultMessage": "211 Kansas and MyFriendBen home page button",
+            },
         },
+        # The co-branded logo's MyFriendBen wordmark is dark navy, which would disappear against
+        # the theme's dark blue header, so this referrer gets the white header treatment.
+        "uiOptions": {"default": [], "uwgkc": ["white_header"]},
         "logoFooterSource": {"default": "MFB_Logo"},
         "logoFooterAlt": {
             "default": {"id": "footer.logo.alt", "defaultMessage": "MFB Logo"},
         },
-        "logoClass": {"default": "logo"},
+        "logoClass": {"default": "logo", "uwgkc": "uwgkc-logo-size"},
         "shareLink": {
             "default": "https://screener.myfriendben.org/ks/step-1",
+            "uwgkc": "https://screener.myfriendben.org/ks/step-1?referrer=uwgkc",
         },
+        "stateOptions": {"default": [], "uwgkc": ["ks", "mo"]},
         "stepDirectory": {
             "default": [
                 "zipcode",
@@ -1117,5 +1129,7 @@ class KsConfigurationData(ConfigurationData):
             ],
         },
         "defaultLanguage": {"default": "en-us"},
-        "stateName": {"default": "Kansas"},
+        # Blank for uwgkc: its logo already carries "Kansas", so the header's separate state name
+        # would repeat it underneath the artwork.
+        "stateName": {"default": "Kansas", "uwgkc": ""},
     }

--- a/configuration/white_labels/ks.py
+++ b/configuration/white_labels/ks.py
@@ -11,6 +11,9 @@ class KsConfigurationData(ConfigurationData):
     # BASIC INFORMATION
     # ==========================================================================================
 
+    # Reachable at /ks and offered to the 2-1-1 referrers, but not yet in the public dropdown.
+    publicly_launched = False
+
     state = {"name": "Kansas"}
 
     public_charge_rule = {"link": "https://www.uscis.gov/green-card/green-card-processes-and-procedures/public-charge"}

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -7,6 +7,9 @@ class MaConfigurationData(ConfigurationData):
     def get_white_label(self) -> WhiteLabel:
         return WhiteLabel.objects.get(code="ma")
 
+    # Live in production and offered in the public state dropdown.
+    publicly_launched = True
+
     state = {"name": "Massachusetts"}
 
     public_charge_rule = {

--- a/configuration/white_labels/mo.py
+++ b/configuration/white_labels/mo.py
@@ -1494,9 +1494,34 @@ class MoConfigurationData(ConfigurationData):
 
     # MO uses generic MFB branding and the default step directory, so it inherits
     # everything from base and overrides only the values that are MO-specific:
-    # the share link and the state name.
+    # the share link, the state name, and the Kansas City metro referrer.
     referrer_data = {
         **ConfigurationData.referrer_data,
-        "shareLink": {"default": "https://screener.myfriendben.org/mo/step-1"},
-        "stateName": {"default": "Missouri"},
+        # "uwgkc" is United Way of Greater Kansas City, whose 2-1-1 covers the metro on both sides
+        # of the state line. The same referrer code is configured identically in ks.py, since each
+        # state path loads its own config.
+        "theme": {"default": "default", "uwgkc": "uwgkc"},
+        "logoSource": {"default": "MFB_Logo", "uwgkc": "MO211_MFBLogo"},
+        "logoAlt": {
+            "default": {
+                "id": "referrerHook.logoAlts.default",
+                "defaultMessage": "MyFriendBen home page button",
+            },
+            "uwgkc": {
+                "id": "referrerHook.logoAlts.mo211",
+                "defaultMessage": "211 Missouri and MyFriendBen home page button",
+            },
+        },
+        # The co-branded logo's MyFriendBen wordmark is dark navy, which would disappear against
+        # the theme's dark blue header, so this referrer gets the white header treatment.
+        "uiOptions": {"default": [], "uwgkc": ["white_header"]},
+        "logoClass": {"default": "logo", "uwgkc": "uwgkc-logo-size"},
+        "shareLink": {
+            "default": "https://screener.myfriendben.org/mo/step-1",
+            "uwgkc": "https://screener.myfriendben.org/mo/step-1?referrer=uwgkc",
+        },
+        "stateOptions": {"default": [], "uwgkc": ["ks", "mo"]},
+        # Blank for uwgkc: its logo already carries "Missouri", so the header's separate state name
+        # would repeat it underneath the artwork.
+        "stateName": {"default": "Missouri", "uwgkc": ""},
     }

--- a/configuration/white_labels/mo.py
+++ b/configuration/white_labels/mo.py
@@ -11,6 +11,9 @@ class MoConfigurationData(ConfigurationData):
     # BASIC INFORMATION
     # ==========================================================================================
 
+    # Reachable at /mo and offered to the 2-1-1 referrers, but not yet in the public dropdown.
+    publicly_launched = False
+
     state = {"name": "Missouri"}
 
     public_charge_rule = {"link": "https://www.uscis.gov/green-card/green-card-processes-and-procedures/public-charge"}

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -7,6 +7,9 @@ class NcConfigurationData(ConfigurationData):
     def get_white_label(self) -> WhiteLabel:
         return WhiteLabel.objects.get(code="nc")
 
+    # Live in production and offered in the public state dropdown.
+    publicly_launched = True
+
     state = {"name": "North Carolina"}
 
     # System banner messages

--- a/configuration/white_labels/tx.py
+++ b/configuration/white_labels/tx.py
@@ -7,6 +7,9 @@ class TxConfigurationData(ConfigurationData):
     def get_white_label(self) -> WhiteLabel:
         return WhiteLabel.objects.get(code="tx")
 
+    # Live in production and offered in the public state dropdown.
+    publicly_launched = True
+
     state = {"name": "Texas"}
 
     public_charge_rule = {

--- a/configuration/white_labels/wa.py
+++ b/configuration/white_labels/wa.py
@@ -11,6 +11,9 @@ class WaConfigurationData(ConfigurationData):
     # BASIC INFORMATION
     # ==========================================================================================
 
+    # Live in production and offered in the public state dropdown.
+    publicly_launched = True
+
     state = {"name": "Washington"}
 
     public_charge_rule = {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-1672](https://linear.app/myfriendben/issue/MFB-1672/handle-moks-kansas-city-overlap-in-landing-page)
- Related PR: MyFriendBen/benefits-calculator#2187 (frontend half — renders what this config declares)

United Way of Greater Kansas City's 2-1-1 serves the Kansas City metro, which spans the state line,
so its referral links need to land on a state dropdown offering exactly Kansas and Missouri.
Neither state is publicly launched, so this can't be a filter over the launched set — it needs a
per-referrer override.

The dropdown's contents were entirely frontend-side: a hardcoded `code -> name` map plus a
hardcoded public-state list with `ks` and `mo` commented out. Both went stale whenever a white
label was added or launched. So this PR also moves that knowledge into the white label configs,
where the states are already declared.

The ticket's second acceptance criterion — 2-1-1 branding for KS and MO — is covered here too, as
the theme, logo and share-link config the frontend PR renders.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

### State dropdown

- `base.py`: two class attributes on `ConfigurationData` — `is_state` (whether the dropdown can
  offer this white label at all) and `publicly_launched` (whether it shows without a referrer).
  `publicly_launched` defaults to `False`, so launching is opt-in: a state under construction
  can't reach the public dropdown by omission.
- `co.py` / `il.py` / `ma.py` / `nc.py` / `tx.py` / `wa.py`: `publicly_launched = True`, opting the
  six live states in. The derived catalog is byte-identical before and after that flip.
- `cesn.py`: `is_state = False`, since it's a Colorado sub-brand rather than a state screener and
  should never be selectable as a state.
- `ks.py` / `mo.py`: `publicly_launched = False` — reachable at `/ks` and `/mo` and offered to the
  2-1-1, but not in the public dropdown. Now the same as the default, kept explicit because these
  two are the point of the PR.
- `white_labels/__init__.py`: `state_options()` derives the dropdown catalog from the registry —
  `[{"code", "name", "public"}]`, name taken from each state's existing `state["name"]`, sorted by
  display name.
- `add_config.py`: saves that catalog as a new `state_options` configuration row. The write sits
  above the `is_default` guard, so **every** white label gets an identical copy, and the frontend
  reads the row for whichever label is loaded — which is why `--all` is required.

### The `uwgkc` referrer

Stakeholders confirmed one referrer code for both states, reached as
`/ks/step-1?referrer=uwgkc` and `/mo/step-1?referrer=uwgkc`. Each state path loads its own config,
so the referrer is declared in both — sharing the theme and `stateOptions`, while `logoSource`,
`logoAlt`, `shareLink` and `stateName` differ per state:

- `ks.py` / `mo.py` `referrer_data`: a `uwgkc` entry under `theme` (`"uwgkc"`), `logoSource`
  (`"KS211_MFBLogo"` / `"MO211_MFBLogo"` — UWGKC supplied a lockup per state, same 2-1-1 signature
  differing only in the state label), `logoAlt`, `shareLink` (state-specific, carrying the referrer
  through a share), `stateOptions` (`["ks", "mo"]`), `uiOptions` (`["white_header"]`), `logoClass`
  (`"uwgkc-logo-size"`, since the lockup is far wider than the default logo slot allows for), and a
  blank `stateName` — the lockup already reads "Kansas" / "Missouri", so the header's separate
  state name rendered the word a second time underneath the artwork.
- `uiOptions: ["white_header"]` is load-bearing, not cosmetic: the supplied lockups carry
  MyFriendBen's `#293457` navy wordmark, which sits at 1.08:1 against the theme's `#21296B` header
  and is effectively invisible. `white_header` is the existing option `cesn` already uses — it
  whitens the bar and flips the header text and icons to black, where the wordmark is 12.2:1.
- `_default.py`: stays the generic `{"default": []}` — every publicly launched state. It backs the
  state-agnostic `/select-state` route, so it has no business naming one partner's states, and the
  `uwgkc` entry lives only where the screener reads it. The tradeoff is that a bare
  `/?referrer=uwgkc` link can't narrow the dropdown; UWGKC's links are state-scoped, so nothing in
  the agreed flow depended on that.

### Tests and docs

- `configuration/tests.py`: `TestStateOptionsConfiguration` covers five things — the catalog
  matches a pinned `{code: public}` map, non-state white labels are excluded from it, `_default`
  declares exactly the generic `{"default": []}` and nothing partner-specific, every code a
  referrer override names exists in the catalog, and a referrer offering two or more states is
  configured with `theme`, `logoSource` and `logoClass` in *each* of them and offers the same set
  of states from each. That last one is the failure mode this design invites: configure `uwgkc` in
  `ks.py` only and the Missouri path silently serves generic branding with an unscoped dropdown.

  The catalog assertion is pinned rather than recomputed from `is_state`/`publicly_launched`, which
  would only restate the predicate `state_options()` filters on. Adding a state now needs a
  deliberate edit to `EXPECTED_CATALOG` — the right place to decide whether it belongs in the
  public dropdown yet.

  On the `stateOptions` half of that check, CodeRabbit correctly caught that the first version only
  asserted the referrer *key* was present, so `ks.py` could offer `["ks"]` while `mo.py` offered
  `["ks", "mo"]` and the guard stayed green — entering from `/ks` would then hide Missouri, the
  exact misconfiguration the test exists for. It now compares membership (order left free, since a
  state may reasonably list itself first), and gates on a referrer naming two or more states rather
  than on the declaring state appearing in its own list — which also covers a referrer pointing at
  states other than its own, previously skipped entirely.
- `_template.py`: points at `styleController.ts` for theme names instead of duplicating the list,
  corrected the `stateOptions` note (it claimed only `_default` is read), and defaults
  `publicly_launched` to `False` with a TODO to flip it at launch.
- `white_labels/README.md`: rewrote the `stateOptions` section for the same reason, and corrected
  where the catalog lands — an earlier revision of this PR said it was written to the `_default`
  row and offered `add_config _default` as a shortcut. Both were wrong: the write precedes
  `add_config`'s `is_default` guard, so every white label gets a copy and the frontend reads its
  own, meaning that shortcut would have left every state row stale.

No migrations and no model changes — a derived config row, two class flags, and referrer config.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: `python manage.py add_config --all` (the catalog row is written for
  every white label)
- Environment variables/settings to add: none
- Manual testing steps:
  1. `python manage.py add_config --all`
  2. `GET /api/configuration/_default/` and confirm `state_options` lists all eight states with
     `ks` and `mo` at `"public": false`, and that `referrer_data.stateOptions` is just
     `{"default": []}`
  3. `GET /api/configuration/ks/` and `/mo/` and confirm each carries a `uwgkc` entry under
     `referrer_data.theme`, `logoSource`, `logoAlt`, `shareLink`, `stateOptions` and `uiOptions`,
     with the state's own logo key
  4. With the frontend branch running, `/ks/step-1?referrer=uwgkc` and
     `/mo/step-1?referrer=uwgkc` render United Way branding; `/` with no referrer offers the same
     six states as production
  5. `python manage.py test configuration` (53 passing locally)

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: `python manage.py add_config --all` on staging, then production.
  `--all` is required, not a convenience: `state_options` is written per white label, so a
  single-label run leaves every other row stale, and until it runs at all the row doesn't exist and
  the frontend renders an empty dropdown — see Notes for Reviewers. Nine configs changed here
  (`_default`, the six launched states, `ks` and `mo`).
- Production config updates: the same `add_config --all` run.
- Admin updates needed: **yes.** `add_config` does not write `Referrer` rows, and they're
  `unique(white_label, referrer_code)` — so `uwgkc` needs a row created under **both** `ks` and
  `mo` for referral-source attribution. The dropdown and branding work off the URL param without
  them; attribution does not.
- Notify team/users of: UWGKC needs the final links —
  `screener.myfriendben.org/ks/step-1?referrer=uwgkc` and `.../mo/step-1?referrer=uwgkc`.
- **This unblocks a red CI job on the frontend PR.** MyFriendBen/benefits-calculator#2187 has 7
  failing `e2e-tests` specs, all of them timing out on an empty state dropdown, because that suite
  runs against the deployed API and `state_options` does not exist there yet. After this merges and
  `add_config --all` has run, re-run that job and confirm all 7 pass with no code change — that is
  the staging QA gate for the ordering tradeoff below.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- **The referrer code is `uwgkc`**, one code across both states, per stakeholders. An earlier
  revision of this PR used separate `211ks` / `211mo` codes declared in `_default.py`; the switch is
  why the config now lives in `ks.py` and `mo.py`, with `_default.py` left generic.
- **Deploy ordering matters now**, unlike the first version of this PR. The frontend no longer has
  a hardcoded fallback list, so between the frontend deploy and `add_config` the dropdown would be
  empty. Running `add_config --all` first, or in the same release, avoids it. The frontend PR's red
  `e2e-tests` job is this tradeoff made visible — it runs against the deployed API, so it cannot go
  green until this side ships. Worth a second opinion on whether that tradeoff is right, or whether
  the frontend should keep a minimal fallback, which would also decouple its e2e suite from API
  deploy order.
- Known limitations:
  - A `uwgkc` user who clicks "click here for other state options" on the zipcode step loses the
    referrer: that link is a plain `<a href="/select-state">` with no query string, so the reload
    falls back to the public list — which contains neither KS nor MO. Deliberately out of scope
    here; the cross-state link needs the referrer propagated through the state page.
  - State names are plain strings, not translation keys, matching the hardcoded English names they
    replace. Making them translatable is a follow-up.
  - `publicly_launched` is a launch decision, so it can't be derived — but it now lives beside the
    state it describes rather than in frontend code.
- Future considerations:
  - The "single screener covering both states" framing in the original ticket description isn't
    addressed here: `state_code` is a per-white-label class constant on every PE calculator, so a
    combined white label would need it derived per household from the ZIP. Two screeners plus one
    shared referrer gets the KC-metro user to the right state screener instead.
  - Cross-state program visibility isn't needed — `ks` and `mo` already duplicate the KC-metro
    resources, and the four programs `ks` was missing (ACA PTC, federal EITC, WIC, WAP) are tracked
    in MFB-1052, MFB-1048, MFB-1051 and MFB-1067. See the comment on MFB-1672.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - State dropdown options are now generated from configured, publicly launched states.
  - Kansas and Missouri remain accessible by direct links and can be offered through eligible referrer links without appearing in the public dropdown.
  - Added United Way of Greater Kansas City branding and cross-state options for Kansas and Missouri.

- **Bug Fixes**
  - Referrer-specific state selections now apply consistently across state entry points.

- **Documentation**
  - Clarified state visibility, referrer configuration, theming, and rollout guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->