### PR TITLE
MFB-1733: clear blank rows for refused strings too

### DIFF
--- a/translations/management/commands/add_translations.py
+++ b/translations/management/commands/add_translations.py
@@ -89,6 +89,36 @@ class Command(BaseCommand):
             ),
         )
 
+    def _clear_rows(self, pairs, by_text):
+        """
+        Delete the non-English rows named by `pairs` so those languages fall back to English.
+
+        Deleting rather than blanking is load-bearing. `_build_translation_data` picks the
+        English fallback on key *presence*, not emptiness:
+
+            label: (texts[lang] if lang in texts else texts.get(default_lang))
+
+        so a row holding "" is served as empty text and the UI renders nothing at all -
+        strictly worse than the English it was meant to fall back to.
+
+        Returns (cleared_count, preserved_labels). Rows a human has edited are never
+        deleted; they are reported instead.
+        """
+        cleared = 0
+        preserved: list[str] = []
+        for text, lang in pairs:
+            for translation_obj in by_text.get(text, []):
+                row = translation_obj.translations.filter(language_code=lang).first()
+                if row is None:
+                    continue
+                if row.edited:
+                    # Never destroy a human's work to make room for a fallback.
+                    preserved.append(f"{translation_obj.label} [{lang}]")
+                    continue
+                row.delete()
+                cleared += 1
+        return cleared, preserved
+
     def _load_data(self, options):
         try:
             data = json.load(options["data"])
@@ -203,10 +233,18 @@ class Command(BaseCommand):
                 by_text.setdefault(text, []).append(translation_obj)
 
         # Strings we refuse to machine-translate (ICU plural/select) are reported and
-        # skipped rather than aborting the batch: their English rows are already saved
-        # above, so the label exists and react-intl falls back to English until a human
-        # supplies the other languages.
+        # skipped rather than aborting the batch, so their English rows still save and the
+        # label exists.
+        #
+        # Skipping the translate step is NOT enough to get an English fallback, though.
+        # add_translation creates a row for every configured language, and the non-English
+        # ones start empty - so a refused string ends up with 17 blank rows, which
+        # _build_translation_data serves as empty text rather than falling back. Measured on
+        # staging: a refused ICU label had 18 rows and served '' for es, zh-hans and ar.
+        # The blank rows are therefore cleared, exactly as they are for a failed integrity
+        # check further down.
         refused = {}
+        refused_pairs: list[tuple[str, str]] = []
         for text in list(by_text):
             reason = unsupported_reason(text)
             if reason is not None:
@@ -222,6 +260,28 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.WARNING(f"  ! {', '.join(labels)}"))
                 self.stdout.write(f"      {text!r}")
                 self.stdout.write(f"      it {reason}")
+                refused_pairs.extend((text, lang) for lang in target_languages)
+
+            # by_text no longer holds the refused strings, so rebuild the mapping the
+            # clearing helper needs from the objects created above.
+            refused_by_text: dict[str, list] = {}
+            for translation_obj, text in translation_objects:
+                if text in refused:
+                    refused_by_text.setdefault(text, []).append(translation_obj)
+
+            cleared, preserved = self._clear_rows(refused_pairs, refused_by_text)
+            if cleared:
+                _invalidate_translation_cache()
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Cleared {cleared} blank row(s) so these fall back to English rather than "
+                        f"rendering empty."
+                    )
+                )
+            if preserved:
+                self.stdout.write(
+                    self.style.WARNING(f"  Kept {len(preserved)} manually-edited row(s): {', '.join(preserved)}")
+                )
 
         unique_texts = list(by_text.keys())
         if not unique_texts:
@@ -267,19 +327,7 @@ class Command(BaseCommand):
             # guard reports a problem while the corruption stays live. Delete the row so
             # the API's key-presence fallback serves English instead. Deleting rather than
             # blanking matters: an empty row is served as empty text, not fallen back on.
-            cleared = 0
-            preserved: list[str] = []
-            for text, lang, _detail in integrity_failures:
-                for translation_obj in by_text.get(text, []):
-                    row = translation_obj.translations.filter(language_code=lang).first()
-                    if row is None:
-                        continue
-                    if row.edited:
-                        # Never destroy a human's work to make room for a fallback.
-                        preserved.append(f"{translation_obj.label} [{lang}]")
-                        continue
-                    row.delete()
-                    cleared += 1
+            cleared, preserved = self._clear_rows([(text, lang) for text, lang, _detail in integrity_failures], by_text)
 
             if cleared:
                 _invalidate_translation_cache()

--- a/translations/management/commands/tests/test_add_translations.py
+++ b/translations/management/commands/tests/test_add_translations.py
@@ -239,3 +239,55 @@ class IntegrityFailureRowCleanupTest(AddTranslationsCommandTest):
         self._run({"k": "Are {subject} employed?"})
 
         mock_invalidate.assert_not_called()
+
+    @patch("translations.management.commands.add_translations._invalidate_translation_cache")
+    @patch("translations.management.commands.add_translations.Translate")
+    @patch("translations.management.commands.add_translations.Translation")
+    def test_refused_string_blank_rows_are_cleared(self, mock_translation, mock_translate, mock_invalidate):
+        """
+        A refused ICU string must fall back to English, not render empty.
+
+        add_translation creates a row for every configured language and the non-English
+        ones start blank. _build_translation_data picks the English fallback on key
+        presence, not emptiness, so leaving those blanks in place makes the label render
+        as empty text in every language - worse than the English it should fall back to.
+        Measured on staging before this fix: 18 rows, serving '' for es, zh-hans and ar.
+        """
+        mock_translation.objects = self._mock_existing({})
+        blank_rows = {}
+
+        def _row_for(language_code):
+            return blank_rows.setdefault(language_code, MagicMock(edited=False, text=""))
+
+        parent = MagicMock(id="k", label="k")
+        parent.translations.filter.side_effect = lambda language_code: MagicMock(first=lambda: _row_for(language_code))
+        mock_translation.objects.add_translation.side_effect = lambda label, default_message, **_: parent
+
+        self._translate_mock(mock_translate, [])
+        self._run({"k": "{count, plural, one {item} other {items}}"})
+
+        # Never sent to the API...
+        mock_translate.return_value.bulk_translate.assert_not_called()
+        # ...but its blank non-English rows must still be removed.
+        assert blank_rows, "expected blank non-English rows to be looked up"
+        for lang, row in blank_rows.items():
+            assert lang != "en-us"
+            row.delete.assert_called_once()
+        mock_invalidate.assert_called_once()
+
+    @patch("translations.management.commands.add_translations._invalidate_translation_cache")
+    @patch("translations.management.commands.add_translations.Translate")
+    @patch("translations.management.commands.add_translations.Translation")
+    def test_refused_string_keeps_edited_rows(self, mock_translation, mock_translate, mock_invalidate):
+        """A human's translation of a refused string survives the blank-row cleanup."""
+        mock_translation.objects = self._mock_existing({})
+        edited_row = MagicMock(edited=True, text="人間の翻訳")
+        parent = MagicMock(id="k", label="k")
+        parent.translations.filter.return_value.first.return_value = edited_row
+        mock_translation.objects.add_translation.side_effect = lambda label, default_message, **_: parent
+
+        self._translate_mock(mock_translate, [])
+        self._run({"k": "{count, plural, one {item} other {items}}"})
+
+        edited_row.delete.assert_not_called()
+        mock_invalidate.assert_not_called()


### PR DESCRIPTION
## Context & Motivation

Follow-up to [#1728](https://github.com/MyFriendBen/benefits-api/pull/1728) (merged yesterday), on [MFB-1733](https://linear.app/myfriendben/issue/MFB-1733). **Bug in code that is already on `main` and deployed to staging.**

#1728's headline feature is refusing to machine-translate ICU plural/select strings. That refusal did not actually produce an English fallback — it produced **blank text in all 17 languages**, which is worse than the English it was meant to fall back to.

`add_translation` creates a row for every configured language and the non-English ones start empty. `_build_translation_data` then picks the English fallback on key **presence**, not emptiness:

```python
label: (texts[lang] if lang in texts else texts.get(default_lang))
```

A blank row is present, so `''` is served and the UI renders nothing.

**Measured on staging, not inferred.** Added a throwaway ICU label through the deployed command and inspected the result:

```
db_rows=18  [('en-us', "'{count, plural, one {item} other {items}}'"),
             ('es', "''"), ('vi', "''"), ('fr', "''"), ('am', "''"), ('so', "''"), ...]
served es      -> ''
served zh-hans -> ''
served ar      -> ''
```

The probe label was deleted afterwards; staging is clean.

## Why it was missed

#1728 fixed this exact trap for **failed integrity checks** and I wrote the row-clearing there. The refusal path a few lines above kept a comment asserting the opposite:

> their English rows are already saved above, so the label exists and react-intl falls back to English

That was written from assumption and never measured, and it read as settled, so the second path never got checked. The same sentence is the reason the `--no-translate` trap bit staging the day before.

## Changes Made

- **`_clear_rows(pairs, by_text)`** — the row-clearing logic extracted out of the integrity-failure branch into a shared method, so the two paths cannot drift apart again. Same semantics: delete rather than blank (a blanked row is still *present* and still served as empty), and never delete a row with `edited=True`.
- **The refusal path now calls it**, clearing the blank non-English rows for every refused string and invalidating the cache. Reports the count, and reports any manually-edited rows it preserved instead.
- **The misleading comment is replaced** with the measured behaviour and the reason the clearing is required.

`by_text` has the refused strings removed by the time clearing happens, so the mapping the helper needs is rebuilt from `translation_objects` rather than reusing the pruned dict.

## Testing

```
translations/ + integrations/clients/tests/ + programs/management/commands/tests/   166 passed
```

`black -l 120` clean.

Two new tests:

| Test | Against unfixed code |
|---|---|
| `test_refused_string_blank_rows_are_cleared` | **fails** — no rows deleted, no cache invalidation |
| `test_refused_string_keeps_edited_rows` | passes either way |

Being straight about the second one: it asserts a human's row is *not* deleted, which is trivially true when nothing deletes anything. It guards the fix against future regression rather than demonstrating the current bug, so only the first is a true regression test.

Verified by swapping in the `HEAD` version of the command and re-running, rather than by reasoning about it.

## Deployment

**Handled automatically** — staging on merge, production on publishing a Release. No migration, no config change.

- **Post-deployment scripts needed:** none. This changes command behaviour only.
- **Production config updates:** none.
- **Admin updates needed:** none.
- **Notify team/users of:** nothing user-facing. **No production data is currently affected** — prod has zero ICU keys, so nothing there is rendering blank today. This is a latent bug: it would fire the first time anyone added an ICU string through `add_translations` or the admin.

  Sequencing note, since a production Release is planned today: this should go out **with** #1728 rather than after it. #1728 alone makes "refuse ICU" reachable in prod, and that path is the one that renders blank. Merging this first keeps the pair consistent.

## Notes for Reviewers

The interesting line is the one deleted from the comment. The bug was not a missing branch, it was a claim about behaviour that nobody measured — and it survived a self-review, a CodeRabbit pass, and a merge, because it read like a statement of fact.

Worth considering as a follow-up, out of scope here: make `_build_translation_data` treat empty or whitespace-only text as absent. That would make this whole class of bug impossible instead of requiring every writer to remember to clean up after itself. Three separate paths have now hit it (`--no-translate`, integrity failures, refusals), which is a reasonable argument that the fallback condition is the actual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refused machine-translatable strings no longer leave unnecessary blank translations in other languages.
  - Manually edited translations are preserved during cleanup.
  - Translation caches are correctly refreshed when blank entries are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->