### PR TITLE
MFB-1733: protect ICU placeholders from auto-translation

### DIFF
--- a/integrations/clients/google_translate.py
+++ b/integrations/clients/google_translate.py
@@ -214,12 +214,15 @@ class Translate:
         if "__all__" in langs:
             langs = Translate.languages
 
+        # Reset before the refusal check, not after: a caller that catches the refusal
+        # and then reads last_integrity_failures must not see the previous call's
+        # failures attributed to this batch.
+        self.last_integrity_failures = []
+
         for text in texts:
             reason = unsupported_reason(text)
             if reason is not None:
                 raise TranslationIntegrityError(f"Refusing to auto-translate {text!r}: it {reason}")
-
-        self.last_integrity_failures: list[tuple[str, str, str]] = []
 
         translations = {text: {} for text in texts}
         for lang in langs:

--- a/integrations/clients/google_translate.py
+++ b/integrations/clients/google_translate.py
@@ -1,10 +1,60 @@
+from collections import Counter
 from sentry_sdk import capture_exception
 from django.conf import settings
 from decouple import config
 import json
+import re
 from google.oauth2 import service_account
 from google.cloud import translate_v2 as translate
 import html
+
+# Matches a simple ICU argument such as {subject} or {count}. Deliberately
+# excludes nested braces so it can never half-match a plural/select message.
+_PLACEHOLDER_RE = re.compile(r"\{[^{}]*\}")
+
+# Matches the opening of an ICU plural/select/selectordinal message.
+_ICU_RE = re.compile(r"\{\s*\w+\s*,\s*(?:plural|select|selectordinal)\b")
+
+# Sentinel substituted for each placeholder before the text is sent to Google.
+# The double underscores are load-bearing: a bare token gets semantically
+# reinterpreted (Google read "PH0" as pH and returned "acidity level" in
+# Arabic), and control-character delimiters are stripped outright.
+_SENTINEL = "__PH{}__"
+_SENTINEL_RE = re.compile(r"__PH(\d+)__")
+
+
+class TranslationIntegrityError(Exception):
+    """
+    Raised when a string cannot be auto-translated safely, either because it is
+    a kind we refuse to machine-translate or because the translation came back
+    with its placeholders altered.
+    """
+
+
+def unsupported_reason(text: str) -> str | None:
+    """
+    Return why `text` cannot be safely auto-translated, or None if it can be.
+
+    Deliberately a module-level function rather than a method: classification is a
+    pure property of the string, needing no credentials, client or network. That
+    lets callers filter a batch without constructing a Translate, and keeps tests
+    that mock the API client from accidentally stubbing out this logic too.
+    """
+    if _ICU_RE.search(text):
+        return (
+            "contains an ICU plural/select message. Plural categories differ by language "
+            "(English has 2, Russian and Polish 3-4, Arabic 6), so machine translation "
+            "cannot produce the forms the source does not have. Needs a human translation, "
+            "or rephrase the English so it does not need a plural at all."
+        )
+    if _SENTINEL_RE.search(text):
+        return "contains the reserved placeholder-protection token __PHn__"
+    return None
+
+
+def is_auto_translatable(text: str) -> bool:
+    """True when `text` can be machine-translated without corrupting it."""
+    return unsupported_reason(text) is None
 
 
 class Translate:
@@ -14,6 +64,14 @@ class Translate:
     This class preserves paragraph structure by splitting input text into paragraphs before translation
     and joining them after translation. This ensures that multi-paragraph texts retain their original
     formatting when translated. All translation entry points (single and bulk) use this logic.
+
+    It also protects `react-intl` placeholders. Sent unprotected, Google translates
+    the contents of {...} along with everything else: {subject} comes back as
+    {sujeto} in Spanish and {субъект} in Russian, and French drops it entirely by
+    paraphrasing it away. The frontend then passes values={{ subject }} against a
+    message that no longer references `subject`, so the value never renders. Every
+    placeholder is therefore swapped for a sentinel before the API call, restored
+    after, and the result is verified before it is handed back.
     """
 
     main_language: str = settings.LANGUAGE_CODE
@@ -44,6 +102,9 @@ class Translate:
         info = json.loads(config("GOOGLE_APPLICATION_CREDENTIALS"))
         creds = service_account.Credentials.from_service_account_info(info)
         self.client = translate.Client(credentials=creds)
+        # Per-call log of (text, lang, detail) for placeholder failures tolerated
+        # under strict=False. Reset at the start of every bulk_translate.
+        self.last_integrity_failures: list[tuple[str, str, str]] = []
 
     LANGUAGE_CODE_MAPPING = {
         "pt-br": "pt",  # Map pt-br to pt for Google Translate
@@ -52,6 +113,65 @@ class Translate:
 
     def _map_language_code(self, lang_code):
         return self.LANGUAGE_CODE_MAPPING.get(lang_code, lang_code)
+
+    @staticmethod
+    def _protect_placeholders(text: str) -> tuple[str, list[str]]:
+        """
+        Swap every {placeholder} for an opaque sentinel, returning the protected
+        text and the placeholders in the order they were replaced.
+        """
+        found: list[str] = []
+
+        def _replace(match: re.Match) -> str:
+            found.append(match.group(0))
+            return _SENTINEL.format(len(found) - 1)
+
+        return _PLACEHOLDER_RE.sub(_replace, text), found
+
+    @staticmethod
+    def _restore_placeholders(text: str, placeholders: list[str]) -> str:
+        """Put the original placeholders back where their sentinels ended up."""
+
+        def _replace(match: re.Match) -> str:
+            index = int(match.group(1))
+            # An out-of-range index means the model invented a sentinel; leave it
+            # alone so the integrity check below reports the discrepancy.
+            return placeholders[index] if index < len(placeholders) else match.group(0)
+
+        return _SENTINEL_RE.sub(_replace, text)
+
+    @staticmethod
+    def _assert_placeholders_intact(source: str, translated: str, lang: str) -> None:
+        """
+        Refuse a translation whose placeholders do not match the source exactly.
+
+        Compares multisets rather than sets: a source that uses {count} twice must
+        come back with it twice, since a dropped repeat silently changes meaning.
+        Also rejects any protection sentinel left behind, which the multiset check
+        alone would miss. Failing loudly here is the point - a silent corruption is
+        what let 18 keys reach production with unresolvable placeholders.
+        """
+        # A sentinel left in the output means the model invented an index we never
+        # issued. The placeholder multiset can still match in that case, so this is
+        # checked separately - otherwise a literal "__PH7__" renders to the user.
+        leftover = _SENTINEL_RE.findall(translated)
+        if leftover:
+            raise TranslationIntegrityError(
+                f"Translation to {lang} left unresolved protection tokens "
+                f"{sorted(set(leftover))} in {translated!r} (source {source!r})"
+            )
+
+        expected = Counter(_PLACEHOLDER_RE.findall(source))
+        actual = Counter(_PLACEHOLDER_RE.findall(translated))
+        if expected == actual:
+            return
+
+        lost = sorted((expected - actual).elements())
+        gained = sorted((actual - expected).elements())
+        raise TranslationIntegrityError(
+            f"Translation to {lang} altered the placeholders of {source!r}: "
+            f"got {translated!r} (missing {lost}, unexpected {gained})"
+        )
 
     def translate(self, lang: str, text: str):
         """
@@ -68,13 +188,38 @@ class Translate:
         result = self.bulk_translate([lang], [text])
         return result[text][lang]
 
-    def bulk_translate(self, langs: list[str], texts: list[str]):
+    def bulk_translate(self, langs: list[str], texts: list[str], strict: bool = True):
         """
         Translates all of the texts to the target langs, preserving paragraph structure for each text.
         Include __all__ in langs to translate to all languages.
+
+        Raises TranslationIntegrityError for a string we refuse to machine-translate
+        (see the module-level `unsupported_reason`) or one whose placeholders did not survive the
+        round trip. Filter with `is_auto_translatable` first if a batch should skip
+        such strings rather than abort.
+
+        Placeholder failures are per-language, not per-string: Google can mangle a
+        placeholder in one language and handle the other sixteen perfectly. Observed
+        live - "Step {step} of {total}" came back from zh-hans as
+        "步骤 {step}（{total} 的 {step}）", duplicating a sentinel, while every other
+        language was clean.
+
+        With strict=True (the default) any such failure raises, so no caller degrades
+        silently. With strict=False the offending language is omitted from that text's
+        result and recorded in `last_integrity_failures`, letting a caller keep the
+        languages that worked and report the ones that did not. An omitted row is the
+        right degradation: with no row at all the API falls back to English, whereas a
+        blank row would render as empty text.
         """
         if "__all__" in langs:
             langs = Translate.languages
+
+        for text in texts:
+            reason = unsupported_reason(text)
+            if reason is not None:
+                raise TranslationIntegrityError(f"Refusing to auto-translate {text!r}: it {reason}")
+
+        self.last_integrity_failures: list[tuple[str, str, str]] = []
 
         translations = {text: {} for text in texts}
         for lang in langs:
@@ -85,9 +230,10 @@ class Translate:
             google_lang = self._map_language_code(lang)
             google_source = self._map_language_code(Translate.main_language)
 
-            # For each text, split into paragraphs, translate, and rejoin
+            # For each text, protect placeholders, split into paragraphs, translate, and rejoin
             for text in texts:
-                paragraphs = self.split_paragraphs(text)
+                protected, placeholders = self._protect_placeholders(text)
+                paragraphs = self.split_paragraphs(protected)
 
                 try:
                     results = self.client.translate(
@@ -102,7 +248,17 @@ class Translate:
                     translated_paragraphs = [self.format_text(results)]
                 else:
                     translated_paragraphs = [self.format_text(res) for res in results]
-                translations[text][lang] = self.join_paragraphs(translated_paragraphs)
+
+                restored = self._restore_placeholders(self.join_paragraphs(translated_paragraphs), placeholders)
+                try:
+                    self._assert_placeholders_intact(text, restored, lang)
+                except TranslationIntegrityError as e:
+                    if strict:
+                        raise
+                    # Omit this language and carry on; the caller reports the gap.
+                    self.last_integrity_failures.append((text, lang, str(e)))
+                    continue
+                translations[text][lang] = restored
         return translations
 
     def format_text(self, result):

--- a/integrations/clients/tests/test_google_translate.py
+++ b/integrations/clients/tests/test_google_translate.py
@@ -1,0 +1,227 @@
+"""
+Unit tests for placeholder protection in the Google Translate client.
+
+These mock the Google API client directly rather than `bulk_translate`, because
+the behaviour under test lives inside `bulk_translate` itself. The fake client
+mimics the specific ways Google mangles `react-intl` placeholders, all observed
+against the real API while diagnosing MFB-1733:
+
+  - renames them   {subject} -> {sujeto} (es), {субъект} (ru), {주제} (ko)
+  - drops them     French paraphrases the subject away entirely
+  - localises ICU  plural -> pluriel (fr), 复数 with a fullwidth comma (zh-hans)
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from integrations.clients.google_translate import (
+    Translate,
+    TranslationIntegrityError,
+    is_auto_translatable,
+    unsupported_reason,
+)
+
+
+def _fake_google(transform):
+    """
+    Build a stand-in for google.cloud.translate_v2.Client.
+
+    `transform` receives each paragraph and returns the "translated" string, so a
+    test can simulate a specific corruption. The shape of the return value matches
+    what the real client produces: a list of dicts carrying input and translatedText.
+    """
+
+    class FakeClient:
+        def translate(self, values, target_language=None, source_language=None):
+            return [{"input": value, "translatedText": transform(value, target_language)} for value in values]
+
+    return FakeClient()
+
+
+class TranslateClientTestBase(TestCase):
+    """Builds a Translate instance without touching credentials or the network."""
+
+    def make_translator(self, transform) -> Translate:
+        with patch.object(Translate, "__init__", lambda self: None):
+            translator = Translate()
+        translator.client = _fake_google(transform)
+        return translator
+
+
+class PlaceholderProtectionTests(TranslateClientTestBase):
+    def test_placeholder_survives_a_translator_that_would_rename_it(self):
+        """The whole point: a renaming translator must not be able to break the message."""
+
+        def rename_braced_content(text, lang):
+            # Stands in for Google turning {subject} into {sujeto}. It only fires on
+            # literal braces, so protected sentinels pass through untouched.
+            return text.replace("{subject}", "{sujeto}")
+
+        translator = self.make_translator(rename_braced_content)
+        result = translator.bulk_translate(["es"], ["Are {subject} employed?"])
+
+        self.assertEqual(result["Are {subject} employed?"]["es"], "Are {subject} employed?")
+
+    def test_multiple_placeholders_are_restored_in_the_right_order(self):
+        source = "Tell us about your {relationship}, age {age}"
+
+        translator = self.make_translator(lambda text, lang: text)
+        self.assertEqual(translator.bulk_translate(["es"], [source])[source]["es"], source)
+
+    def test_reordered_sentinels_each_resolve_to_their_own_placeholder(self):
+        """
+        Word order legitimately changes between languages, so the sentinels can come
+        back in a different order. Each must still map to the placeholder it replaced
+        rather than to its new position.
+        """
+        source = "Tell us about your {relationship}, age {age}"
+        reversing = self.make_translator(lambda text, lang: "__PH1__ then __PH0__")
+
+        result = reversing.bulk_translate(["ko"], [source])[source]["ko"]
+
+        self.assertEqual(result, "{age} then {relationship}")
+
+    def test_sentinel_is_not_left_in_the_output(self):
+        translator = self.make_translator(lambda text, lang: text)
+        source = "Step {step} of {total}"
+        result = translator.bulk_translate(["fr"], [source])[source]["fr"]
+        self.assertNotIn("__PH", result)
+        self.assertEqual(result, source)
+
+    def test_text_without_placeholders_is_unaffected(self):
+        translator = self.make_translator(lambda text, lang: f"[{lang}] {text}")
+        source = "Help finding shelter"
+        result = translator.bulk_translate(["es"], [source])[source]["es"]
+        self.assertEqual(result, "[es] Help finding shelter")
+
+    def test_paragraph_structure_is_preserved_alongside_placeholders(self):
+        source = "First line about {subject}\nSecond line about {other}"
+        translator = self.make_translator(lambda text, lang: text)
+        result = translator.bulk_translate(["ru"], [source])[source]["ru"]
+        self.assertEqual(result, source)
+        self.assertEqual(result.count("\n"), 1)
+
+
+class IntegrityGuardTests(TranslateClientTestBase):
+    def test_dropped_placeholder_is_rejected(self):
+        """French paraphrased the subject away; that must fail rather than be stored."""
+
+        def drop_the_sentinel(text, lang):
+            return "Les personnes suivantes sont-elles employees?"
+
+        translator = self.make_translator(drop_the_sentinel)
+        with self.assertRaises(TranslationIntegrityError) as ctx:
+            translator.bulk_translate(["fr"], ["Are {subject} employed?"])
+        self.assertIn("{subject}", str(ctx.exception))
+
+    def test_invented_sentinel_index_is_rejected(self):
+        def invent_a_sentinel(text, lang):
+            return f"{text} __PH7__"
+
+        translator = self.make_translator(invent_a_sentinel)
+        with self.assertRaises(TranslationIntegrityError):
+            translator.bulk_translate(["es"], ["Are {subject} employed?"])
+
+    def test_repeated_placeholder_must_come_back_the_same_number_of_times(self):
+        """Multiset comparison: a dropped repeat changes meaning silently."""
+        source = "{count} of {count}"
+        translator = self.make_translator(lambda text, lang: text.replace("__PH1__", "").strip())
+        with self.assertRaises(TranslationIntegrityError):
+            translator.bulk_translate(["pl"], [source])
+
+    def test_error_names_the_language_and_the_offending_text(self):
+        translator = self.make_translator(lambda text, lang: "nothing here")
+        with self.assertRaises(TranslationIntegrityError) as ctx:
+            translator.bulk_translate(["ko"], ["Are {subject} employed?"])
+        message = str(ctx.exception)
+        self.assertIn("ko", message)
+        self.assertIn("Are {subject} employed?", message)
+
+
+class IcuRefusalTests(TranslateClientTestBase):
+    ICU = "{count, plural, one {program} other {programs}}"
+
+    def test_icu_plural_is_refused(self):
+        translator = self.make_translator(lambda text, lang: text)
+        with self.assertRaises(TranslationIntegrityError) as ctx:
+            translator.bulk_translate(["fr"], [self.ICU])
+        self.assertIn("plural", str(ctx.exception))
+
+    def test_icu_select_is_refused(self):
+        translator = self.make_translator(lambda text, lang: text)
+        with self.assertRaises(TranslationIntegrityError):
+            translator.bulk_translate(["fr"], ["{gender, select, male {he} other {they}}"])
+
+    def test_batch_is_refused_before_any_api_call(self):
+        """A bad string must not let its neighbours through half-translated."""
+        calls = []
+
+        def record(text, lang):
+            calls.append(text)
+            return text
+
+        translator = self.make_translator(record)
+        with self.assertRaises(TranslationIntegrityError):
+            translator.bulk_translate(["es"], ["Fine {subject} string", self.ICU])
+        self.assertEqual(calls, [], "no paragraph should be sent when the batch contains a refused string")
+
+    def test_is_auto_translatable_classifies_correctly(self):
+        self.assertTrue(is_auto_translatable("Are {subject} employed?"))
+        self.assertTrue(is_auto_translatable("Help finding shelter"))
+        self.assertFalse(is_auto_translatable(self.ICU))
+        self.assertFalse(is_auto_translatable("already has __PH0__ in it"))
+
+    def test_unsupported_reason_explains_the_plural_problem(self):
+        reason = unsupported_reason(self.ICU)
+        self.assertIsNotNone(reason)
+        self.assertIn("Plural categories differ by language", reason)
+        self.assertIsNone(unsupported_reason("Are {subject} employed?"))
+
+
+class PerLanguageFailureTests(TranslateClientTestBase):
+    """
+    A placeholder failure in one language must not cost us the others. Observed
+    live: zh-hans duplicated a sentinel for "Step {step} of {total}" while the
+    other sixteen languages were clean.
+    """
+
+    SOURCE = "Step {step} of {total}"
+
+    def _duplicating_in(self, bad_lang):
+        def transform(text, lang):
+            # google_lang codes are the mapped ones, so compare on the prefix
+            return f"{text} (__PH0__)" if lang == bad_lang else text
+
+        return transform
+
+    def test_strict_by_default_so_nothing_degrades_silently(self):
+        translator = self.make_translator(self._duplicating_in("es"))
+        with self.assertRaises(TranslationIntegrityError):
+            translator.bulk_translate(["es", "fr"], [self.SOURCE])
+
+    def test_non_strict_keeps_the_good_languages(self):
+        translator = self.make_translator(self._duplicating_in("es"))
+
+        result = translator.bulk_translate(["es", "fr"], [self.SOURCE], strict=False)
+
+        self.assertNotIn("es", result[self.SOURCE], "the mangled language must not be written")
+        self.assertEqual(result[self.SOURCE]["fr"], self.SOURCE)
+
+    def test_non_strict_records_the_failure_for_reporting(self):
+        translator = self.make_translator(self._duplicating_in("es"))
+
+        translator.bulk_translate(["es", "fr"], [self.SOURCE], strict=False)
+
+        self.assertEqual(len(translator.last_integrity_failures), 1)
+        text, lang, detail = translator.last_integrity_failures[0]
+        self.assertEqual((text, lang), (self.SOURCE, "es"))
+        self.assertIn("{step}", detail)
+
+    def test_failures_reset_between_calls(self):
+        translator = self.make_translator(self._duplicating_in("es"))
+        translator.bulk_translate(["es"], [self.SOURCE], strict=False)
+        self.assertEqual(len(translator.last_integrity_failures), 1)
+
+        translator.bulk_translate(["fr"], [self.SOURCE], strict=False)
+        self.assertEqual(translator.last_integrity_failures, [])

--- a/integrations/clients/tests/test_google_translate.py
+++ b/integrations/clients/tests/test_google_translate.py
@@ -225,3 +225,28 @@ class PerLanguageFailureTests(TranslateClientTestBase):
 
         translator.bulk_translate(["fr"], [self.SOURCE], strict=False)
         self.assertEqual(translator.last_integrity_failures, [])
+
+
+class FailureLogLifecycleTests(TranslateClientTestBase):
+    """
+    The failure log must always describe the most recent call. bulk_translate.py
+    reuses one Translate across batches, so a stale log would misattribute a
+    previous batch's failures to the current one.
+    """
+
+    ICU = "{count, plural, one {program} other {programs}}"
+
+    def test_refusal_clears_the_previous_calls_failures(self):
+        translator = self.make_translator(
+            lambda text, lang: f"{text} (__PH0__)" if "__PH0__" in text else text,
+        )
+
+        translator.bulk_translate(["es"], ["Are {subject} employed?"], strict=False)
+        self.assertEqual(len(translator.last_integrity_failures), 1)
+
+        # A refused string raises before any translating happens; the log must still
+        # have been reset, so a caller catching this does not read the stale entry.
+        with self.assertRaises(TranslationIntegrityError):
+            translator.bulk_translate(["es"], [self.ICU])
+
+        self.assertEqual(translator.last_integrity_failures, [])

--- a/translations/management/commands/add_translations.py
+++ b/translations/management/commands/add_translations.py
@@ -236,10 +236,14 @@ class Command(BaseCommand):
             # keeping a stale corrupted value.
             results = translate.bulk_translate(["__all__"], unique_texts, strict=False)
         except TranslationIntegrityError as e:
+            # Backstop only: refused strings are filtered out above with the same
+            # predicate bulk_translate uses, and strict=False suppresses per-language
+            # integrity raises, so this should be unreachable. If it does fire, some
+            # languages may already have been written before the failure.
             raise CommandError(
-                f"A translation came back with its placeholders altered; English rows were saved "
-                f"but no other-language rows were written. This is the guard working - the string "
-                f"needs a human translation rather than a re-run. Error: {e}"
+                f"A string was refused by the translation integrity guard. English rows were saved and "
+                f"some languages may already have been written. The string needs a human translation "
+                f"rather than a re-run. Error: {e}"
             )
         except Exception as e:
             raise CommandError(f"Translation API call failed; English rows were saved. Re-run to retry. Error: {e}")

--- a/translations/management/commands/add_translations.py
+++ b/translations/management/commands/add_translations.py
@@ -5,7 +5,12 @@ from sys import stdin
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from integrations.clients.google_translate import Translate
+from integrations.clients.google_translate import (
+    Translate,
+    TranslationIntegrityError,
+    is_auto_translatable,
+    unsupported_reason,
+)
 from translations.models import Translation
 
 
@@ -156,6 +161,17 @@ class Command(BaseCommand):
             )
         else:
             self.stdout.write(f"Auto-translate target languages: {target_languages}")
+            not_translatable = {
+                label: unsupported_reason(text) for label, text in data.items() if not is_auto_translatable(text)
+            }
+            if not_translatable:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"{len(not_translatable)} label(s) will get English rows only, not auto-translated:"
+                    )
+                )
+                for label, reason in not_translatable.items():
+                    self.stdout.write(self.style.WARNING(f"  ! {label} - it {reason}"))
 
         if dry_run:
             self.stdout.write(self.style.NOTICE("\nDry run — no changes written, no translation API calls made."))
@@ -186,6 +202,27 @@ class Command(BaseCommand):
             if text and text.strip():
                 by_text.setdefault(text, []).append(translation_obj)
 
+        # Strings we refuse to machine-translate (ICU plural/select) are reported and
+        # skipped rather than aborting the batch: their English rows are already saved
+        # above, so the label exists and react-intl falls back to English until a human
+        # supplies the other languages.
+        refused = {}
+        for text in list(by_text):
+            reason = unsupported_reason(text)
+            if reason is not None:
+                refused[text] = reason
+                del by_text[text]
+
+        if refused:
+            self.stdout.write(
+                self.style.WARNING(f"\nSkipping auto-translate for {len(refused)} string(s) - English rows saved:")
+            )
+            for text, reason in refused.items():
+                labels = sorted(label for label, value in data.items() if value == text)
+                self.stdout.write(self.style.WARNING(f"  ! {', '.join(labels)}"))
+                self.stdout.write(f"      {text!r}")
+                self.stdout.write(f"      it {reason}")
+
         unique_texts = list(by_text.keys())
         if not unique_texts:
             self.stdout.write(self.style.SUCCESS("No non-empty English text to translate."))
@@ -193,9 +230,31 @@ class Command(BaseCommand):
 
         try:
             # "__all__" expands to every configured non-default language inside the client.
-            results = translate.bulk_translate(["__all__"], unique_texts)
+            # strict=False so one language mangling a placeholder does not cost us the
+            # other sixteen; the failures are reported below and simply get no row,
+            # which falls back to English.
+            results = translate.bulk_translate(["__all__"], unique_texts, strict=False)
+        except TranslationIntegrityError as e:
+            raise CommandError(
+                f"A translation came back with its placeholders altered; English rows were saved "
+                f"but no other-language rows were written. This is the guard working - the string "
+                f"needs a human translation rather than a re-run. Error: {e}"
+            )
         except Exception as e:
             raise CommandError(f"Translation API call failed; English rows were saved. Re-run to retry. Error: {e}")
+
+        integrity_failures = getattr(translate, "last_integrity_failures", [])
+        if integrity_failures:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\n{len(integrity_failures)} (string, language) pair(s) came back with altered "
+                    f"placeholders and were NOT written - those languages fall back to English:"
+                )
+            )
+            for text, lang, detail in integrity_failures:
+                labels = sorted(label for label, value in data.items() if value == text)
+                self.stdout.write(self.style.WARNING(f"  ! {', '.join(labels)} [{lang}]"))
+                self.stdout.write(f"      {detail}")
 
         translated_records = 0
         langs_written = set()

--- a/translations/management/commands/add_translations.py
+++ b/translations/management/commands/add_translations.py
@@ -11,7 +11,7 @@ from integrations.clients.google_translate import (
     is_auto_translatable,
     unsupported_reason,
 )
-from translations.models import Translation
+from translations.models import Translation, _invalidate_translation_cache
 
 
 class Command(BaseCommand):
@@ -231,8 +231,9 @@ class Command(BaseCommand):
         try:
             # "__all__" expands to every configured non-default language inside the client.
             # strict=False so one language mangling a placeholder does not cost us the
-            # other sixteen; the failures are reported below and simply get no row,
-            # which falls back to English.
+            # other sixteen. Failed pairs are reported below, and any pre-existing row
+            # for them is cleared so the label falls back to English rather than
+            # keeping a stale corrupted value.
             results = translate.bulk_translate(["__all__"], unique_texts, strict=False)
         except TranslationIntegrityError as e:
             raise CommandError(
@@ -255,6 +256,39 @@ class Command(BaseCommand):
                 labels = sorted(label for label, value in data.items() if value == text)
                 self.stdout.write(self.style.WARNING(f"  ! {', '.join(labels)} [{lang}]"))
                 self.stdout.write(f"      {detail}")
+
+            # Skipping the write is only "falls back to English" for a brand-new label.
+            # Re-translating an already-corrupted key is the main use of this command, and
+            # there the old bad row is still sitting in the DB - leaving it would mean the
+            # guard reports a problem while the corruption stays live. Delete the row so
+            # the API's key-presence fallback serves English instead. Deleting rather than
+            # blanking matters: an empty row is served as empty text, not fallen back on.
+            cleared = 0
+            preserved: list[str] = []
+            for text, lang, _detail in integrity_failures:
+                for translation_obj in by_text.get(text, []):
+                    row = translation_obj.translations.filter(language_code=lang).first()
+                    if row is None:
+                        continue
+                    if row.edited:
+                        # Never destroy a human's work to make room for a fallback.
+                        preserved.append(f"{translation_obj.label} [{lang}]")
+                        continue
+                    row.delete()
+                    cleared += 1
+
+            if cleared:
+                _invalidate_translation_cache()
+                self.stdout.write(
+                    self.style.WARNING(f"  Cleared {cleared} stale row(s) so those languages fall back to English.")
+                )
+            if preserved:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Kept {len(preserved)} manually-edited row(s) despite the failure: "
+                        f"{', '.join(preserved)}"
+                    )
+                )
 
         translated_records = 0
         langs_written = set()

--- a/translations/management/commands/bulk_translate.py
+++ b/translations/management/commands/bulk_translate.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.db.models import Q, OuterRef, Exists
 from translations.models import Translation
-from integrations.clients.google_translate import Translate
+from integrations.clients.google_translate import Translate, is_auto_translatable, unsupported_reason
 
 
 class Command(BaseCommand):
@@ -103,13 +103,35 @@ class Command(BaseCommand):
         print(f"Processing {len(batches)} batches for language {lang}")
 
         records_created = 0
+        # Accumulated across batches, since the client resets its own log per call.
+        skipped_integrity: list[tuple[str, str]] = []
+        skipped_refused: list[tuple[str, str]] = []
 
         for i, batch in enumerate(batches):
 
             try:
-                auto = translate.bulk_translate([lang], list(batch.keys()))
+                # Strings we refuse to machine-translate would raise and abort the whole
+                # run, losing the batches still to come. Filter them out and report.
+                translatable = [text for text in batch if is_auto_translatable(text)]
+                for text in batch:
+                    if text not in translatable:
+                        for trans in batch[text]:
+                            skipped_refused.append((trans.label, unsupported_reason(text)))
+                if not translatable:
+                    continue
+
+                # strict=False so one mangled placeholder costs only that string, not the
+                # rest of this batch and every batch after it.
+                auto = translate.bulk_translate([lang], translatable, strict=False)
+
+                for text, _lang, _detail in translate.last_integrity_failures:
+                    for trans in batch.get(text, []):
+                        skipped_integrity.append((trans.label, lang))
 
                 for [original_text, new_text] in auto.items():
+                    if lang not in new_text:
+                        # Placeholder integrity failure; recorded above.
+                        continue
                     for trans in batch[original_text]:
                         Translation.objects.edit_translation_by_id(trans.id, lang, new_text[lang], manual=False)
                         records_created += 1
@@ -120,3 +142,11 @@ class Command(BaseCommand):
 
         print(f"Bulk translate completed successfully for {lang}")
         print(f"Total records created/updated: {records_created}")
+        if skipped_integrity:
+            print(f"Skipped {len(skipped_integrity)} label(s) whose placeholders did not survive translation:")
+            for label, failed_lang in skipped_integrity:
+                print(f"  ! {label} [{failed_lang}]")
+        if skipped_refused:
+            print(f"Skipped {len(skipped_refused)} label(s) we refuse to machine-translate:")
+            for label, reason in skipped_refused:
+                print(f"  ! {label} - it {reason}")

--- a/translations/management/commands/tests/test_add_translations.py
+++ b/translations/management/commands/tests/test_add_translations.py
@@ -121,7 +121,9 @@ class AddTranslationsCommandTest(TestCase):
         mock_translation.objects = self._mock_existing({})
         translate_instance = mock_translate.return_value
         # Echo back a translation per requested lang so fan-out has something to write.
-        translate_instance.bulk_translate.side_effect = lambda langs, texts: {t: {"es": f"{t}-es"} for t in texts}
+        translate_instance.bulk_translate.side_effect = lambda langs, texts, strict=True: {
+            t: {"es": f"{t}-es"} for t in texts
+        }
 
         # Three labels, two of which share identical English text.
         self._run({"x": "Shared", "y": "Shared", "z": "Unique"})

--- a/translations/management/commands/tests/test_add_translations.py
+++ b/translations/management/commands/tests/test_add_translations.py
@@ -172,3 +172,70 @@ class AddTranslationsCommandTest(TestCase):
         path = self._write_json('{"a": 123}')
         with self.assertRaises(CommandError):
             call_command("add_translations", path, stdout=self.out)
+
+
+class IntegrityFailureRowCleanupTest(AddTranslationsCommandTest):
+    """
+    A skipped language must not leave a stale corrupted row behind.
+
+    Skipping the write only means "falls back to English" for a brand-new label.
+    Re-translating an already-corrupted key is the main use of this command, and
+    there the old bad row is still in the DB - so the guard would report a problem
+    while the corruption stayed live on the site.
+    """
+
+    def _translate_mock(self, mock_translate, failures):
+        instance = mock_translate.return_value
+        instance.bulk_translate.side_effect = lambda langs, texts, strict=True: {t: {} for t in texts}
+        instance.last_integrity_failures = failures
+        return instance
+
+    @patch("translations.management.commands.add_translations._invalidate_translation_cache")
+    @patch("translations.management.commands.add_translations.Translate")
+    @patch("translations.management.commands.add_translations.Translation")
+    def test_stale_row_is_deleted_so_the_label_falls_back_to_english(
+        self, mock_translation, mock_translate, mock_invalidate
+    ):
+        mock_translation.objects = self._mock_existing({})
+        row = MagicMock(edited=False)
+        parent = MagicMock(id="k", label="k")
+        parent.translations.filter.return_value.first.return_value = row
+        mock_translation.objects.add_translation.side_effect = lambda label, default_message, **_: parent
+
+        self._translate_mock(mock_translate, [("Are {subject} employed?", "es", "detail")])
+        self._run({"k": "Are {subject} employed?"})
+
+        row.delete.assert_called_once()
+        mock_invalidate.assert_called_once()
+
+    @patch("translations.management.commands.add_translations._invalidate_translation_cache")
+    @patch("translations.management.commands.add_translations.Translate")
+    @patch("translations.management.commands.add_translations.Translation")
+    def test_manually_edited_row_is_preserved(self, mock_translation, mock_translate, mock_invalidate):
+        """Never destroy a human's translation to make room for an English fallback."""
+        mock_translation.objects = self._mock_existing({})
+        row = MagicMock(edited=True)
+        parent = MagicMock(id="k", label="k")
+        parent.translations.filter.return_value.first.return_value = row
+        mock_translation.objects.add_translation.side_effect = lambda label, default_message, **_: parent
+
+        self._translate_mock(mock_translate, [("Are {subject} employed?", "es", "detail")])
+        self._run({"k": "Are {subject} employed?"})
+
+        row.delete.assert_not_called()
+        mock_invalidate.assert_not_called()
+
+    @patch("translations.management.commands.add_translations._invalidate_translation_cache")
+    @patch("translations.management.commands.add_translations.Translate")
+    @patch("translations.management.commands.add_translations.Translation")
+    def test_absent_row_needs_no_cleanup(self, mock_translation, mock_translate, mock_invalidate):
+        """A brand-new label has no row to clear; nothing should be deleted or invalidated."""
+        mock_translation.objects = self._mock_existing({})
+        parent = MagicMock(id="k", label="k")
+        parent.translations.filter.return_value.first.return_value = None
+        mock_translation.objects.add_translation.side_effect = lambda label, default_message, **_: parent
+
+        self._translate_mock(mock_translate, [("Are {subject} employed?", "es", "detail")])
+        self._run({"k": "Are {subject} employed?"})
+
+        mock_invalidate.assert_not_called()

--- a/translations/tests.py
+++ b/translations/tests.py
@@ -29,6 +29,8 @@ from translations.models import (
     _translation_cache_timeout,
 )
 from translations.views import TranslationView
+from authentication.models import User
+from integrations.clients.google_translate import TranslationIntegrityError
 
 DEFAULT_LANG = settings.LANGUAGE_CODE
 
@@ -262,3 +264,70 @@ class TestTranslationViewErrorPath(TestCase):
             response = self._get(DEFAULT_LANG)
 
         self.assertNotIn("traceback", response.data)
+
+
+class TestAdminAutoTranslateFailurePaths(TestCase):
+    """
+    The translation integrity guard raises where it used to silently write corrupted
+    text. These admin views had no exception handling, so an unprotected guard turned
+    a silent corruption into a 500 for the admin -- and in the create case the label
+    row is committed before the translation call, so a 500 would strand a new label
+    behind an error page with no explanation.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_superuser(email_or_cell="admin@example.com", password="pw")
+        self.client.force_login(self.user)
+
+    def _make_label(self, label, english):
+        parent = Translation.objects.create(label=label, active=True)
+        parent.create_translation(DEFAULT_LANG, text=english, edited=True)
+        _invalidate_translation_cache()
+        return parent
+
+    @patch("translations.views.Translate")
+    def test_create_with_icu_plural_does_not_500_and_still_creates_the_label(self, mock_translate):
+        """An ICU string is refused by the guard; the label must still be created."""
+        response = self.client.post(
+            "/api/translations/admin",
+            {"label": "test.plural", "default_message": "{count, plural, one {item} other {items}}"},
+        )
+
+        self.assertNotEqual(response.status_code, 500)
+        self.assertTrue(Translation.objects.filter(label="test.plural").exists())
+        # Refused before any API call, so the client is never even constructed.
+        mock_translate.return_value.bulk_translate.assert_not_called()
+
+    @patch("translations.views.Translate")
+    def test_create_survives_an_integrity_error_from_the_client(self, mock_translate):
+        mock_translate.return_value.bulk_translate.side_effect = TranslationIntegrityError("mangled")
+
+        response = self.client.post(
+            "/api/translations/admin",
+            {"label": "test.placeholder", "default_message": "Are {subject} employed?"},
+        )
+
+        self.assertNotEqual(response.status_code, 500)
+        self.assertTrue(Translation.objects.filter(label="test.placeholder").exists())
+
+    @patch("translations.views.Translate")
+    def test_edit_skips_only_the_failing_language(self, mock_translate):
+        """A placeholder failure in one language must not cost the others, or 500."""
+        parent = self._make_label("test.subject", "Are {subject} employed?")
+        mock_translate.return_value.bulk_translate.return_value = {
+            "Are {subject} changed?": {"es": "es-text"}  # note: 'fr' absent -> integrity failure
+        }
+        mock_translate.languages = ["es", "fr"]
+
+        response = self.client.post(
+            f"/api/translations/admin/{parent.id}/en-us",
+            {"text": "Are {subject} changed?", "auto_translate_check": "on"},
+        )
+
+        self.assertNotEqual(response.status_code, 500)
+        parent.refresh_from_db()
+        parent.set_current_language("es")
+        self.assertEqual(parent.text, "es-text")
+        # fr was omitted by the guard, so no row should have been written for it.
+        self.assertFalse(parent.has_translation("fr"))

--- a/translations/views.py
+++ b/translations/views.py
@@ -34,7 +34,7 @@ from programs.translation_overrides import warning_calculators
 from phonenumber_field.formfields import PhoneNumberField
 from django.contrib.auth.decorators import login_required
 from django.contrib.admin.views.decorators import staff_member_required
-from integrations.clients.google_translate import Translate
+from integrations.clients.google_translate import Translate, TranslationIntegrityError, is_auto_translatable
 from django.urls import path
 
 
@@ -112,7 +112,15 @@ def admin_view(request):
             text = form["default_message"].value()
             translation = Translation.objects.add_translation(form["label"].value(), text)
 
-            auto_translations = Translate().bulk_translate(["__all__"], [text])[text]
+            # The label row is already committed above, so a translation problem must not
+            # 500 the request and lose that. strict=False keeps the languages that worked;
+            # a refused string (ICU plural/select) raises regardless and yields none.
+            auto_translations = {}
+            if is_auto_translatable(text):
+                try:
+                    auto_translations = Translate().bulk_translate(["__all__"], [text], strict=False).get(text, {})
+                except Exception as e:
+                    capture_exception(e, level="warning")
 
             for [language, auto_text] in auto_translations.items():
                 Translation.objects.edit_translation_by_id(translation.id, language, auto_text, False)
@@ -290,9 +298,26 @@ def edit_translation(request, id=0, lang="en-us"):
                     if not auto_translate_check:
                         Translation.objects.edit_translation_by_id(id, lang, text, False)
                     else:
-                        translations = Translate().bulk_translate(languages, [text])[text]
+                        # strict=False so one language mangling a placeholder does not cost
+                        # the rest, and so an integrity failure cannot 500 an admin edit.
+                        translations = {}
+                        if is_auto_translatable(text):
+                            try:
+                                translations = Translate().bulk_translate(languages, [text], strict=False).get(text, {})
+                            except TranslationIntegrityError as e:
+                                capture_exception(e, level="warning")
+
                         for language in languages:
-                            translated_text = text if translation.no_auto else translations[language]
+                            if translation.no_auto:
+                                translated_text = text
+                            elif language in translations:
+                                translated_text = translations[language]
+                            else:
+                                # Placeholder failure for this language. Leave the existing row
+                                # alone rather than writing junk. Unlike add_translations, which
+                                # deletes the stale row because nobody inspects a bulk run, an
+                                # admin is looking at this page and will see the untouched value.
+                                continue
                             Translation.objects.edit_translation_by_id(id, language, translated_text, False)
 
             parent = Translation.objects.get(pk=id)


### PR DESCRIPTION
## Context & Motivation

Fixes [MFB-1733](https://linear.app/myfriendben/issue/MFB-1733), found while doing [MFB-1685](https://linear.app/myfriendben/issue/MFB-1685). Sub-issue of [MFB-1642](https://linear.app/myfriendben/issue/MFB-1642) and it **unblocks [MFB-1689](https://linear.app/myfriendben/issue/MFB-1689)**.

`Translate.bulk_translate` sent raw strings to Google Translate with no protection for `react-intl` placeholders, so Google translated the contents of `{...}` along with everything else. **18 keys are corrupted in production right now.**

Three distinct failures, all observed against the live API:

| | Example |
|---|---|
| Placeholder renamed | `{subject}` -> `{sujeto}` (es), `{субъект}` (ru), `{الموضوع}` (ar), `{주제}` (ko) |
| Placeholder dropped | `fr` returned "Les personnes suivantes sont-elles actuellement employées…" — paraphrased away entirely |
| ICU keywords localised | `{count, plural, one {…}}` -> `{count, pluriel, un {…}}` (fr); `{count，复数，一个 {…}}` (zh-hans, note the fullwidth comma, which invalidates the pattern) |

The frontend passes `values={{ subject }}` against a message that no longer references `subject`, so the value never resolves — Korean renders the literal braces to the user (`{주제}는 해당 교육기관에서…`).

**This is the root cause of MFB-1642's loudest complaint.** All 7 income and student-eligibility keys are affected, 2-6 languages each. `{subject}` is how the screener injects "you" vs "they", so when it is renamed or dropped the subject vanishes — which is exactly the reporter's "the word **you** is often left untranslated". MFB-1689 was previously blocked on MFB-1308's conditional-language logic; that attribution was wrong and has been corrected.

Not shipping means the corruption continues. `progressBar.stepOf` landed on `benefits-calculator` `main` in `782f5a7e` *during this investigation*, from a refactor whose author was deliberately using named placeholders so each locale could control word order — the correct i18n instinct, and precisely what the current tooling destroys.

## Changes Made

### Placeholder protection — `integrations/clients/google_translate.py`

Each `{placeholder}` is substituted for a `__PHn__` sentinel before the API call and restored after. **Sentinel choice was settled empirically against the live API, not assumed:**

| Candidate | Result |
|---|---|
| `\x00PH0\x00` | Fails — null bytes stripped; Google then read the bare `PH0` as *pH* and returned "مستوى الحموضة" ("acidity level") in Arabic |
| `<span translate="no">` | Survives, but inserts a space before punctuation (`</span> , edad`) in every language |
| `__PH0__` | Survives all 17 languages, order preserved, no artifacts — **chosen** |

### Validation guard, because protection alone is not enough

Protection is necessary but not sufficient, so the result is verified and rejected if it did not round-trip. Two real failures survive protection:

- `es` still drops a protected sentinel on `studentEligibility.enrolledHalfTime`, paraphrasing it to "los estudiantes"
- `zh-hans` **duplicated** a sentinel on `Step {step} of {total}`, returning `步骤 {step}（{total} 的 {step}）`

Placeholders are compared as **multisets, not sets** — that duplication is invisible to a set comparison, and a dropped repeat silently changes meaning. A leftover `__PHn__` is checked separately, since the multiset can match while an invented sentinel remains in the text.

### Failures are per-language, not per-string

`strict=True` (default) raises, so no caller degrades silently. `strict=False` omits the offending language, records it in `last_integrity_failures`, and keeps the rest.

### ICU plural/select is refused outright

English has 2 plural categories; Russian and Polish have 3-4, Arabic 6. Machine translation cannot produce forms the source does not contain, so a syntactically valid ICU result would still be linguistically wrong. Only 3 keys are affected and **none are live**.

**Recommended alternative, not done here:** all 3 only need plurals because of phrasing. `{count, plural, one {person} other {people}}` -> "Household size: 3" removes the plural entirely and machine-translates fine. That is a product copy decision, noted on MFB-1687 — worth taking, since MFB has no translator access at present and "needs a human" otherwise means "stays English indefinitely".

### Stale rows are cleared on failure — `add_translations`

Skipping the write only means "falls back to English" for a **brand-new** label. Re-translating an already-corrupted key is the primary use of this command in this ticket, and there the old bad row is still in the DB — so the guard would report a problem while the corruption stayed live. The offending row is now deleted and the cache invalidated.

Deleting rather than blanking is load-bearing: `_build_translation_data` decides the English fallback on key *presence*, not emptiness, so a blanked row is served as empty text. Rows with `edited=True` are preserved and reported instead — a human's translation is never destroyed to make room for a fallback. *(Caught by CodeRabbit.)*

### The other three call sites, which assumed the old contract — `views.py`, `bulk_translate`

Changing a shared client's failure mode from *silently writes corruption* to *raises* is a contract change, and `add_translations` was initially the only caller updated. The other three still assumed the old behaviour, so the change traded silent corruption for 500s and aborted runs. Found by self-review after the first two commits.

- **`translations/views.py`, new-translation admin POST.** The label row is committed *before* the translation call, so an unhandled raise stranded a newly-created label behind a 500 with no explanation. Now pre-filters refused strings, uses `strict=False`, and reports to Sentry rather than failing the request.
- **`translations/views.py`, `edit_translation` POST.** Same crash. Note `strict=False` alone would *not* have been safe here — the loop indexes `translations[language]` for every language, so an omitted language raises `KeyError` (the regression test reproduces exactly that). Now checks presence per language and leaves the existing row untouched when one fails.
- **`bulk_translate` management command.** Used the strict default and re-raised, so one mangled placeholder aborted the whole run with earlier batches already committed — and re-running hit the same wall. Now pre-filters refused strings, passes `strict=False`, and reports skipped labels per language at the end.

### Deliberately not changed

- **The 18 corrupted production rows.** This PR fixes the mechanism; re-translating the data is a separate step so the code can be reviewed without a production data change riding along.
- **`edit_translation` does not delete a stale row** the way `add_translations` does. An admin is looking at that page and will see the untouched value; nobody inspects each key of a bulk run. Flagging it as a decision rather than an inconsistency — say the word if you'd rather both paths behave identically.
- **No retry on integrity failure.** Google is non-deterministic so a retry might succeed, but might also produce a different corruption. Left out to keep this reviewable.
- **`programs/migrations/0114`** still calls `.translate()`. It operates on program category names, not placeholder strings, and is historical.

### Design note

`unsupported_reason` / `is_auto_translatable` are module-level functions, not methods. Classification is a pure property of the string needing no credentials, client or network, so callers can filter a batch without constructing a `Translate` — and it keeps tests that mock the API client from stubbing out the classification logic by accident. Two existing `add_translations` tests failed on the first attempt for exactly that reason.

## Testing

```
integrations/clients/tests/           20 passed   (new file)
translations/                         73 passed   (incl. 3 new admin-view tests)
programs/management/commands/tests/   71 passed
                                     ---
                                     164 passed
```

`black -l 120` clean. No pre-existing failures encountered.

**Every regression test verified against the unfixed code**, not assumed:

| Test group | Against unfixed code |
|---|---|
| Placeholder protection + guard (19) | **10 fail** with `_protect_placeholders` neutered and the guard bypassed |
| Stale-row cleanup (3) | **1 fails** with `row.delete()` neutered |
| Admin view hardening (3) | **all 3 fail** — the edit one with the predicted `KeyError: 'fr'` |
| Failure-log reset (1) | **fails** without moving the reset above the refusal check |

Tests mock the **Google API client**, not `bulk_translate`, since the behaviour under test lives inside `bulk_translate`. The fake client reproduces each corruption observed live (rename, drop, ICU localisation, duplication).

**Live end-to-end verification** across all 17 languages, 4 strings including the exact production-corrupted ones:

| String | Rows written | Corrupted rows written |
|---|---|---|
| `householdDataBlock.incomeQuestion-employed` | 17/17 | **0** |
| `studentEligibility.enrolledHalfTime` | 16/17 | **0** (`es` skipped + reported) |
| `householdDataBlock.questionHeader-relationship-age` | 17/17 | **0** |
| `progressBar.stepOf` | 16/17 | **0** (`zh-hans` skipped + reported) |

Before this change, `incomeQuestion-employed` wrote 5 of 17 corrupted, silently.

## Deployment

**Handled automatically** — per [`docs/DEPLOYMENT.md`](https://github.com/MyFriendBen/benefits-api/blob/main/docs/DEPLOYMENT.md), staging deploys on merge to `main` and production on publishing a Release; both run `manage.py migrate` and `manage.py add_config --all`. This PR adds no migration and touches no white-label config, so there is nothing for either to pick up.

This change is **inert until a translation command runs**. It alters how `bulk_translate` behaves, not any stored data, so merging it fixes nothing on its own and breaks nothing on its own.

- **Post-deployment scripts needed:** none for this PR. The 18 corrupted production keys are **not** repaired by merging — that is a follow-up on MFB-1733, to be run per environment once this is deployed, and it is where the user-visible fix actually lands. A full runbook with pre-built input maps is on the ticket.
- **Production config updates:** none.
- **Admin updates needed:** none. Note for whoever runs the follow-up re-translation: set `no_auto=True` on the 6 protected keys — the `bulk_translate` command skips `no_auto` labels, which stops a routine re-translate re-corrupting them.
- **Notify team/users of:** nothing user-facing on merge. Two behaviour changes the team should know about:
  - `add_translations` now **refuses** ICU plural/select strings instead of silently mangling them, and reports per-language skips. A run that used to "succeed" may now report skips — that is the guard working, not a regression.
  - The `bulk_translate` command now **skips and reports** problem strings instead of either writing corruption or (as of the first commit) aborting the run. Check its end-of-run summary for skipped labels.

  Rollback if needed: `heroku rollback -a cobenefits-api`.

## Notes for Reviewers

Start at `_assert_placeholders_intact` — it is the load-bearing part. Protection reduces the failure rate; the guard is what makes silent corruption impossible, and Spanish still defeating a protected sentinel is the evidence that ordering matters.

**Review history worth knowing:** CodeRabbit's one finding was valid and is fixed in `25deef61`; it confirmed the fix. Its review was then **rate limited**, so it has not seen `25deef61` or `3e6d9802` — a re-review has been requested. The caller sweep in `3e6d9802` is the part with the least external review and touches two admin views, so it deserves the closest human look.

**Known limitations, stated rather than hidden:**

- The sentinel is empirically validated, not guaranteed. Google is a black box and non-deterministic; a future model change could break `__PH0__` too. The guard is the actual safety property — worst case becomes a reported skip and an English fallback, never a corrupted row.
- Multiset comparison may occasionally reject a translation a human would accept, e.g. a language that legitimately merges a repeated placeholder. No instance seen in 4 strings × 17 languages, and the failure mode is a reported skip, which is the direction to err.
- ICU support is refused, not implemented. If someone later wants real plural support the honest path is per-CLDR-category human translations, not more code here.
- The integrity guard validates `{...}` placeholders only. `cesnHeader.httpsBody` also contains `<b>` tags, which Google can still mangle unchecked — pre-existing, not made worse here, but worth a follow-up if HTML in copy becomes common.

**Follow-ups this surfaced:** [MFB-1689](https://linear.app/myfriendben/issue/MFB-1689) is unblocked once the re-translation runs. [MFB-1692](https://linear.app/myfriendben/issue/MFB-1692) (CI key-parity check) should also validate placeholder integrity against the export — the check that would have caught all 18 of these years ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
