### PR TITLE
Keep the PolicyEngine token across the between-test cache flush

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -408,21 +408,21 @@ def _preserved_cache_entries():
 
     from integrations.clients.policyengine.engines import _PE_TOKEN_CACHE_KEY
 
-    entries = []
     value = cache.get(_PE_TOKEN_CACHE_KEY)
     if value is None:
-        return entries
+        return []
 
-    # django_redis returns remaining seconds, None for "no expiry", 0 for absent; LocMemCache
-    # has no ttl() at all, so fall back to no expiry and let a 401 evict a stale token.
+    # django_redis reports seconds remaining, None for "no expiry", and 0 for a key that is
+    # absent or already expired - which the read above can race. Restoring on a 0 would put a
+    # dead token back with no expiry at all, so drop it and let the next caller mint one.
+    # LocMemCache has no ttl() to consult, so fall back to no expiry and let a 401 evict.
     timeout = None
     if hasattr(cache, "ttl"):
-        remaining = cache.ttl(_PE_TOKEN_CACHE_KEY)
-        if remaining:
-            timeout = remaining
+        timeout = cache.ttl(_PE_TOKEN_CACHE_KEY)
+        if timeout == 0:
+            return []
 
-    entries.append((_PE_TOKEN_CACHE_KEY, value, timeout))
-    return entries
+    return [(_PE_TOKEN_CACHE_KEY, value, timeout)]
 
 
 @pytest.fixture(autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -396,19 +396,53 @@ def auto_vcr(request, vcr_config):
         _discard_failed_recording(cassette_path, contents_before)
 
 
+def _preserved_cache_entries():
+    """Snapshot the cache entries that must survive a between-test flush.
+
+    Only the PolicyEngine bearer token: it is a credential rather than application state, and
+    PolicyEngine issues a limited number of long-life tokens per month. Flushing it between tests
+    means a recording run re-authenticates for every test that hits the network, minting one
+    30-day token per test.
+    """
+    from django.core.cache import cache
+
+    from integrations.clients.policyengine.engines import _PE_TOKEN_CACHE_KEY
+
+    entries = []
+    value = cache.get(_PE_TOKEN_CACHE_KEY)
+    if value is None:
+        return entries
+
+    # django_redis returns remaining seconds, None for "no expiry", 0 for absent; LocMemCache
+    # has no ttl() at all, so fall back to no expiry and let a 401 evict a stale token.
+    timeout = None
+    if hasattr(cache, "ttl"):
+        remaining = cache.ttl(_PE_TOKEN_CACHE_KEY)
+        if remaining:
+            timeout = remaining
+
+    entries.append((_PE_TOKEN_CACHE_KEY, value, timeout))
+    return entries
+
+
 @pytest.fixture(autouse=True)
 def clear_cache():
-    """Start every test with an empty cache.
+    """Start every test with an empty cache, except for preserved credentials.
 
     LocMemCache gives each process its own cache, so isolation was implicit while
     CI set no REDIS_URL. Against a real Redis the state outlives both the test and
     the run, which makes order-dependent passes and stale-value failures easy to
     introduce. Note this flushes the configured cache database, so pointing
     REDIS_URL at a Redis you also use for development will clear it.
+
+    See ``_preserved_cache_entries`` for what is carried across the flush and why.
     """
     from django.core.cache import cache
 
+    preserved = _preserved_cache_entries()
     cache.clear()
+    for key, value, timeout in preserved:
+        cache.set(key, value, timeout=timeout)
     yield
 
 

--- a/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
+++ b/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
@@ -49,7 +49,7 @@ class TestPeTokenSurvivesTestCacheFlush(TestCase):
         """
         cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
 
-        (_, _, timeout), = _preserved_cache_entries()
+        ((_, _, timeout),) = _preserved_cache_entries()
 
         if hasattr(cache, "ttl"):
             self.assertIsNotNone(timeout)

--- a/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
+++ b/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
@@ -1,0 +1,58 @@
+"""The PolicyEngine bearer token has to outlive the between-test cache flush.
+
+PolicyEngine issues a limited number of long-life (30-day) tokens per month, and
+``_fetch_pe_bearer_token`` only avoids requesting a new one when it finds the last one in the
+Django cache. conftest's autouse ``clear_cache`` fixture flushes that cache before every test, so
+without an exemption a recording run mints one token per test that reaches the network.
+"""
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from conftest import _preserved_cache_entries
+from integrations.clients.policyengine.engines import _PE_TOKEN_CACHE_KEY
+
+
+class TestPeTokenSurvivesTestCacheFlush(TestCase):
+    def test_token_is_carried_across_a_flush(self):
+        """The whole point: a token set before the flush is still readable after it."""
+        cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
+
+        preserved = _preserved_cache_entries()
+        cache.clear()
+        for key, value, timeout in preserved:
+            cache.set(key, value, timeout=timeout)
+
+        self.assertEqual(cache.get(_PE_TOKEN_CACHE_KEY), "token-abc")
+
+    def test_nothing_else_is_carried_across_a_flush(self):
+        """Only the credential is exempt - ordinary cache state must still be isolated."""
+        cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
+        cache.set("some_other_key", "should not survive", timeout=600)
+
+        preserved = _preserved_cache_entries()
+
+        self.assertEqual([key for key, _, _ in preserved], [_PE_TOKEN_CACHE_KEY])
+
+    def test_absent_token_is_not_resurrected(self):
+        """With no token cached there is nothing to preserve, and no placeholder is invented."""
+        cache.delete(_PE_TOKEN_CACHE_KEY)
+
+        self.assertEqual(_preserved_cache_entries(), [])
+
+    def test_remaining_expiry_is_preserved_not_extended(self):
+        """Restoring must not hand a stale token a fresh 30-day lease.
+
+        Carrying the remaining TTL keeps the cache entry expiring when the token really does. A
+        token that outlives its lease would 401, and ``PrivateApiSim`` evicts the key on 401 and
+        requests a new one - self-healing, but only if the entry expires roughly on time.
+        """
+        cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
+
+        (_, _, timeout), = _preserved_cache_entries()
+
+        if hasattr(cache, "ttl"):
+            self.assertIsNotNone(timeout)
+            self.assertLessEqual(timeout, 600)
+        else:
+            self.assertIsNone(timeout)

--- a/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
+++ b/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
@@ -6,6 +6,8 @@ Django cache. conftest's autouse ``clear_cache`` fixture flushes that cache befo
 without an exemption a recording run mints one token per test that reaches the network.
 """
 
+from unittest import mock
+
 from django.core.cache import cache
 from django.test import TestCase
 
@@ -39,6 +41,29 @@ class TestPeTokenSurvivesTestCacheFlush(TestCase):
         cache.delete(_PE_TOKEN_CACHE_KEY)
 
         self.assertEqual(_preserved_cache_entries(), [])
+
+    def test_expired_token_is_not_restored(self):
+        """A ttl of 0 means the key is gone, even though the read above returned a value.
+
+        django_redis reports 0 for a key that is absent or already expired, which the read can
+        race. Restoring on that signal would put a dead token back with no expiry, and every
+        caller would use it until something got a 401.
+        """
+        cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
+
+        with mock.patch.object(cache, "ttl", return_value=0, create=True):
+            self.assertEqual(_preserved_cache_entries(), [])
+
+    def test_token_with_no_expiry_is_restored_with_no_expiry(self):
+        """A ttl of None means the key exists and never expires - distinct from a ttl of 0.
+
+        ``seed_pe_token`` stores its placeholder this way, so conflating the two signals would
+        either drop it or, worse, treat a genuinely expired token as unexpiring.
+        """
+        cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=None)
+
+        with mock.patch.object(cache, "ttl", return_value=None, create=True):
+            self.assertEqual(_preserved_cache_entries(), [(_PE_TOKEN_CACHE_KEY, "token-abc", None)])
 
     def test_remaining_expiry_is_preserved_not_extended(self):
         """Restoring must not hand a stale token a fresh 30-day lease.


### PR DESCRIPTION
## Context & Motivation

PolicyEngine reported that their auth provider saw the MFB testing app requesting as many as **1,200 bearer tokens in a single day** (2026-08-26). These are long-life (30-day) tokens and PE can only issue a limited number per month. Their ask was a standard JWT workflow: store one, reuse it, request a new one only at expiry.

`engines._fetch_pe_bearer_token()` already implements exactly that — it reads the last token out of the Django cache before requesting a new one, and stores each with `timeout=expires_in - 60`.

The leak is in the test harness. `conftest.py`'s `clear_cache` fixture is `autouse=True` and calls `cache.clear()` before **every test**, which flushes the bearer token along with everything else. So under `PE_RECORD=1` the cache lookup misses on every test, and **one fresh 30-day token is minted per test that reaches the network**. Recording a program's scenario suite mints roughly as many tokens as it has scenarios.

`seed_pe_token()` already documents the flush and re-seeds a placeholder per test for the *replay* path — but the recording path deliberately leaves the cache empty so a real token gets fetched, and nothing carries that real token to the next test.

- Linear: [MFB-1743](https://linear.app/myfriendben/issue/MFB-1743/test-harness-mints-a-policyengine-bearer-token-per-test)
- Related PR: #1663 (introduced the fixture, 2026-08-10)

## Changes Made

- `conftest.py`: added `_preserved_cache_entries()`, which snapshots the PolicyEngine bearer token (and only that key) before the flush; `clear_cache` restores it afterwards. Everything else is still cleared, so test isolation is unchanged.
- The snapshot carries the entry's **remaining TTL** rather than resetting it, so a restored token still expires when the real token does. `LocMemCache` has no `ttl()`, so that path falls back to no expiry and relies on `PrivateApiSim` evicting the key on a 401 and re-requesting — self-healing.
- `django_redis.ttl()` reports three different things, and they are now handled separately. This came out of review: the first version tested the value for truthiness, which conflated the last two rows and would put an already-expired token back with no expiry at all.

  | Key state | `ttl()` | Behaviour |
  |---|---|---|
  | exists, expires later | seconds | restore with that remaining TTL |
  | exists, no expiry | `None` | restore with no expiry — this is how `seed_pe_token` stores its placeholder |
  | absent or already expired | `0` | **don't restore**; the read above can race, and a dead token cached without expiry would be served to every caller until something got a 401 |
- New `integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py`: 6 tests — the token is carried across a flush, nothing else is, an absent token isn't resurrected, expiry is preserved rather than extended, and one test per `ttl()` signal in the table above.

## Testing

- Migrations to run: **none**
- Configuration updates needed: **none**
- Environment variables/settings to add: **none**
- Manual testing steps:
  - `VCR_MODE=none venv/bin/pytest -q` → 3,790 passed, 5 skipped, 0 failures
  - `venv/bin/pytest integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py -q` → 4 passed
  - `venv/bin/pytest integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py -q` → 6 passed. Reverting only the `conftest.py` change gives `1 failed, 5 passed`, so the expired-key test does catch the old behaviour.
  - `black --check` on the changed files, at the 26.5.1 pinned in both `requirements.txt` and the format workflow → clean
  - End-to-end A/B on the fixture itself, using a throwaway two-test file (one test seeds the token, the next reads it) — not committed, since asserting an autouse fixture's cross-test effect requires depending on test order:

    | | test 2 sees token | test 2 sees ordinary key |
    |---|---|---|
    | with this change | `'sentinel-token'` | `None` |
    | without it | `None` | `None` |

    The second column is the isolation check — ordinary cache state is discarded either way.
  - Deliberately **not** verified by doing a live recording run, since that would mint the tokens this PR exists to stop.

## Deployment

- Post-deployment scripts needed: **none**
- Production config updates: **none**
- Admin updates needed: **none**
- Notify team/users of:
  - **Anyone who has run `PE_RECORD=1` since 2026-08-10 has been minting a token per test.** Worth telling the team so re-recording is done deliberately until this lands.
  - Worth replying to PolicyEngine with the cause — they flagged the symptom, and "our test harness flushed the token before each test" is a concrete answer.

## Notes for Reviewers

- **CI is not a source, and I'd like that double-checked.** `pr-validation.yaml` sets `REDIS_URL` and runs `vcr-mode: new_episodes`, but passes no `POLICY_ENGINE_CLIENT_ID`/`SECRET` and no `PE_RECORD`, so `seed_pe_token()` seeds a placeholder and nothing authenticates. `deploy-production.yml` sets `VCR_MODE: all`, but `PeIntegrationTestCase.setUp` skips under that mode. So the minting has been local-only — please sanity-check that reading of the secrets available to those workflows.
- **Exempting a key from the flush is a deliberate weakening of test isolation.** It's scoped to one key that holds a credential rather than application state, and `test_nothing_else_is_carried_across_a_flush` pins the scope. If you'd rather not touch shared infra, the narrower alternative is for `seed_pe_token()` to stash the real token in a module-level variable and re-seed it per test — same effect, confined to the PE fixture, but it only helps tests that go through `PeIntegrationTestCase`.
- Known limitations:
  - Reduces a recording run from one token per test to one per run. It does not dedupe across runs beyond the existing 30-day cache entry, and a local `cache.clear()` or a flushed Redis still costs one token.
  - `LocMemCache` can't report a remaining TTL, so on that backend a restored token is held without expiry until a 401 evicts it.
  - Skipping restoration when `ttl()` is `0` costs one minted token in that race. Deliberate trade: one extra token beats caching a dead one indefinitely.
- Future considerations:
  - A stronger guard would be asserting in the PE fixture that the token came from cache rather than the network, so a regression fails a test instead of quietly minting. Left out here to keep the change small.
  - Separately: PE now serves only `current` 1.815.1 / `frontier` 1.821.2, so cassettes pinned at 1.794.2 (including the MO Medicaid ones) 422 on re-record. Committed cassettes still replay, so CI is unaffected, but the next re-record needs a pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved PolicyEngine authentication tokens when test cache data is cleared, preventing unnecessary re-authentication during recording runs.
  * Maintained existing token expiration times while keeping unrelated cache entries isolated.
  * Avoided restoring tokens that were not previously cached.

* **Tests**
  * Added coverage verifying token preservation, TTL handling, cache isolation, and behavior when no token exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
