### PR TITLE
Value MO Medicaid at KFF's published annual figures

### DIFF
--- a/programs/programs/cross_white_label/medicaid/mo.py
+++ b/programs/programs/cross_white_label/medicaid/mo.py
@@ -12,24 +12,51 @@ class MoHealthNet(Medicaid):
     people, parents/caretakers, and the aged/blind/disabled route through their own
     PE categories.
 
-    Known PE divergences from Missouri's current FSD standards, all upstream parameter
-    issues rather than wiring gaps here. They affect band edges and specific
-    sub-populations, not the mainline MAGI pathways:
+    PE's income limits were measured against Missouri's published standards by bisecting
+    each pathway's ceiling on a live screener. They agree - the boundaries below are PE's,
+    and each matches the corresponding MO DSS figure once you account for DSS publishing
+    the *monthly* equivalent rounded up to the whole dollar:
 
-    - The children's ceiling is frozen at 155% FPL; Missouri's current standard is 153%
-      (148% nominal + 5% MAGI disregard), so PE reports eligible slightly above the line.
-    - The parent/caretaker limit is stored as a percent of FPL (frozen at 23%), but
-      Missouri's standard is a flat 1996-AFDC dollar figure that isn't FPL-indexed.
-    - The pregnant/infant limit is frozen at 201%; the current MPW line is 196%.
-    - There is no blind-specific MHABD standard - one flat ~85% FPG rate covers both
-      blind and non-blind applicants.
-    - Adult-expansion eligibility carries no Medicare-enrollment or SSI-receipt
-      exclusion, and no Substantial Gainful Activity test gates the disability
-      pathways.
+    - Adult expansion: 138% FPL. HH1 boundary $1,835/mo (1.38 * $15,960 = $22,024.80/yr,
+      i.e. $1,835.40/mo); DSS Appendix A publishes $1,836.
+    - Children 1-18: 153% FPL, matching Missouri's 148% nominal plus the 5% MAGI
+      disregard. HH2 boundary $2,759/mo (1.53 * $21,640 = $33,109.20/yr); DSS publishes
+      $2,760.
+    - Infants under 1 and pregnant people: 201% FPL, which is Missouri's 196% nominal
+      plus the 5% disregard. HH2 boundary $3,624/mo (2.01 * $21,640 = $43,496.40/yr);
+      DSS publishes $3,625. The pregnant boundary equals the HH2 infant boundary, which
+      confirms PE counts the unborn child in the pregnant applicant's own unit.
+    - MHABD aged/disabled: 85% FPG, $13,566/yr = $1,130.50/mo; DSS publishes $1,131.
+    - MHABD blind: 100% FPG, $15,960/yr = $1,330/mo, matching DSS exactly. PE does have a
+      blind-specific standard distinct from the aged/disabled one.
 
-    Fixes for these have been requested upstream. They are deliberately not patched
-    here: this calculator stays a wiring-only PE subclass, so PolicyEngine remains the
-    single source of the eligibility decision.
+    Because DSS rounds the monthly figure up while eligibility is tested on annualized
+    income, entering a DSS-published monthly limit exactly lands a few dollars above the
+    annual limit. That is a units artifact, not an off-by-one in the comparator.
+
+    Known divergences from Missouri's standards, deliberately not patched here so that
+    PolicyEngine stays the single source of the eligibility decision:
+
+    - MHABD applies the $20 general income exclusion before halving earned income
+      (SSI ordering, ``(earned - 65 - 20) / 2``) rather than after, as Missouri's own
+      sequence does (``(earned - 65) / 2 - 20``). Worth $10/mo of countable income, so a
+      wage earner's MHABD ceiling sits about $21/mo of gross earnings below Missouri's.
+      Requested upstream.
+    - The parent/caretaker limit is stored as a percent of FPL rather than Missouri's flat
+      1996-AFDC dollar standard, which is not FPL-indexed. Not isolated by measurement:
+      the adult-expansion ceiling is far higher, so a parent failing the flat standard is
+      still found eligible through expansion.
+    - No Substantial Gainful Activity test gates the disability pathways. Not measured.
+
+    Two behaviours that are ours rather than PolicyEngine's, both in
+    ``Medicaid.member_value`` and shared by every Medicaid state, so neither is worked
+    around here:
+
+    - A member who reports any disability and fails the PE aged/disabled pathway returns
+      $0 without being evaluated for adult expansion, even when their income is under the
+      expansion ceiling.
+    - A member who is both 65+ and reports a disability is valued at the disabled rate
+      rather than the senior rate, because the disability branch is tested first.
     """
 
     program_code = "mo_medicaid"
@@ -47,22 +74,34 @@ class MoHealthNet(Medicaid):
         dependency.household.MoStateCodeDependency,
     ]
 
-    # KFF Medicaid Spending per Full-Benefit Enrollee by Enrollment Group, MO, 2023,
-    # converted to monthly (the annual figure returned = value * 12):
-    #   children (18 and under) -> $4,576/yr  -> $381/mo
-    #   adults (19-64)          -> $6,379/yr  -> $532/mo
-    #   seniors (65+)           -> $21,857/yr -> $1,821/mo
-    #   people with disabilities -> $30,410/yr -> $2,534/mo
+    # KFF Medicaid Spending per Full-Benefit Enrollee by Enrollment Group, MO, 2023
+    # preliminary - the Full-Benefit table, because this calculator represents full-scope
+    # MO HealthNet coverage. KFF's groups are mutually exclusive by age, disability
+    # eligibility, and expansion status. These are the published *annual* figures.
+    KFF_CHILDREN = 4_576  # age 18 and under, not disability-eligible
+    KFF_ADULTS = 6_379  # 19-64, not disability-eligible, not expansion
+    KFF_EXPANSION_ADULTS = 7_445  # 19-64, newly eligible via ACA expansion
+    KFF_SENIORS = 21_857  # 65+, regardless of disability
+    KFF_DISABLED = 30_410  # under 65, disability-eligible
+
+    # NOTE: Monthly - Medicaid.member_value multiplies by 12. Stored as annual/12 rather
+    # than a rounded whole-dollar monthly rate: rounding the monthly figure moves the
+    # annual value we report by up to $5 away from KFF's published number.
     medicaid_categories = {
         "NONE": 0,
-        "ADULT": 532,
-        "INFANT": 381,
-        "YOUNG_CHILD": 381,
-        "OLDER_CHILD": 381,
-        "PREGNANT": 532,
-        "YOUNG_ADULT": 532,
-        "PARENT": 532,
-        "SSI_RECIPIENT": 2_534,
-        "AGED": 1_821,
-        "DISABLED": 2_534,
+        # Missouri expanded, so PE's ADULT category is the expansion group and carries
+        # KFF's higher expansion rate. PARENT and PREGNANT are mandatory pre-expansion
+        # categories and take precedence over it, so they keep the non-expansion rate -
+        # which is also what makes a parent found through MHF distinguishable from one
+        # found through expansion.
+        "ADULT": KFF_EXPANSION_ADULTS / 12,
+        "YOUNG_ADULT": KFF_ADULTS / 12,
+        "PARENT": KFF_ADULTS / 12,
+        "PREGNANT": KFF_ADULTS / 12,
+        "INFANT": KFF_CHILDREN / 12,
+        "YOUNG_CHILD": KFF_CHILDREN / 12,
+        "OLDER_CHILD": KFF_CHILDREN / 12,
+        "SSI_RECIPIENT": KFF_DISABLED / 12,
+        "AGED": KFF_SENIORS / 12,
+        "DISABLED": KFF_DISABLED / 12,
     }

--- a/programs/programs/cross_white_label/medicaid/mo.py
+++ b/programs/programs/cross_white_label/medicaid/mo.py
@@ -12,51 +12,30 @@ class MoHealthNet(Medicaid):
     people, parents/caretakers, and the aged/blind/disabled route through their own
     PE categories.
 
-    PE's income limits were measured against Missouri's published standards by bisecting
-    each pathway's ceiling on a live screener. They agree - the boundaries below are PE's,
-    and each matches the corresponding MO DSS figure once you account for DSS publishing
-    the *monthly* equivalent rounded up to the whole dollar:
-
-    - Adult expansion: 138% FPL. HH1 boundary $1,835/mo (1.38 * $15,960 = $22,024.80/yr,
-      i.e. $1,835.40/mo); DSS Appendix A publishes $1,836.
-    - Children 1-18: 153% FPL, matching Missouri's 148% nominal plus the 5% MAGI
-      disregard. HH2 boundary $2,759/mo (1.53 * $21,640 = $33,109.20/yr); DSS publishes
-      $2,760.
-    - Infants under 1 and pregnant people: 201% FPL, which is Missouri's 196% nominal
-      plus the 5% disregard. HH2 boundary $3,624/mo (2.01 * $21,640 = $43,496.40/yr);
-      DSS publishes $3,625. The pregnant boundary equals the HH2 infant boundary, which
-      confirms PE counts the unborn child in the pregnant applicant's own unit.
-    - MHABD aged/disabled: 85% FPG, $13,566/yr = $1,130.50/mo; DSS publishes $1,131.
-    - MHABD blind: 100% FPG, $15,960/yr = $1,330/mo, matching DSS exactly. PE does have a
-      blind-specific standard distinct from the aged/disabled one.
-
-    Because DSS rounds the monthly figure up while eligibility is tested on annualized
-    income, entering a DSS-published monthly limit exactly lands a few dollars above the
-    annual limit. That is a units artifact, not an off-by-one in the comparator.
+    Each pathway's income ceiling was verified against Missouri's published standards by
+    bisecting it on a live screener, and they agree - including a blind MHABD standard
+    distinct from the aged/disabled one. Missouri publishes *monthly* limits rounded up to
+    the whole dollar while eligibility is tested on annualized income, so entering a
+    published monthly limit exactly lands just above the annual limit; that is a units
+    artifact rather than an off-by-one comparator.
 
     Known divergences from Missouri's standards, deliberately not patched here so that
     PolicyEngine stays the single source of the eligibility decision:
 
-    - MHABD applies the $20 general income exclusion before halving earned income
-      (SSI ordering, ``(earned - 65 - 20) / 2``) rather than after, as Missouri's own
-      sequence does (``(earned - 65) / 2 - 20``). Worth $10/mo of countable income, so a
-      wage earner's MHABD ceiling sits about $21/mo of gross earnings below Missouri's.
-      Requested upstream.
+    - MHABD subtracts the general income exclusion before halving earned income (SSI
+      ordering) rather than after, as Missouri's own sequence does, which lowers a wage
+      earner's MHABD ceiling. Requested upstream.
     - The parent/caretaker limit is stored as a percent of FPL rather than Missouri's flat
       1996-AFDC dollar standard, which is not FPL-indexed. Not isolated by measurement:
       the adult-expansion ceiling is far higher, so a parent failing the flat standard is
       still found eligible through expansion.
     - No Substantial Gainful Activity test gates the disability pathways. Not measured.
 
-    Two behaviours that are ours rather than PolicyEngine's, both in
-    ``Medicaid.member_value`` and shared by every Medicaid state, so neither is worked
-    around here:
-
-    - A member who reports any disability and fails the PE aged/disabled pathway returns
-      $0 without being evaluated for adult expansion, even when their income is under the
-      expansion ceiling.
-    - A member who is both 65+ and reports a disability is valued at the disabled rate
-      rather than the senior rate, because the disability branch is tested first.
+    Two behaviours are ours rather than PolicyEngine's, both in ``Medicaid.member_value``
+    and shared by every Medicaid state, so neither is worked around here: a member who
+    reports a disability and fails the aged/disabled pathway is not then evaluated for
+    adult expansion, and a member who is both 65+ and disabled is valued at the disabled
+    rather than the senior rate.
     """
 
     program_code = "mo_medicaid"
@@ -74,26 +53,20 @@ class MoHealthNet(Medicaid):
         dependency.household.MoStateCodeDependency,
     ]
 
-    # KFF Medicaid Spending per Full-Benefit Enrollee by Enrollment Group, MO, 2023
-    # preliminary - the Full-Benefit table, because this calculator represents full-scope
-    # MO HealthNet coverage. KFF's groups are mutually exclusive by age, disability
-    # eligibility, and expansion status. These are the published *annual* figures.
+    # KFF's published annual spend per full-benefit MO enrollee, whose groups are mutually
+    # exclusive by age, disability eligibility, and expansion status.
     KFF_CHILDREN = 4_576  # age 18 and under, not disability-eligible
     KFF_ADULTS = 6_379  # 19-64, not disability-eligible, not expansion
     KFF_EXPANSION_ADULTS = 7_445  # 19-64, newly eligible via ACA expansion
     KFF_SENIORS = 21_857  # 65+, regardless of disability
     KFF_DISABLED = 30_410  # under 65, disability-eligible
 
-    # NOTE: Monthly - Medicaid.member_value multiplies by 12. Stored as annual/12 rather
-    # than a rounded whole-dollar monthly rate: rounding the monthly figure moves the
-    # annual value we report by up to $5 away from KFF's published number.
+    # NOTE: Monthly - stored as annual/12 so member_value's * 12 restores the published
+    # figure exactly, which a rounded whole-dollar rate would not.
     medicaid_categories = {
         "NONE": 0,
-        # Missouri expanded, so PE's ADULT category is the expansion group and carries
-        # KFF's higher expansion rate. PARENT and PREGNANT are mandatory pre-expansion
-        # categories and take precedence over it, so they keep the non-expansion rate -
-        # which is also what makes a parent found through MHF distinguishable from one
-        # found through expansion.
+        # ADULT is the expansion group, while the mandatory pre-expansion categories take
+        # precedence over it and so keep the lower non-expansion rate.
         "ADULT": KFF_EXPANSION_ADULTS / 12,
         "YOUNG_ADULT": KFF_ADULTS / 12,
         "PARENT": KFF_ADULTS / 12,

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_at_the_mhf_standard_is_valued_as_a_mandatory_adult.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_at_the_mhf_standard_is_valued_as_a_mandatory_adult.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"age": {"2026": 36}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": null},
+      "employment_income": {"2026": 2892}, "self_employment_income": {"2026": 0},
+      "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null},
+      "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+      "meets_ssi_disability_criteria": {"2026": null}, "is_blind": {"2026": false},
+      "medicaid": {"2026": null}, "medicaid_category": {"2026": null}, "is_optional_senior_or_disabled_for_medicaid":
+      {"2026": null}}, "2": {"age": {"2026": 11}, "is_pregnant": {"2026": false},
+      "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": null}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "meets_ssi_disability_criteria": {"2026": null}, "is_blind":
+      {"2026": false}, "medicaid": {"2026": null}, "medicaid_category": {"2026": null},
+      "is_optional_senior_or_disabled_for_medicaid": {"2026": null}}}, "tax_units":
+      {"main_tax_unit": {"members": ["1", "2"]}}, "families": {"family": {"members":
+      ["1", "2"]}}, "households": {"household": {"members": ["1", "2"], "state_code":
+      {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1", "2"], "tanf":
+      {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+      {"2026": false}}}, "marital_units": {}}, "version": "1.794.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1971'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
+        {"2026": 36}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": false}, "employment_income": {"2026": 2892}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": false}, "is_blind":
+        {"2026": false}, "medicaid": {"2026": 15486.9}, "medicaid_category": {"2026":
+        "PARENT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}},
+        "2": {"age": {"2026": 11}, "is_pregnant": {"2026": false}, "ssi_countable_resources":
+        {"2026": 0}, "is_disabled": {"2026": false}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": false}, "is_blind":
+        {"2026": false}, "medicaid": {"2026": 9632.3545}, "medicaid_category": {"2026":
+        "OLDER_CHILD"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}}},
+        "tax_units": {"main_tax_unit": {"members": ["1", "2"]}}, "families": {"family":
+        {"members": ["1", "2"]}}, "households": {"household": {"members": ["1", "2"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1",
+        "2"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+        {"2026": false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.794.2", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '2095'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Aug 2026 20:12:45 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-276d0359f4d90003a037bf9ce199e8c5-30837f5d63eb0458-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 276d0359f4d90003a037bf9ce199e8c5;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 2dd6045d-e86b-4a29-816c-d058ee40f0f9
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_one_dollar_over_the_mhf_standard_falls_through_to_expansion.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_one_dollar_over_the_mhf_standard_falls_through_to_expansion.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"age": {"2026": 36}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": null},
+      "employment_income": {"2026": 2904}, "self_employment_income": {"2026": 0},
+      "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+      {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+      {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null},
+      "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+      "meets_ssi_disability_criteria": {"2026": null}, "is_blind": {"2026": false},
+      "medicaid": {"2026": null}, "medicaid_category": {"2026": null}, "is_optional_senior_or_disabled_for_medicaid":
+      {"2026": null}}, "2": {"age": {"2026": 11}, "is_pregnant": {"2026": false},
+      "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": null}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "meets_ssi_disability_criteria": {"2026": null}, "is_blind":
+      {"2026": false}, "medicaid": {"2026": null}, "medicaid_category": {"2026": null},
+      "is_optional_senior_or_disabled_for_medicaid": {"2026": null}}}, "tax_units":
+      {"main_tax_unit": {"members": ["1", "2"]}}, "families": {"family": {"members":
+      ["1", "2"]}}, "households": {"household": {"members": ["1", "2"], "state_code":
+      {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1", "2"], "tanf":
+      {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+      {"2026": false}}}, "marital_units": {}}, "version": "1.794.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1971'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
+        {"2026": 36}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": false}, "employment_income": {"2026": 2904}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": false}, "is_blind":
+        {"2026": false}, "medicaid": {"2026": 15486.9}, "medicaid_category": {"2026":
+        "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}},
+        "2": {"age": {"2026": 11}, "is_pregnant": {"2026": false}, "ssi_countable_resources":
+        {"2026": 0}, "is_disabled": {"2026": false}, "employment_income": {"2026":
+        0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income":
+        {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+        {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": false}, "is_blind":
+        {"2026": false}, "medicaid": {"2026": 9632.3545}, "medicaid_category": {"2026":
+        "OLDER_CHILD"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}}},
+        "tax_units": {"main_tax_unit": {"members": ["1", "2"]}}, "families": {"family":
+        {"members": ["1", "2"]}}, "households": {"household": {"members": ["1", "2"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1",
+        "2"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+        {"2026": false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.794.2", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '2094'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Aug 2026 20:12:48 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-55f3d5186e1cd7e3dbe375ba24a103c9-fd44bc12aa33b262-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 55f3d5186e1cd7e3dbe375ba24a103c9
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - a82934af-af65-497d-bf8d-8e7fdb6d8f41
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo.py
@@ -122,8 +122,8 @@ class TestMoHealthNet(TestCase):
     def test_every_category_annualizes_to_a_published_kff_figure(self):
         """member_value multiplies by 12, so each rate must restore its KFF annual figure exactly.
 
-        Storing a whole-dollar monthly rate instead would report a value up to $5 away from
-        KFF's published number - $4,572 rather than $4,576 for a child, for example.
+        A rounded whole-dollar monthly rate would report a value a few dollars away from
+        KFF's published number, which is what this catches if one creeps back in.
         """
         published = {
             0,

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo.py
@@ -96,19 +96,60 @@ class TestMoHealthNet(TestCase):
     def test_medicaid_categories_are_kff_monthly_figures(self):
         """Category values are the KFF 2023 MO per-full-benefit-enrollee figures, monthly.
 
-        Grouped the way KFF reports them: one rate for the MAGI adult categories, one for
-        children, and the higher aged and disabled rates.
+        KFF publishes five mutually exclusive groups; all five are represented, including
+        the expansion-adult rate that PE's ADULT category maps to in an expansion state.
         """
         cats = MoHealthNet.medicaid_categories
 
         self.assertEqual(cats["NONE"], 0)
-        for adult_category in ("ADULT", "YOUNG_ADULT", "PARENT", "PREGNANT"):
-            self.assertEqual(cats[adult_category], 532)
+        self.assertEqual(cats["ADULT"], MoHealthNet.KFF_EXPANSION_ADULTS / 12)
+        for adult_category in ("YOUNG_ADULT", "PARENT", "PREGNANT"):
+            self.assertEqual(cats[adult_category], MoHealthNet.KFF_ADULTS / 12)
         for child_category in ("INFANT", "YOUNG_CHILD", "OLDER_CHILD"):
-            self.assertEqual(cats[child_category], 381)
-        self.assertEqual(cats["AGED"], 1_821)
-        self.assertEqual(cats["DISABLED"], 2_534)
+            self.assertEqual(cats[child_category], MoHealthNet.KFF_CHILDREN / 12)
+        self.assertEqual(cats["AGED"], MoHealthNet.KFF_SENIORS / 12)
+        self.assertEqual(cats["DISABLED"], MoHealthNet.KFF_DISABLED / 12)
         self.assertEqual(cats["SSI_RECIPIENT"], cats["DISABLED"])
+
+    def test_kff_annual_figures_are_the_published_values(self):
+        """The annual KFF figures are the source of truth, not the derived monthly rates."""
+        self.assertEqual(MoHealthNet.KFF_CHILDREN, 4_576)
+        self.assertEqual(MoHealthNet.KFF_ADULTS, 6_379)
+        self.assertEqual(MoHealthNet.KFF_EXPANSION_ADULTS, 7_445)
+        self.assertEqual(MoHealthNet.KFF_SENIORS, 21_857)
+        self.assertEqual(MoHealthNet.KFF_DISABLED, 30_410)
+
+    def test_every_category_annualizes_to_a_published_kff_figure(self):
+        """member_value multiplies by 12, so each rate must restore its KFF annual figure exactly.
+
+        Storing a whole-dollar monthly rate instead would report a value up to $5 away from
+        KFF's published number - $4,572 rather than $4,576 for a child, for example.
+        """
+        published = {
+            0,
+            MoHealthNet.KFF_CHILDREN,
+            MoHealthNet.KFF_ADULTS,
+            MoHealthNet.KFF_EXPANSION_ADULTS,
+            MoHealthNet.KFF_SENIORS,
+            MoHealthNet.KFF_DISABLED,
+        }
+
+        for category, monthly in MoHealthNet.medicaid_categories.items():
+            annual = monthly * 12
+            self.assertEqual(annual, int(annual), f"{category} does not annualize to a whole dollar")
+            self.assertIn(int(annual), published, f"{category} annualizes to an unpublished value")
+
+    def test_expansion_and_mandatory_adult_rates_differ(self):
+        """A parent found through MHF must be distinguishable from one found through expansion.
+
+        Missouri's mandatory categories (MHF, MPW) take precedence over adult expansion and
+        carry KFF's non-expansion Adults rate, so collapsing them onto one adult rate would
+        make categorical precedence unobservable in the result.
+        """
+        cats = MoHealthNet.medicaid_categories
+
+        self.assertNotEqual(cats["ADULT"], cats["PARENT"])
+        self.assertGreater(cats["ADULT"], cats["PARENT"])
 
     def test_aged_min_age_inherited(self):
         """MO uses the federal 65+ cutoff for the aged pathway."""

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
@@ -87,12 +87,11 @@ class TestMoHealthNetSmoke(PeIntegrationTestCase):
         return self._member_values(calc_pe_program(screen, MoHealthNet, program))
 
     def test_parent_at_the_mhf_standard_is_valued_as_a_mandatory_adult(self):
-        """Parent at Missouri's flat $241/mo MHF standard -> the non-expansion Adults rate.
+        """Parent at Missouri's flat MHF standard -> the non-expansion Adults rate.
 
-        MHF is a mandatory pre-expansion category and takes precedence over adult expansion,
-        so this parent must not be valued at the higher expansion rate even though their
-        income also clears the far higher expansion ceiling. Pairs with the $242 test below:
-        together they are what makes categorical precedence observable in the result at all.
+        MHF is mandatory and takes precedence over adult expansion, so this parent must not
+        be valued at the expansion rate even though their income also clears the much higher
+        expansion ceiling.
         """
         values = self._parent_and_child(241)
 
@@ -102,8 +101,8 @@ class TestMoHealthNetSmoke(PeIntegrationTestCase):
     def test_parent_one_dollar_over_the_mhf_standard_falls_through_to_expansion(self):
         """Parent one dollar over the flat MHF standard -> expansion, not denial.
 
-        $242/mo is nowhere near the expansion ceiling, so failing MHF re-routes them to
-        adult expansion at KFF's higher expansion rate rather than dropping them.
+        Their income is nowhere near the expansion ceiling, so failing MHF re-routes them to
+        adult expansion rather than dropping them.
         """
         values = self._parent_and_child(242)
 

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
@@ -1,19 +1,23 @@
 """
 Smoke test for MO Medicaid — proves Missouri's ``medicaid`` pathway resolves end to end.
 
-MO HealthNet is a Fed-tier passthrough: ``MoHealthNet`` adds only Missouri's state code to
-the federal ``medicaid`` calculator, so there is no ``spec.md`` and no per-scenario suite
-here. The federal math is already covered by the other states' medicaid tests; re-testing
-it per state would only duplicate them.
+``MoHealthNet`` adds only Missouri's state code and the two disability inputs to the federal
+``medicaid`` calculator, so the federal math is already covered by the other states' medicaid
+tests and re-testing it per state would only duplicate them.
+
+This file is a smoke test rather than the per-scenario suite the ``specs/mo.md`` scenarios call
+for. Those scenarios exist and are not yet covered here.
 
 What this does pin is the one thing that is Missouri-specific and could silently break: that
 Missouri is read as an ACA expansion state, so a childless adult under 138% FPL comes back
 eligible in the ``ADULT`` category rather than $0. That is the distinction between MO and a
 non-expansion state like Kansas, and it is the whole reason the MO state code is wired in.
 
-The value asserted is the KFF per-enrollee ``ADULT`` rate × 12, so this also catches a
-category the calculator maps to the wrong rate.
+The value asserted is KFF's ACA-expansion-adult rate, which is what PE's ``ADULT`` category
+maps to in an expansion state, so this also catches a category mapped to the wrong rate.
 """
+
+import math
 
 import pytest
 
@@ -59,4 +63,49 @@ class TestMoHealthNetSmoke(PeIntegrationTestCase):
         eligibility = calc_pe_program(screen, MoHealthNet, program)
 
         self.assertTrue(eligibility.eligible)
-        self.assertEqual(screener_value(eligibility), 6_384)
+        self.assertEqual(screener_value(eligibility), MoHealthNet.KFF_EXPANSION_ADULTS)
+
+    def _member_values(self, eligibility):
+        """Per-member values keyed by member id, so a scenario can assert each person."""
+        return {me.member.id: math.trunc(me.value) for me in eligibility.eligible_members if me.eligible}
+
+    def _parent_and_child(self, parent_monthly_wages):
+        """HH2: a parent at the given monthly wage plus their 11-year-old child."""
+        screen = make_screen(
+            screen_id=2,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=2,
+            zipcode="63101",
+            county="St. Louis City",
+        )
+        parent = add_member(screen, member_id=1, relationship="headOfHousehold", age=36)
+        add_income(parent, amount=parent_monthly_wages)
+        add_member(screen, member_id=2, relationship="child", age=11)
+        program = make_program("mo", "mo_medicaid", year=YEAR)
+
+        return self._member_values(calc_pe_program(screen, MoHealthNet, program))
+
+    def test_parent_at_the_mhf_standard_is_valued_as_a_mandatory_adult(self):
+        """Parent at Missouri's flat $241/mo MHF standard -> the non-expansion Adults rate.
+
+        MHF is a mandatory pre-expansion category and takes precedence over adult expansion,
+        so this parent must not be valued at the higher expansion rate even though their
+        income also clears the far higher expansion ceiling. Pairs with the $242 test below:
+        together they are what makes categorical precedence observable in the result at all.
+        """
+        values = self._parent_and_child(241)
+
+        self.assertEqual(values[1], MoHealthNet.KFF_ADULTS)
+        self.assertEqual(values[2], MoHealthNet.KFF_CHILDREN)
+
+    def test_parent_one_dollar_over_the_mhf_standard_falls_through_to_expansion(self):
+        """Parent one dollar over the flat MHF standard -> expansion, not denial.
+
+        $242/mo is nowhere near the expansion ceiling, so failing MHF re-routes them to
+        adult expansion at KFF's higher expansion rate rather than dropping them.
+        """
+        values = self._parent_and_child(242)
+
+        self.assertEqual(values[1], MoHealthNet.KFF_EXPANSION_ADULTS)
+        self.assertEqual(values[2], MoHealthNet.KFF_CHILDREN)


### PR DESCRIPTION
## Context & Motivation

`mo_medicaid` shipped in #1718 as a wiring-only PolicyEngine subclass. Running the 34 authored scenarios from the program's `mo_medicaid_spec.md` against staging returned 7/34, and the largest single cause was the value table rather than eligibility: 17 of the 27 failures were the dollar figure alone.

Two distinct problems:

1. **Four of KFF's five enrollee groups were priced.** `medicaid_categories` mapped `ADULT`, `PARENT`, `PREGNANT` and `YOUNG_ADULT` to one rate, so an adult found through ACA expansion — Missouri's largest MO HealthNet population — was valued at KFF's *non-expansion* Adults rate. $6,384 instead of $7,445, a $1,061/yr understatement.
2. **Whole-dollar monthly rates can't reproduce an annual figure.** `Medicaid.member_value` multiplies by 12, so `381` reports $4,572 where KFF publishes $4,576. Every group was off by $2–$5.

A side effect of (1) worth calling out: because `ADULT` and `PARENT` shared a rate, a parent found through MO HealthNet for Families and one found through adult expansion reported the *same* dollar value, so the spec's categorical-precedence requirement was unobservable in the result.

- Linear: [MFB-1215](https://linear.app/myfriendben/issue/MFB-1215/program-mo-healthnet-medicaid) (QA findings, buckets A and B)
- Related PR: #1718 (original implementation, merged)

## Changes Made

- **Added KFF's ACA-Expansion-Adults group** and mapped PE's `ADULT` category to it. `PARENT`, `PREGNANT` and `YOUNG_ADULT` keep the non-expansion Adults rate, since those are mandatory pre-expansion categories that take precedence over expansion.
- **Store each rate as `annual / 12`** rather than a rounded whole-dollar monthly figure, so `member_value`'s `× 12` restores KFF's published number exactly. The five annual figures are now named class constants (`KFF_CHILDREN`, `KFF_ADULTS`, `KFF_EXPANSION_ADULTS`, `KFF_SENIORS`, `KFF_DISABLED`) — the published annual value is the source of truth and the monthly rate is derived, not the other way round.

  | Group | Before | After |
  |---|---|---|
  | Children (`INFANT`, `YOUNG_CHILD`, `OLDER_CHILD`) | $4,572 | $4,576 |
  | Adults (`PARENT`, `PREGNANT`, `YOUNG_ADULT`) | $6,384 | $6,379 |
  | ACA Expansion Adults (`ADULT`) | $6,384 | **$7,445** |
  | Seniors (`AGED`) | $21,852 | $21,857 |
  | People with Disabilities (`DISABLED`, `SSI_RECIPIENT`) | $30,408 | $30,410 |

- **Two new integration scenarios** pinning the `ADULT`/`PARENT` split at Missouri's flat $241/mo MHF standard — one at $241, one at $242. PolicyEngine returns `PARENT` at $241 and `ADULT` at $242, so categorical precedence is real and is now asserted.
- **Four new unit tests**: the annual constants are the published values; every category annualizes to a whole dollar that is one of the five published figures (this is what would catch a future whole-dollar monthly rate creeping back in); and the expansion and mandatory-adult rates must differ.
- **Rewrote the class docstring against measured behaviour.** It previously listed five PolicyEngine divergences as the justification for patching nothing. Three do not hold — PE applies the children's ceiling at 153% (not 155%), does have a blind-specific MHABD standard at 100% FPG, and does apply the Medicare-enrollment exclusion to adult expansion. The docstring now records each pathway's measured boundary, the two divergences that are real, and two behaviours in the shared `Medicaid.member_value` that a Missouri QA run surfaced.

No eligibility logic changed. `MoHealthNet` still does not override `member_value`, and the existing test asserting that still passes.

## Testing

- Migrations to run: **none**
- Configuration updates needed: **none** — `mo_medicaid_initial_config.json` is unchanged and no re-import is required
- Environment variables/settings to add: **none**
- Manual testing steps:
  - `VCR_MODE=none venv/bin/pytest -q` → 3,789 passed, 5 skipped, 0 failures
  - `VCR_MODE=none venv/bin/pytest programs/programs/cross_white_label/medicaid/ -q` → 301 passed
  - `venv/bin/black --check programs/programs/cross_white_label/medicaid/` → clean
  - The two new cassettes were recorded live at PolicyEngine 1.794.2 (`PE_RECORD=1 VCR_MODE=once`), matching the pin the existing smoke-test cassette uses. They replay under `VCR_MODE=none` with no network access.
  - After deploy, re-run the API QA against staging: `/api-qa-execution MFB-1215 staging`. Expect 24/34 (up from 7/34) — the 12 rounding-only and 5 expansion-tier scenarios should flip to pass.

## Deployment

- Post-deployment scripts needed: **none**
- Production config updates: **none**
- Admin updates needed: **none**
- Notify team/users of:
  - **The estimated annual value shown for MO HealthNet changes on deploy**, most visibly for expansion adults ($6,384 → $7,445). Anyone tracking reported benefit values, or comparing screener output against an earlier run, should know the figures moved deliberately.
  - The four other groups shift by $2–$5 for the same reason.

## Notes for Reviewers

- **Worth focusing on: the `ADULT` → expansion mapping.** NC maps `ADULT`, `YOUNG_ADULT` and `PARENT` all to its expansion rate (`nc.py`), which is a different reading from this one. Missouri's spec is explicit that MHF and MPW are mandatory categories carrying the non-expansion Adults rate, and Scenario 12 vs Scenario 26 exists precisely to pin that distinction — hence the split here. The two new cassettes are the evidence, but if you read Missouri's categories differently, this is the decision to challenge.
- **The `annual / 12` float.** All five values round-trip exactly under IEEE754, including multi-member sums, and a test asserts every category annualizes to a whole dollar. Flagging it because storing a non-integer monthly rate is new for this family — `wa.py`/`nc.py`/`ks.py` all use whole-dollar monthlies and accept the drift.
- Known limitations:
  - **Does not fix the eligibility findings.** Scenarios 6, 8 and 11 still fail, and 19, 21 and 24 still return an unexpected category. Those are in the shared `Medicaid.member_value` (no expansion fall-through for a member who reports a disability and fails the aged/disabled pathway; disability tested before age when both apply), in PolicyEngine (the MHABD `$20`-exclusion ordering), and in how the PE payload builds household units (physical household rather than per-applicant MAGI unit). All six Medicaid states are affected by the first two, so they belong in their own tickets rather than here.
  - The four boundary scenarios (2, 4, 27, 29) fail on a units artifact, not code: MO DSS publishes monthly limits rounded *up*, while eligibility is tested on annualized income. Those are spec-side edits.
- Future considerations:
  - **The spec is not in the repo.** `mo_medicaid_spec.md` exists only as a Linear attachment, unlike `medicaid/specs/ks.md` and `specs/wa.md`. It should be committed — with the boundary corrections folded in — and the 34 scenarios landed as a suite. This PR adds 2 of them.
  - `Medicaid.pe_inputs` does not declare `IsMedicareEligibleDependency`; only `msp/base.py` does. The Medicare exclusion works today only because PE inputs are pooled per request and `mo_medicare_savings` is active. Same shape as the `meets_ssi_disability_criteria` bug fixed in #1718, and it belongs with the existing `co`/`il`/`ma`/`nc`/`wa` input-declaration ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Missouri Medicaid calculations to use published annual KFF spending figures.
  * Added distinct rates for children, adults, expansion adults, seniors, and disabled enrollees.
  * Improved handling of parents at and above Missouri’s Medicaid income standard.

* **Bug Fixes**
  * Corrected category-specific Medicaid valuation and annualized spending amounts.

* **Tests**
  * Added coverage for category rates and parent eligibility thresholds.
  * Added smoke-test scenarios for mandatory and expansion adult classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->