### PR TITLE
Let PolicyEngine's routing decide the Medicaid value tier

### DIFF
--- a/programs/programs/cross_white_label/medicaid/base.py
+++ b/programs/programs/cross_white_label/medicaid/base.py
@@ -41,40 +41,83 @@ class Medicaid(PolicyEngineMembersCalculator, abstract=True):
 
     aged_min_age = 65
 
+    # PolicyEngine categories that mean "eligible on an age or disability basis". Neither
+    # distinguishes aged from disabled - SENIOR_OR_DISABLED names both in one value, and
+    # SSI_RECIPIENT says only that SSI receipt is the route - so the value tier for these has
+    # to come from the member's own age and disability flags. See ``abd_value``.
+    abd_categories = ("SENIOR_OR_DISABLED", "SSI_RECIPIENT")
+
+    # ACA expansion is a 19-64 group (42 CFR 435.119), so a member past ``aged_min_age`` must
+    # never be valued at an expansion rate even if PolicyEngine hands one back. Other MAGI
+    # categories have no upper age bound - a 66-year-old can genuinely be a Sec. 1931
+    # parent/caretaker - so only the expansion groups are excluded.
+    expansion_categories = ("ADULT", "YOUNG_ADULT")
+
+    # How to value a member who is both 65+ and disability-eligible.
+    #
+    # False (the default) keeps the disabled rate, which is what the per-enrollee spending
+    # tables the earlier states were built from assume: they publish "age 65 and older" and
+    # "with a disability" as disjoint groups with disability taking precedence, and
+    # specs/ks.md commits to that reading.
+    #
+    # States whose own spec says age wins - KFF publishes Seniors as 65+ regardless of
+    # disability - set this True. Left per-state rather than made uniform because the two
+    # committed specs disagree and each is right about its own source table.
+    senior_value_takes_precedence = False
+
+    def abd_value(self, is_senior: bool, is_disabled: bool):
+        """Annual value for a member eligible on the aged/blind/disabled basis.
+
+        The aged rate belongs to seniors; everyone else on this pathway takes the disabled
+        rate, including a member PolicyEngine reports as an SSI recipient who set no
+        disability flag on the screener - SSI receipt is itself the disability signal there.
+        """
+        if is_senior and (self.senior_value_takes_precedence or not is_disabled):
+            return self.medicaid_categories["AGED"] * 12
+        return self.medicaid_categories["DISABLED"] * 12
+
     def member_value(self, member: HouseholdMember):
-        # PolicyEngine uses two separate pathways for Medicaid eligibility:
-        # 1. "medicaid" variable - ACA expansion eligibility (138% FPL for adults under 65)
-        # 2. "is_optional_senior_or_disabled_for_medicaid" - aged/disabled pathway
-        #    (state-specific FPL thresholds, typically 74-100%)
+        # PolicyEngine answers Medicaid over two pathways, and a member can clear either:
         #
-        # Seniors (65+) and disabled individuals must use the aged/disabled pathway,
-        # as ACA expansion only applies to adults under 65.
+        # 1. ``medicaid`` - the ordinary MAGI pathways (expansion, parent/caretaker,
+        #    pregnant, children), with ``medicaid_category`` naming which group applied.
+        # 2. ``is_optional_senior_or_disabled_for_medicaid`` - the optional aged/disabled
+        #    pathway, at state-specific thresholds (typically 74-100% FPL).
+        #
+        # PolicyEngine's own routing decides the group. Reading the ABD pathway first would
+        # discard it: a disabled adult whom PE placed in ADULT would be valued at the disabled
+        # rate, and one who failed ABD would be dropped entirely despite PE finding them
+        # eligible under expansion. So the ordinary pathway is consulted first, and the ABD
+        # pathway is the fallback for the members it does not reach.
         age = member.calc_age()
         is_senior = age is not None and age >= self.aged_min_age
         is_disabled = member.has_disability()
 
+        if self.get_member_variable(member.id) > 0:
+            medicaid_category = self.get_member_dependency_value(dependency.member.MedicaidCategory, member.id)
+
+            if medicaid_category in self.abd_categories:
+                return self.abd_value(is_senior, is_disabled)
+
+            if not (is_senior and medicaid_category in self.expansion_categories):
+                # .get rather than [] because medicaid_categories covers only the categories we
+                # price. PolicyEngine's enum is larger and grows: MEDICALLY_NEEDY,
+                # WORKING_DISABLED_BUY_IN and SECTION_1115_MEC_ADULT have no key here, and a
+                # state whose covered-category list includes one would raise KeyError out of
+                # member_value - which fails the whole eligibility request, not just this
+                # program.
+                value = self.medicaid_categories.get(medicaid_category, 0) * 12
+                if value > 0:
+                    return value
+
+        # Fallback, reached when the ordinary pathway found nothing this state prices: an
+        # unrecognised category, a category priced at 0, or a senior PE routed to expansion.
+        # A member eligible on the aged/disabled basis is still eligible.
         if is_senior or is_disabled:
             qualifies_via_aged_disabled_pathway = self.get_member_dependency_value(
                 dependency.member.MedicaidSeniorOrDisabled, member.id
             )
-            if not qualifies_via_aged_disabled_pathway:
-                return 0
+            if qualifies_via_aged_disabled_pathway:
+                return self.abd_value(is_senior, is_disabled)
 
-            if is_disabled:
-                return self.medicaid_categories["DISABLED"] * 12
-            else:
-                return self.medicaid_categories["AGED"] * 12
-
-        # Non-senior, non-disabled members use regular Medicaid eligibility
-        if self.get_member_variable(member.id) <= 0:
-            return 0
-
-        medicaid_category = self.get_member_dependency_value(dependency.member.MedicaidCategory, member.id)
-
-        # .get rather than [] because medicaid_categories covers only the categories we price.
-        # PolicyEngine's enum is larger and grows: MEDICALLY_NEEDY, WORKING_DISABLED_BUY_IN,
-        # SECTION_1115_MEC_ADULT and SENIOR_OR_DISABLED have no key here, and a state whose
-        # covered-category list includes one of them would raise KeyError out of member_value -
-        # which fails the whole eligibility request, not just this program. Falling back to 0
-        # drops the program from results instead, the same as any other ineligible answer.
-        return self.medicaid_categories.get(medicaid_category, 0) * 12
+        return 0

--- a/programs/programs/cross_white_label/medicaid/mo.py
+++ b/programs/programs/cross_white_label/medicaid/mo.py
@@ -79,7 +79,7 @@ class MoHealthNet(Medicaid):
         "DISABLED": KFF_DISABLED / 12,
     }
 
-    # KFF defines Seniors as 65+ regardless of disability, and mo_medicaid_spec.md's
+    # KFF defines Seniors as 65+ regardless of disability, and specs/mo.md's
     # value-priority rule follows it: "age 65+ -> Seniors, even if disability-eligible".
     # The default is the opposite because specs/ks.md reads its source table the other way.
     senior_value_takes_precedence = True

--- a/programs/programs/cross_white_label/medicaid/mo.py
+++ b/programs/programs/cross_white_label/medicaid/mo.py
@@ -31,11 +31,11 @@ class MoHealthNet(Medicaid):
       still found eligible through expansion.
     - No Substantial Gainful Activity test gates the disability pathways. Not measured.
 
-    Two behaviours are ours rather than PolicyEngine's, both in ``Medicaid.member_value``
-    and shared by every Medicaid state, so neither is worked around here: a member who
-    reports a disability and fails the aged/disabled pathway is not then evaluated for
-    adult expansion, and a member who is both 65+ and disabled is valued at the disabled
-    rather than the senior rate.
+    Valuation is ours rather than PolicyEngine's, and lives in ``Medicaid.member_value``:
+    PolicyEngine decides which pathway found a member eligible, and the KFF group is then
+    assigned from the member's own age and disability, per specs/mo.md's value-priority
+    rule. ``senior_value_takes_precedence`` below is the one place Missouri departs from
+    the shared default.
     """
 
     program_code = "mo_medicaid"
@@ -78,3 +78,8 @@ class MoHealthNet(Medicaid):
         "AGED": KFF_SENIORS / 12,
         "DISABLED": KFF_DISABLED / 12,
     }
+
+    # KFF defines Seniors as 65+ regardless of disability, and mo_medicaid_spec.md's
+    # value-priority rule follows it: "age 65+ -> Seniors, even if disability-eligible".
+    # The default is the opposite because specs/ks.md reads its source table the other way.
+    senior_value_takes_precedence = True

--- a/programs/programs/cross_white_label/medicaid/specs/mo.md
+++ b/programs/programs/cross_white_label/medicaid/specs/mo.md
@@ -14,9 +14,9 @@
 
 **Documented but not directly screenable** — surfaced in the program description, not gated on: postpartum continuation (criterion 3), Transitional MO HealthNet (NOT RUNNABLE, criterion 9), automatic newborn continuation (criterion 10), Former Foster Care Youth (NOT RUNNABLE, criterion 11), §1619(b) continuation (NOT RUNNABLE, criterion 15), and the four-month spousal-support extension (NOT RUNNABLE, criterion 16).
 
-**Legal status / immigration**: handled through `legal_status_required`, the platform-wide household-visibility gate — not per-member logic inside `MoMedicaid`. See "Legal Status & Immigration" below.
+**Legal status / immigration**: handled through `legal_status_required`, the platform-wide household-visibility gate — not per-member logic inside `MoHealthNet`. See "Legal Status & Immigration" below.
 
-**Build pattern**: `MoMedicaid(Medicaid)`, following the existing Medicaid PE-calculator pattern (`KsKanCare(Medicaid)` precedent, MFB-1054).
+**Build pattern**: `MoHealthNet(Medicaid)`, following the existing Medicaid PE-calculator pattern (`KsKanCare(Medicaid)` precedent, MFB-1054).
 
 **Explicitly out of scope**: Premium CHIP 73/74/75 (MFB-1262 — not CHIP 4M, which this calculator continues to cover under criterion 2b), Ticket to Work Health Assurance (MFB-1287/MFB-1223), institutional/vendor/HCBS/long-term-care Medicaid, BCCT, Show-Me Healthy Babies, UWHS, and Emergency MO HealthNet Care for Ineligible Aliens (EMCIA).
 
@@ -27,7 +27,7 @@
 1. **Missouri residency required**
    - Screener fields: `zipcode`, `county`
    - Source: MO DSS FSD Manual Section 1805.005.00 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-005-00/ — "42 CFR subsection 435.403 requires individuals to reside in the state where they are applying for benefits."
-   - **Screener-level precondition, not a calculator-level test**: `benefits-calculator`'s `Zipcode.tsx` step Zod-validates the ZIP against `counties_by_zipcode` before the screener advances, so no non-Missouri household ever reaches `MoMedicaid`.
+   - **Screener-level precondition, not a calculator-level test**: `benefits-calculator`'s `Zipcode.tsx` step Zod-validates the ZIP against `counties_by_zipcode` before the screener advances, so no non-Missouri household ever reaches `MoHealthNet`.
 
 2a. **MO HealthNet for Kids (MHK) — Infants (under age 1): base 196% FPL, effective 201% FPL after the 5% MAGI disregard**
    - Operative table row (Appendix A, effective 07-01-26–03-31-27): "196% of Poverty# MPW & MHK under 1" — HH1 $2,674, HH2 **$3,625**, HH3 $4,577, HH4 $5,528 ("#" = 5% disregard already applied).
@@ -206,7 +206,7 @@ Medicaid is valued per MFB convention as KFF's published average spending per fu
 
 **Implementation is complete when:**
 
-- [ ] All 34 scenarios pass with the exact eligibility, category, and annual value stated. `eligible: true` alone is insufficient where a value is specified.
+- [ ] 33 of the 34 scenarios pass with the exact eligibility, category, and annual value stated. `eligible: true` alone is insufficient where a value is specified. Scenario 8 is the accepted exception: it depends on applicant-specific MAGI household construction, which the platform does not yet build, and so cannot pass on any white label — tracked in MFB-1745 and annotated at the scenario itself.
 - [ ] Income boundaries confirm an inclusive (`≤`) comparator across the tested household sizes and pathways: AEG HH1 $1,836/$1,837 (2/5) and HH4 $3,795/$3,797 (32/33); MHK HH2 $2,760/$2,761 (4/17); MHF HH2 $241/$242 (12/26); and infant/MPW HH2 $3,625/$3,626 (27/28, 29/30). MHABD is tested at the exact adjusted-income ceiling only (11) because the over-limit branch may depend on unobservable spend-down.
 - [ ] Scenarios 27 and 29 confirm the infant/MPW 201% standard is load-bearing by using income above the 1–18 children's 153% ceiling.
 - [ ] MHDC deeming scenarios 9 and 25 assert the exact PE deemed-income value and non-spend-down classification, not only top-level eligibility/value.
@@ -215,7 +215,7 @@ Medicaid is valued per MFB convention as KFF's published average spending per fu
 - [ ] Scenario 20 reads PE's `is_parent_for_medicaid` result as-is for `relatedOther`, consistent with criterion 4's kinship data-gap handling.
 - [ ] Scenario 34 switches from MHDC deeming to adult MHABD and uses the applicant's own income once the MHDC deeming period has ended.
 - [ ] Non-runnable pathways remain documentation/data-gap treatments only and are not implemented as calculator gates.
-- [ ] Household construction uses applicant-specific units; non-spouses and non-dependent relatives sharing a physical household are not combined into one unit — see MAGI Household Composition & Income Methodology.
+- [ ] Household construction uses applicant-specific units; non-spouses and non-dependent relatives sharing a physical household are not combined into one unit — see MAGI Household Composition & Income Methodology. **Not met today**, for the reason recorded against Scenario 8 above; this is the criterion that scenario tests.
 
 ## Test Scenarios
 

--- a/programs/programs/cross_white_label/medicaid/specs/mo.md
+++ b/programs/programs/cross_white_label/medicaid/specs/mo.md
@@ -1,0 +1,699 @@
+# Implement Medicaid (MO) Program
+
+## Program Details
+
+- **Program**: Medicaid
+- **Program key**: `mo_medicaid`
+- **Policy year**: 2026
+- **Calculator type**: PE (eligibility varies)
+- **State**: MO
+- **White Label**: mo
+- **Research Date**: 2026-07-20
+
+**Screenable pathways**: infants and children, pregnant women, parent/caretaker relatives (MHF), Adult Expansion, MHABD (aged/blind/disabled), and MO HealthNet for Disabled Children (MHDC).
+
+**Documented but not directly screenable** — surfaced in the program description, not gated on: postpartum continuation (criterion 3), Transitional MO HealthNet (NOT RUNNABLE, criterion 9), automatic newborn continuation (criterion 10), Former Foster Care Youth (NOT RUNNABLE, criterion 11), §1619(b) continuation (NOT RUNNABLE, criterion 15), and the four-month spousal-support extension (NOT RUNNABLE, criterion 16).
+
+**Legal status / immigration**: handled through `legal_status_required`, the platform-wide household-visibility gate — not per-member logic inside `MoMedicaid`. See "Legal Status & Immigration" below.
+
+**Build pattern**: `MoMedicaid(Medicaid)`, following the existing Medicaid PE-calculator pattern (`KsKanCare(Medicaid)` precedent, MFB-1054).
+
+**Explicitly out of scope**: Premium CHIP 73/74/75 (MFB-1262 — not CHIP 4M, which this calculator continues to cover under criterion 2b), Ticket to Work Health Assurance (MFB-1287/MFB-1223), institutional/vendor/HCBS/long-term-care Medicaid, BCCT, Show-Me Healthy Babies, UWHS, and Emergency MO HealthNet Care for Ineligible Aliens (EMCIA).
+
+**PE alignment**: PE remains authoritative for modelable Medicaid eligibility/category decisions; MFB does not add state-specific overrides solely to correct PE differences.
+
+## Eligibility Criteria
+
+1. **Missouri residency required**
+   - Screener fields: `zipcode`, `county`
+   - Source: MO DSS FSD Manual Section 1805.005.00 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-005-00/ — "42 CFR subsection 435.403 requires individuals to reside in the state where they are applying for benefits."
+   - **Screener-level precondition, not a calculator-level test**: `benefits-calculator`'s `Zipcode.tsx` step Zod-validates the ZIP against `counties_by_zipcode` before the screener advances, so no non-Missouri household ever reaches `MoMedicaid`.
+
+2a. **MO HealthNet for Kids (MHK) — Infants (under age 1): base 196% FPL, effective 201% FPL after the 5% MAGI disregard**
+   - Operative table row (Appendix A, effective 07-01-26–03-31-27): "196% of Poverty# MPW & MHK under 1" — HH1 $2,674, HH2 **$3,625**, HH3 $4,577, HH4 $5,528 ("#" = 5% disregard already applied).
+   - Screener fields: `household_size`, `birth_year`/`birth_month`, `relationship`, `income (all types)`
+   - Source: MO DSS MAGI Income Limits Appendix A, "196%# MPW & MHK under 1" row — https://dssmanuals.mo.gov/wp-content/uploads/2019/03/MAGIappendix-a.pdf; MO DSS "MAGI MO HealthNet Program Descriptions" (04/2026), MHK/CHIP row — https://dssmanuals.mo.gov/wp-content/uploads/2020/03/MAGI-Appendix-I.pdf
+
+2b. **Children ages 1–18, effective 153% FPL — non-CHIP MHK and CHIP 4M share one 153% ceiling**
+   - Non-CHIP MHK (§1830.010.05) covers ages 1–18 up to 148% base. CHIP 4M (§1840.010.05) covers the remainder up to 153% base: ages 1–5 from 148–153%; ages 6–18 from 110–153% (so CHIP 4M also covers ages 6–18 between 110–148%, not just the gap above 148%). CHIP 4M is legally a Title XXI "Non-Premium Group" (§1840.010.00), not non-CHIP MHK — but PE models it `is_medicaid_eligible: true`, and MFB-1262's `mo_chip_spec.md` scopes it out of premium CHIP. `mo_medicaid` follows PE's routing (one flat 153% test for the whole 1–18 band) as an **implementation convention**, not a claim that CHIP 4M is Medicaid policy. **Value**: $4,576 (Children) — see Benefit Value's CHIP 4M methodology note.
+   - Operative table row (Appendix A, effective 07-01-26–03-31-27): "153%* of Poverty CHIP 4M" — HH1 $2,035, HH2 **$2,760**, HH3 $3,484, HH4 $4,208 ("*" = income ranges CHIP 4M ages 1–5: 148%–153%; ages 6–18: 110%–153%).
+   - Screener fields: `household_size`, `birth_year`/`birth_month`, `relationship`, `income (all types)`
+   - Source: MO DSS FSD manual, Section 1830.010.05 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1830-000-00/1830-010-00/1830-010-05/; CHIP 4M — Section 1840.010.05 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1840-000-00/1840-010-00/1840-010-05/; MFB-1262 `mo_chip_spec.md`; PE source — `policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/{young_child,older_child}/income_limit.yaml`.
+
+3. **MO HealthNet for Pregnant Women (MPW) — base 196% FPL, effective 201% FPL, including 12 months postpartum**
+   - Same operative table row as criterion 2a: "196% of Poverty# MPW & MHK under 1" — HH2 **$3,625** (unborn child counted toward household size, per below).
+   - Income test applies only during pregnancy; household size includes the unborn child. Self-attestation (`pregnant: true/false`) is sufficient.
+   - ⚠️ **Data gap (postpartum continuation)**: no "was pregnant within the last 12 months" field. No inclusive assumption (would risk false positives) — surface in the program description; don't gate; no new field proposed.
+   - Screener fields: `household_size`, `pregnant`, `income (all types)`
+   - Source: MO DSS "MAGI MO HealthNet Program Descriptions" (04/2026), MPW row — https://dssmanuals.mo.gov/wp-content/uploads/2020/03/MAGI-Appendix-I.pdf; continuous eligibility — Section 1850.020.00 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1850-000-00/1850-020-00/.
+
+4. **MO HealthNet for Families (MHF) — Parent/Caretaker Relatives**
+   - Three conditions, all required:
+     1. **Relationship/responsibility**: a blood/adoption/marriage relative of a dependent child (parent, grandparent, sibling, step-relation, aunt/uncle, cousin, niece/nephew, or their spouse) with whom the child lives and who is primarily responsible for their care (§1810.020.20.10). A non-relative caregiver doesn't qualify (the child is still independently evaluated under 2b).
+        - ⚠️ **Data gap — kinship**: MFB cannot independently verify Missouri's blood/adoption/marriage requirement for every relationship represented by `relatedOther`. Do not add a separate MFB kinship gate; use PE's returned MHF result. Scenario 20 covers `relatedOther`.
+        - ⚠️ **Data gap — foster-care kinship**: `fosterChild`/`fosterParent` doesn't confirm an *additional* blood/adoption/marriage tie. No dedicated scenario.
+        - **Foster-care handling**: pass the foster-care relationship fact to PE; do not use it as a separate MFB eligibility gate.
+     2. **Income**: MHF uses a flat, non-FPL-indexed 1996 AFDC-equivalent monthly standard:
+
+        | HH size | Limit | HH size | Limit |
+        |---|---|---|---|
+        | 1 | $141 | 5 | $400 |
+        | 2 | $241 | 6 | $445 |
+        | 3 | $301 | 7 | $490 |
+        | 4 | $353 | 8 | $532 |
+
+        Operative table row (Appendix A): "MHF/MPW MHF" — HH1 $141, HH2 $241, HH3 $301, HH4 $353 (figures above continue this row through HH8). Missouri's table continues past HH8, but the screener caps household entry at 8 (`MAX_HOUSEHOLD_SIZE`, `HouseholdMemberBasicInfoPage.tsx`), so HH9+ is structurally unreachable — not a gap.
+     3. **Student extension for a qualifying child aged 18–19** (high-school student expected to graduate) — determines whether the parent stays on MHF or moves to AEG.
+        - ⚠️ **Data gap**: no school-enrollment field. MFB adds no gate in either direction — it reads PE's own `is_parent_for_medicaid` result unmodified, with no special-cased routing to AEG at 18. Surface in the program description.
+   - Screener fields: `household_size`, `relationship`, `income (all types)`, `birth_year`/`birth_month`
+   - Source: relationship — §1810.020.20.10 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1810-000-00/1810-020-00/1810-020-20/1810-020-20-10/; income standard — MO DSS "MAGI MO HealthNet Program Descriptions" (04/2026), MHF row; dollar figures — MAGI Income Limits Appendix A, "MHF/MPW MHF" row; student extension — §1810.020.20.20 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1810-000-00/1810-020-00/1810-020-20/1810-020-20-20/.
+
+5. **MO HealthNet Adult Expansion (AEG), ages 19–64 — base 133% FPL, effective 138% FPL**
+   - Operative table row (Appendix A): "133% of Poverty# AEG" — HH1 **$1,836**, HH2 $2,489, HH3 $3,142, HH4 **$3,795**.
+   - All required: age 19–64; income ≤138% FPL effective; not pregnant; not entitled to/enrolled in Medicare Part A/B; not receiving SSI; ineligible for all mandatory categories (MPW/3, MHK/2b, MHF/4, MHABD non-spend-down/6, MO foster care to 26/11 — these take precedence); and, if an uninsured child under 19 lives in the household, that child must be found MHN-eligible.
+     - **MEC condition — negative branch NOT RUNNABLE**: existing scenarios satisfy it but don't vary it, and it can't be isolated with current inputs (MHK's 153% ceiling exceeds AEG's 138%, so any income failing the child also fails the parent). The rule (§1865.020.00) is real regardless.
+   - Medicare and SSI each independently exclude AEG (Scenario 10).
+   - **Routing rule for self-reported disability/blindness/SSDI** (§1865.040.10): triggers a **concurrent MAGI (AEG) and non-MAGI (MHABD) determination**, not automatic AEG exclusion or MHABD establishment. If adjusted MHABD income (criterion 6) clears the non-spend-down standard, MHABD is **mandatory** and displaces AEG with no choice. If it doesn't clear (spend-down only, non-mandatory), Missouri's rule defaults to AEG absent an election — MFB doesn't implement this election/default mechanism (the screener can't capture it) and instead sends the facts to PE and reads its `medicaid_category` result.
+   - **Committed launch result**: Scenarios 19, 21, and 31 use PE's Adult Expansion result; see the MFB-1261 accepted-divergences decision.
+   - **SSI vs. SSDI**: SSI independently excludes AEG; MHABD eligibility is then evaluated under criterion 6. SSDI does not independently exclude AEG; like a disability/blindness report, it triggers the concurrent AEG/MHABD determination. `sSDisability` is the per-member SSDI signal — there is no dedicated `has_ssdi` field.
+   - Screener fields: `household_size`, `birth_year`/`birth_month`, `income (all types)`, `pregnant`, `disabled`, `long_term_disability`, `visually_impaired`, insurance type (`medicare`), income type (`sSI`, `sSDisability`)
+   - Source: §1865.020.00 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1865-000-00/1865-020-00/; concurrent-determination and choice mechanism — §1865.040.10 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1865-000-00/1865-040-00/1865-040-10/; PE source — `policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/adult/is_adult_for_medicaid_{fc,nfc}.py`, `.../ssi_recipient/is_209b_ssi_recipient_for_medicaid.py`.
+
+6. **MO HealthNet for Aged, Blind, and Disabled (MHABD)** ⚠️ *partial data gap (spend-down)*
+   - Non-spend-down countable monthly income must not exceed (effective 04-01-26): Aged/disabled $1,131 individual / $1,533 couple. Blind $1,330 individual / $1,804 couple.
+   - Operative table rows (Appendix J, "Spend Down (includes disabled child) - MHNS, MHSD, MHDC"): "1 person – aged or disabled $1,131 04-01-26"; "2 people – aged or disabled 1,533 04-01-26"; "1 person – blind 1,330 04-01-26"; "2 people – blind 1,804 04-01-26."
+   - ⚠️ **Data gap — spend-down**: Missouri allows an otherwise eligible MHABD applicant above the non-spend-down income limit to qualify when the monthly spend-down obligation (incurred medical expenses ≥ excess income) is met. MFB cannot determine whether spend-down is met from current screener inputs. **Committed handling**: do not independently grant eligibility through spend-down; use PE's returned Medicaid result and surface the spend-down possibility in the program description. This handling also applies to MHDC (criterion 12).
+   - ⚠️ **Data gap — SGA**: bars MHABD when earnings exceed $1,690/mo (non-blind) or $2,830/mo (blind), net of IRWE, per an MRT determination the screener can't replicate — not screenable; not surfaced or independently scenario-tested. Operative table rows (Appendix J): "SGA (Substantial Gainful Activity) – aged or disabled 1,690 01-01-26"; "SGA – blind 2,830 01-01-26."
+   - Missouri is a **209(b) state**: SSI receipt doesn't automatically confer eligibility. SSI is entered as unearned income (§0805.015.30) then **deducted** before the final adjusted-income comparison (§0805.015.35).
+   - Blind (100% FPL) and aged/disabled (85% FPL) are distinct standards; use `visually_impaired` / `long_term_disability` respectively. This mandatory-vs-non-mandatory question doesn't arise for MHDC (criterion 12) — no competing AEG pathway for under-18s.
+   - **Formal disability determination required, not just self-report** ⚠️ *data gap*: the screener's flags are self-report only. Any of the three flags is a sufficient MHABD-routing signal (inclusive assumption); not gated on the formal requirement; not surfaced. (Same handling for MHDC, criterion 12.)
+   - Screener fields: `household_size`, `birth_year`/`birth_month`, `disabled`, `long_term_disability`, `visually_impaired`, `income (all types)`
+   - Source: §0805.015.45 — https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-45-income-maximum/; dollar figures — "Eligibility Standards for Non-MAGI Programs" (07/2026) — https://dssmanuals.mo.gov/wp-content/uploads/2022/07/mhabd-appendix-j.pdf; SSI as unearned income — §0805.015.30; SSI deduction — §0805.015.35; SGA/MRT — §0840.010.35; IRWE — §1060.005.12; formal disability requirement — mydss.mo.gov/eligibility-requirements-mo-healthnet-coverage; 209(b) — SSA POMS SI 01715.020; PE source — `policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/senior_or_disabled/income/limit/{individual,couple}.yaml`, `.../medicaid_category.py`.
+
+7. **MHABD Resource/Asset Limit: $6,220.50 individual, $12,441.00 couple (effective 07-01-26)** ⚠️ *data gap — inclusive assumption*
+   - Operative table row (Appendix J, "Spend Down..." resource-maximum column): "1 person – aged or disabled ... $6,220.50 07-01-26"; "2 people – aged or disabled ... 12,441.00 07-01-26" (same figures repeat for the blind rows).
+   - `household_assets` can't separate countable from excluded resources (home, one vehicle, household goods, etc.). Never hard-gate MHABD on assets. Not surfaced.
+   - **Committed handling**: do not use aggregate `household_assets` to enforce the MHABD resource limit because MFB cannot distinguish countable from excluded resources.
+   - Source: "Eligibility Standards for Non-MAGI Programs" (07/2026) — https://dssmanuals.mo.gov/wp-content/uploads/2022/07/mhabd-appendix-j.pdf.
+
+7a. **Non-Correctional Public-Institution Residency** ⚠️ *data gap — inclusive assumption*
+   - A resident of a non-correctional, government-operated public institution is ineligible unless a patient in a medical institution (13 CSR 40-2.080(2)) — distinct from ordinary correctional incarceration, which is NOT an exclusion (CMS: inmate status suspends rather than terminates coverage, effective 2026-01-01, CIB 122325). No screener field; never gate; not surfaced.
+   - Source: 13 CSR 40-2.080(2) — https://www.sos.mo.gov/cmsimages/adrules/csr/current/13csr/13c40-2.pdf.
+
+### MAGI Household Composition & Income Methodology
+
+Missouri determines a **separate MAGI household for each applicant** based on tax-filing status and dependency, not the physical household.
+
+- Tax filer: filer + tax dependents. Non-filer **adult**: self + spouse (if living together) + children under 19. Non-filer **child**: self + parents + dependent siblings/stepsiblings under 19 (§1805.030.10.15) — a different unit than the adult rule, so a parent and child can have different-sized households in the same home. Applicable tax-dependent exceptions (§1805.030.10.20 — e.g. claimed by someone other than a spouse/parent, or by a noncustodial parent) use the non-filer rules instead.
+- ⚠️ **Data gap — tax-filing relationships**: MFB does not collect formal tax-filing/dependency relationships. Apply the age-appropriate non-filer composition when inferable from entered members; otherwise use the inclusive non-filer assumption. A non-dependent adult relative (e.g. a grandparent not claimed as a dependent) is treated as a separate unit.
+- **MHABD income consideration**: single adult — own income only. Married couple living together — combined income at the couple standard, **except** when one spouse already receives SNC/SAB/SP, in which case the applicant is evaluated individually (§0805.015.05). ⚠️ **Data gap**: no SNC/SAB/SP field — default to the couple-combined rule (narrows rather than broadens who counts, so defaulting away from it avoids false positives); the individual-determination branch is NOT RUNNABLE.
+- **Unborn child**: counts only in the pregnant woman's own MAGI household.
+- **Income counting**: MAGI income excludes SSI (criterion 6). Apply the exclusion where the income-type field permits; don't deny an otherwise-eligible applicant over other MAGI adjustments the screener can't capture.
+- Source: §1805.030.10 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-030-00/1805-030-10/; 42 USC 1396a(e)(14); MHABD spousal income — §0805.015.05 — https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-05/.
+
+**Household construction**: use applicant-specific units; do not combine non-spouses or non-dependent relatives solely because they live in the same physical household. Scenarios 7 and 8 verify this requirement.
+
+### Additional Pathways
+
+9. **Transitional MO HealthNet (TMH), up to 12 months** — ⚠️ *NOT RUNNABLE, documentation only*
+   - A family that received MHF in 3 of the last 6 months and loses it due to the parent/caretaker's increased earned income continues coverage up to 12 months if a dependent child under 19 remains in the home (subject to original-household-only, no medical-support sanction, and a 196% FPL ceiling for months 7–12).
+   - No field for prior MHF receipt, conversion timing, original-household membership, sanction status, or compliance — too many unmeasurable defining facts to approve via inclusive assumption. Document the target rule; don't run; surface general TMH availability.
+   - Source: MAGI Program Descriptions TMH row; §1820.015.00, §1820.020.00, §1820.040.00 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1820-000-00/.
+
+10. **Automatic Newborn Coverage** ⚠️ *data gap — narrow continuation, not a universal infant exemption*
+    - A child born to a woman eligible for and receiving Title XIX **on the date of birth** is deemed eligible for MO HealthNet for Newborns through age 1 with no new income determination (§1860.010.20) — a **continuation**, not a blanket exemption from the ordinary under-1 test (2a). A mother not on active Title XIX at birth means the child is evaluated under 2a's ordinary test instead.
+    - Screener can't confirm maternal Medicaid status at birth. **Committed handling**: don't override 2a's income test; surface as an uncheckable note.
+    - Source: §1860.010.20 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1860-000-00/1860-010-00/1860-010-20/; MAGI Program Descriptions, "MO HealthNet for Newborns" row.
+
+11. **Former Foster Care Youth (FFCY), under age 26**
+    - Individuals under 26 who aged out of foster care (in-state or, subject to a 2023 cohort split, out-of-state/tribal) are eligible with no income test and citizenship/SSN waived entirely (§1805.050.00). Would value at $6,379/yr (Adults) for ages 19–25 if runnable.
+    - ⚠️ **Data gap — no inclusive assumption, description only**: no field identifies who aged out of foster care; assuming every 18–25-year-old qualifies would create substantial false positives. A future per-member expansion belongs to **MFB-1254**, not this ticket.
+    - **Cohort split** (out-of-state/tribal only): turned 18 on/after 2023-01-01 — mandatory federal FFCC category (SUPPORT Act §1002), no duration requirement. Turned 18 on/before 2022-12-31 — covered via Missouri's Section 1115 demonstration (approved 2026-03-13), requiring 6 months of prior out-of-state/tribal foster care. No calculator impact either way.
+    - Source: §1805.050.00 — https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-050-00/; 1115 demonstration extension approval — https://www.medicaid.gov/medicaid/section-1115-demonstrations/downloads/mo-ffcy-demo-cms-extnsn-aprvl-03132026.pdf; MO SPA 23-0007 — https://www.medicaid.gov/medicaid/spa/downloads/MO-23-0007.pdf.
+
+12. **MO HealthNet for Disabled Children (MHDC), under age 18**
+    - A disabled child under 18 may receive spend-down, non-spend-down, or vendor coverage under the same standards as disabled adults (criteria 6–7), with parental income deemed only when the child lives with a parent — stepparent/sibling income is explicitly NOT counted.
+    - **Deeming order**: Missouri applies sibling allocation → $20 personal exclusion → $65 earned-income exclusion and half the remainder → parental living allowance → equal division among multiple disabled children (§0805.020.15). Scenarios 9 and 25 intentionally assert the committed PE deemed-income outputs.
+    - ⚠️ **Data gap — non-applying-sibling allocation**: whether another minor child is not applying for MA and not receiving specified cash assistance is not observable. Assume the prerequisite is met for other minor children; not surfaced.
+    - **Multiple disabled children**: divide deemed income equally (Scenario 25).
+    - ⚠️ **Data gap — SSI-receiving parent / spend-down**: Missouri does not deem income from a parent receiving SSI. The screener cannot determine the policy-correct top-level result when spend-down becomes relevant because the necessary medical-expense facts are not collected. No deterministic scenario or MFB-side eligibility correction is applied.
+    - `cashAssistance` is too generic to identify one of Missouri's specifically named no-deeming programs — don't use it to bypass deeming.
+    - ⚠️ **Data gap — existing non-spend-down Medicaid**: MFB cannot distinguish a parent's spend-down vs. non-spend-down `medicaid` status. Default: deeming applies. Not surfaced.
+    - ⚠️ **Data gap — other unobservable deeming adjustments**: spend-down medical expenses and Missouri Family Trust Fund payments aren't separately captured by the screener; no additional calculator logic.
+    - Screener fields: `birth_year`/`birth_month`, `long_term_disability`, `relationship`, `income (all types)` (parent's income, when living with a parent)
+    - Source: §0805.020.00 — https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-020-00/; deeming detail — §0805.020.15 — https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-020-00/0805-020-15/.
+
+### Cross-Cutting Applicant-Level Eligibility Conditions
+
+Criteria 13–14 are genuine but unscreenable conditions layered on top of whichever pathway applies, not alternate routes.
+
+13. **Social Security Number** ⚠️ *data gap — inclusive assumption*: required with several exceptions (§1805.015.00); not screenable — never gate on this; assume satisfied. Source: https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-015-00/
+
+14. **Medical support cooperation (parent/caretaker cases)** ⚠️ *data gap — inclusive assumption*: cooperation in establishing paternity/support (§1805.040.10, good-cause exception), applies to criteria 4/9; non-cooperation ends only the parent/caretaker's own eligibility. Not screenable — never gate; assume satisfied or excused. Source: https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-040-00/1805-040-10/
+
+15. **Section 1619(b) continuation** (disabled workers who lose SSI cash due to earnings) — ⚠️ *NOT RUNNABLE*: requires SSA-approved status, resources under the 1619(b) max, and prior-month MO HealthNet receipt (§0850.005.00). This population reports as **not currently receiving SSI**, so without this rule they'd be wrongly pushed toward ordinary AEG/MHABD routing, and no reliable proxy exists to infer status. Document the target rule; surface briefly; don't gate or assume. Source: https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0850-000-00/0850-005-00/
+
+**Cash-linked automatic MHABD eligibility — out of scope**: SP/SAB/SNC/Blind Pension recipients are automatically Medicaid-eligible (MHABD manual §1.0); SP is a closed 1973 program. Not recreated by this calculator regardless of which are open.
+
+**"Individuals Deemed To Be Receiving SSI" — out of scope**: MO SPA 23-0007's federal deemed/protected-SSI categories (Pickle Amendment, etc.), distinct from §1619(b). Depends on benefit-history facts the screener has no field for; not built.
+
+16. **Four-Month Extended Medicaid** (loss of MHF due to increased spousal-support collections) — ⚠️ *NOT RUNNABLE*: 42 CFR 435.115, distinct from TMH (which requires the loss be from **earned income** specifically). No field for prior receipt, collection amounts, or denial reason — can't distinguish this trigger from an ordinary over-income denial. Document the target rule; surface alongside TMH.
+
+**Child-welfare automatic Medicaid — out of scope, not built**: IV-E/adoption-guardianship-subsidy or Children's Division custody children are automatically eligible (Child Welfare Manual §4 Ch.9.6) — subsidy families already have this in their Agreement; foster-custody Medicaid is handled by the caseworker (FACES), not a family screener.
+
+### Legal Status & Immigration
+
+**Committed treatment**: handled through `legal_status_required` — the same config-level, household-visibility mechanism every MFB calculator uses (e.g. `TxEmergencyMedicaid`). No calculator-level enforcement or dedicated scenario.
+
+- **Committed launch-period value (through 2026-09-30)**: `legal_status_required: ["citizen", "gc_5plus", "refugee", "otherWithWorkPermission"]` — matches Missouri's ordinary rule and the identical precedent shipped for `ks_medicaid`. `non_citizen` and `gc_5less` are deliberately excluded: `non_citizen` doesn't correspond to a Missouri-qualifying status outside EMCIA (out of scope); `gc_5less` is subject to Missouri's standard 5-year bar (Missouri hasn't adopted the ICHIA/CHIPRA §214 option, per KFF).
+- **October 1, 2026 follow-up — not part of this launch**: Missouri's non-citizen Medicaid eligibility rules change effective October 1, 2026. Re-review the MFB `legal_status_required` mapping before that date and update the configuration through a separate post-launch ticket. The launch-period configuration above remains authoritative through September 30, 2026.
+- **Missouri's military exceptions** (active-duty, veterans, their families) exempt from the 5-year bar (§§1805.020.10, .10.05, .10.10) are not separately modeled by the household-level `legal_status_required` gate — the standard MFB treatment.
+- **Emergency-only coverage for immigration-ineligible applicants is out of scope** — see EMCIA in Program Details' "Explicitly out of scope."
+- Source: CMS SHO #26-001; mydss.mo.gov/hr1-non-citizenship-medicaid-faqs; KFF — Medicaid/CHIP Coverage of Lawfully-Residing Immigrant Children and Pregnant Women; §§1805.020.10, 1805.020.10.10.05, 1805.020.10.10.10.
+
+## Priority Criteria
+
+None identified. MO HealthNet is an entitlement program — eligibility runs solely through the categorical pathways above (criteria 1–16), with no waitlist, funding cap, or priority-ranking mechanism.
+
+## Benefit Value
+
+This section reports an **estimated annual valuation** — average per-enrollee program spend from KFF State Health Facts — not a statutory cash payment.
+
+Medicaid is valued per MFB convention as KFF's published average spending per full-benefit enrollee (same methodology as `ks_medicaid`) — **not** PolicyEngine's `medicaid_cost`. Values are from KFF State Health Facts (Missouri, calendar year 2023 preliminary data). KFF's groups are mutually exclusive by age, disability eligibility, and expansion status:
+
+| KFF category | Annual value | Definition | Applies to |
+|---|---|---|---|
+| Children | $4,576 | Age ≤18, not disability-eligible | Non-disabled children (2b), infants (2a), newborn auto-coverage (10), FFCY (11) ≤18, and any otherwise-Adults-pathway person who is themselves ≤18 |
+| Adults | $6,379 | Ages 19–64, not disability-eligible, not expansion | Pregnant women (3), parent/caretaker (4), TMH (9), FFCY (11) ages 19–25, spousal-support extension (16) — only when the person is themselves 19–64 |
+| ACA Expansion Adults | $7,445 | Ages 19–64, newly eligible via expansion | Adult Expansion (5) |
+| Seniors | $21,857 | Age 65+ regardless of disability | MHABD aged pathway (6), and any disabled person who is themselves 65+ |
+| People with Disabilities | $30,410 | Under 65, disability-eligible | MHABD blind/disabled (6), MHDC (12) — only when under 65 |
+
+**Value-priority rule**: assign a member's KFF value by their own facts, regardless of which pathway found them eligible: (1) age 65+ → **Seniors**, even if disability-eligible; (2) under 65, disability-basis pathway → **People with Disabilities**; (3) otherwise age ≤18 → **Children**, even via a nominally "Adults" pathway (MPW, MHF, TMH, spousal-support extension); (4) otherwise 19–64 → **ACA Expansion Adults** if via AEG, else **Adults**. See Scenarios 22–24.
+
+**Per-member values**: report each eligible member's category/value separately; do not sum values into a household total.
+
+**CHIP 4M valuation — $4,576/year.** Missouri legally classifies CHIP 4M as CHIP, but its age/income band corresponds to Missouri's Medicaid-expansion CHIP ("M-CHIP") population, not separate CHIP — confirmed against NASHP's Missouri CHIP fact sheet (M-CHIP ends at 150% FPL both age bands, matching CHIP 4M's range) and CMS T-MSIS coding (M-CHIP reports as Medicaid enrollment, `ENROLLMENT-TYPE=1` — the same data KFF's Medicaid valuation is built from). KFF does not publish a CHIP-4M-specific value; this is MFB's committed informed estimate, applying the KFF Children Medicaid figure. No separate scenario value needed.
+- Source: NASHP Missouri CHIP fact sheet; CMS T-MSIS coding guidance; §§1840.010.05/1840.010.00.
+
+`value_format: estimated_annual`. Source: [KFF State Health Facts — "Medicaid Spending per Full-Benefit Enrollee by Enrollment Group," Missouri, CY2023 preliminary](https://www.kff.org/medicaid/state-indicator/medicaid-spending-per-full-benefit-enrollee/).
+
+**Methodology**: uses the **Full-Benefit** table ($21,857 Seniors / $30,410 Disabilities), not Full-or-Partial-Benefit ($18,373 / $28,345), because this calculator represents full-scope MO HealthNet coverage — the other three category values are identical across both tables.
+
+## Acceptance Criteria
+
+**Scenario coverage**: Scenarios 1–34 are executable and numbered sequentially. Documented data gaps and non-runnable pathways do not receive scenario numbers. Legal status is handled through `legal_status_required`, not calculator logic.
+
+**Implementation is complete when:**
+
+- [ ] All 34 scenarios pass with the exact eligibility, category, and annual value stated. `eligible: true` alone is insufficient where a value is specified.
+- [ ] Income boundaries confirm an inclusive (`≤`) comparator across the tested household sizes and pathways: AEG HH1 $1,836/$1,837 (2/5) and HH4 $3,795/$3,797 (32/33); MHK HH2 $2,760/$2,761 (4/17); MHF HH2 $241/$242 (12/26); and infant/MPW HH2 $3,625/$3,626 (27/28, 29/30). MHABD is tested at the exact adjusted-income ceiling only (11) because the over-limit branch may depend on unobservable spend-down.
+- [ ] Scenarios 27 and 29 confirm the infant/MPW 201% standard is load-bearing by using income above the 1–18 children's 153% ceiling.
+- [ ] MHDC deeming scenarios 9 and 25 assert the exact PE deemed-income value and non-spend-down classification, not only top-level eligibility/value.
+- [ ] Categorical routing returns the committed category/value: Scenario 12 returns MHF rather than Adult Expansion; Scenarios 19, 21, and 31 return the committed PE Adult Expansion result documented in criteria 5–6 and the MFB-1261 accepted-divergences decision.
+- [ ] Value-priority scenarios 22–24 use the member's age/disability category for the KFF value rather than the pathway name alone.
+- [ ] Scenario 20 reads PE's `is_parent_for_medicaid` result as-is for `relatedOther`, consistent with criterion 4's kinship data-gap handling.
+- [ ] Scenario 34 switches from MHDC deeming to adult MHABD and uses the applicant's own income once the MHDC deeming period has ended.
+- [ ] Non-runnable pathways remain documentation/data-gap treatments only and are not implemented as calculator gates.
+- [ ] Household construction uses applicant-specific units; non-spouses and non-dependent relatives sharing a physical household are not combined into one unit — see MAGI Household Composition & Income Methodology.
+
+## Test Scenarios
+
+### Scenario 1: Single Mother with Two Young Children
+**Expected**: Mother eligible — Adult Expansion, $7,445/year. Both children eligible — Children, $4,576/year each.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 3 people
+- **Person 1**: `headOfHousehold`, born March 1996 (age 30), not pregnant/disabled, employment income $1,800/mo, no other income, no insurance
+- **Person 2**: `child`, born January 2020 (age 6), not long_term_disability, no income
+- **Person 3**: `child`, born September 2022 (age 3), not long_term_disability, no income
+
+**Why this matters**: The most common Missouri Medicaid shape — validates MAGI eligibility for both children and the parent in one household.
+
+---
+
+### Scenario 2: Single Adult Age 19 - Barely Eligible for Adult Expansion
+**Expected**: Eligible — Adult Expansion, $7,445/year
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 1 person
+- **Person 1**: born March 2007 (age 19), `headOfHousehold`, not pregnant/disabled, employment income $1,836/mo, no other income, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Tests the exact $1,836/month HH1 AEG ceiling — eligible at the boundary (inclusive `≤`). See Scenario 5 for one dollar over.
+
+---
+
+### Scenario 3: Pregnant Woman with Spouse - Both Members Resolved
+**Expected**: Pregnant woman eligible — Adults, $6,379/year (201% effective FPL, HH3 with unborn counted, $4,577 ceiling). Spouse ineligible — his own AEG test uses HH2 (no unborn credit), and $3,050 combined income exceeds the $2,489 HH2 ceiling.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1996 (age 30), `headOfHousehold`, pregnant: yes, employment income $1,500/mo
+- **Person 2**: born June 1995 (age 31), `spouse`, employment income $1,550/mo
+
+**Why this matters**: Tests the pregnant-to-Adults KFF mapping and the MAGI rule that an unborn child counts only toward the pregnant woman's own household.
+
+---
+
+### Scenario 4: Parent and Child at Age 1 at the Exact $2,760 HH2 Children's Ceiling
+**Expected**: Child eligible — Children, $4,576/year (exact $2,760 HH2 ceiling, `≤`). Parent ineligible (over the $2,489 HH2 AEG ceiling and the MHF flat standard).
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1996 (age 30), `headOfHousehold`, not pregnant/disabled, employment income $2,760/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born March 2025 (age 1), `child`, not long_term_disability, no income
+
+**Why this matters**: The children's ceiling (153% effective) exceeds AEG's (138%), so this pins the real income band where the child qualifies and the parent doesn't, at the exact boundary. See Scenario 17 for one dollar over.
+
+---
+
+### Scenario 5: Single Adult - Income Just Above 138% FPL Effective
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 1 person
+- **Person 1**: born March 1996 (age 30), `headOfHousehold`, not pregnant/disabled, employment income $1,837/mo, no other income, no current benefits
+
+**Why this matters**: Paired with Scenario 2 — one dollar over the $1,836 HH1 AEG ceiling flips the applicant to ineligible.
+
+---
+
+### Scenario 6: Disability Claim With Only Spend-Down-Level MHABD — Defaults to Adult Expansion
+**Expected**: Eligible — Adult Expansion, $7,445/year (not MHABD). Income ($1,700/mo via `pension`, deliberately not `sSI`/`sSDisability`) triggers a concurrent MHABD determination (criterion 5) via the self-reported `disabled` flag, but adjusted MHABD income ($1,700 − $20 = $1,680) exceeds the $1,131 non-spend-down standard — MHABD is only reachable via spend-down (non-mandatory), so Missouri's own choice/default mechanism (not independently implemented by MFB) defaults to AEG, and this scenario's result is PE's actual output. Gross income is under the $1,836 HH1 AEG ceiling.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1986 (age 40), `headOfHousehold`, not pregnant, `disabled`: yes (`long_term_disability`/`visually_impaired`: no), income type `pension` $1,700/mo, no employment income, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Tests the non-mandatory MHABD branch under the AEG ceiling; contrast Scenario 19's mandatory-MHABD case.
+
+---
+
+### Scenario 7: Mixed Household - Corrected MAGI Household Composition
+**Expected**: Child eligible — Children, $4,576/year (under $2,760 HH2 ceiling). Grandparent eligible — Seniors, $21,857/year (own $750/mo income, evaluated independently under MHABD's unconditional individual-income rule). Parent ineligible (over the $2,489 HH2 AEG ceiling).
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 3 people
+- **Person 1**: born March 1991 (age 35), `headOfHousehold`, not pregnant/disabled, employment income $2,600/mo, employer-sponsored insurance, not receiving Medicare or SSI
+- **Person 2**: born January 2018 (age 8), `child`, no income
+- **Person 3**: born February 1958 (age 68), `grandParent`, income type `sSRetirement` $750/mo
+
+**Why this matters**: Confirms a non-dependent grandparent is evaluated in her own MHABD unit rather than the parent's MAGI unit.
+
+---
+
+### Scenario 8: Four-Member Household - Pregnant Mother, Working Father, Toddler, Disabled Sibling
+**Expected**: Mother eligible — Adults (pregnant), $6,379/year. Disabled sibling eligible — People with Disabilities, $30,410/year (his $500/mo SSI is entered as unearned income then fully deducted per §0805.015.35, leaving $0 adjusted income; evaluated in his own MHABD unit). Father ineligible. Toddler ineligible — his MAGI household is parent+spouse+toddler (HH3), and their combined $4,000/mo income exceeds the $3,484 HH3 ceiling, even though neither parent's income alone would.
+
+**Steps**:
+- **Location**: ZIP `65201`, County `Boone`
+- **Household**: 4 people
+- **Person 1**: born March 1994 (age 32), `headOfHousehold`, pregnant: yes, employment income $2,000/mo, not receiving Medicare or SSI
+- **Person 2**: born June 1993 (age 33), `spouse`, employment income $2,000/mo, not receiving Medicare or SSI
+- **Person 3**: born January 2024 (age 2), `child`, no income
+- **Person 4**: born September 1996 (age 29), `sisterOrBrother`, `long_term_disability`: yes, income type `sSI` $500/mo — evaluated on MHABD using only his own income
+
+**Why this matters**: Load-bearing test for Missouri's non-filer child MAGI rule (household = child + both parents + dependent siblings) — combining both parents' income is what correctly denies the toddler; either parent's income alone would wrongly pass him.
+
+**Known platform gap — the toddler currently comes back eligible.** MFB builds one
+`main_tax_unit` per screen holding every member `is_in_tax_unit()` accepts
+(`programs/framework/pe_dependencies/payload.py`), so it never constructs the applicant-specific
+MAGI households 42 CFR 435.603 defines. The 29-year-old sibling satisfies the qualifying-child
+path and joins that unit, which tests the toddler at the HH4 ceiling ($4,208/mo) instead of HH3
+and lets $4,000 through. Confirmed on production; the other three members match this scenario
+exactly. Scenario 7's grandparent passes only because MHABD is evaluated on individual income,
+which masks the same gap. As written this scenario cannot pass on any white label — tracked in
+MFB-1744.
+
+---
+
+### Scenario 9: MHDC Deeming — Stepparent Exclusion
+
+**Expected**: Disabled child eligible — People with Disabilities/MHDC, $30,410/year, with exact deemed income of **$1,103.00**.
+
+Deemed parental income uses **only** the biological parent's $4,300/month earned income (Person 2) — the stepparent's $3,000/month (Person 1) is entirely excluded (criterion 12). No other minor child is in the home, so no non-applying-sibling allocation applies. Calculation: $4,300 − $65 = $4,235, ÷ 2 = $2,117.50; combine with unearned income (none) and subtract the $20 exclusion: $2,117.50 − $20 = $2,097.50, floored to $2,097; subtract the one-parent living allowance ($994) = **$1,103.00** — under the $1,131 standard. Parent and stepparent are both independently ineligible for MHF/AEG (combined $7,300/mo, HH3).
+
+**Steps**:
+- **Location**: ZIP `65201`, County `Boone`
+- **Household**: 3 people
+- **Person 1**: born June 1988 (age 38), `headOfHousehold` — the stepparent, employment income $3,000/mo, not pregnant/disabled, not enrolled in Medicare or receiving SSI
+- **Person 2**: born April 1990 (age 36), `spouse` — the biological parent of Person 3, employment income $4,300/mo, no unearned income
+- **Person 3**: born March 2015 (age 11), `stepChild` (tie to the head), `long_term_disability`: yes, no income
+
+  *(`relationship` describes a member's tie **to the head of household**, not a pairwise descriptor — same convention as the `fosterChild`/`fosterParent` handling, criterion 4.)*
+
+**Why this matters**: Confirms stepparent income is excluded from MHDC deeming; contrast Scenario 25's equal-division test.
+
+---
+
+### Scenario 10: Adult Expansion Denied Due to Medicare Enrollment
+**Expected**: Not eligible, despite otherwise-qualifying income.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1975 (age 51), `headOfHousehold`, employment income $1,000/mo, health insurance: Medicare
+
+**Why this matters**: Confirms the Medicare-enrollment exclusion (criterion 5) is applied rather than approving AEG on income alone.
+
+---
+
+### Scenario 11: MHABD Disregard Application — Gross Income Would Fail, Adjusted Income Passes at the Exact Boundary
+**Expected**: Eligible — Seniors, $21,857/year, non-spend-down, adjusted income landing exactly on the $1,131 standard. Per §0805.015.00's sequence: gross earned income $2,367/mo; standard earned-income deduction (§0805.015.25, $65 plus half) — $2,367 − $65 = $2,302, ÷ 2 = $1,151; no unearned income; subtract the $20 personal exemption (§0805.015.35) — $1,151 − $20 = **$1,131** — exactly at the standard, eligible (`≤`).
+Uses an aged (66) rather than disabled applicant, to isolate the disregard math from criterion 6's separate SGA/IRWE data gap (SGA applies only to the disability-determination pathway).
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born April 1960 (age 66), `headOfHousehold`, not long_term_disability, employed, employment income $2,367/mo, no unearned income
+
+**Why this matters**: A calculator comparing gross income directly against $1,131 would wrongly deny this person — the disregards are what make the difference. Pinned at the exact boundary to confirm the comparator is inclusive.
+
+---
+
+### Scenario 12: Positive MHF Parent/Caretaker Eligibility — MHF Takes Precedence Over Adult Expansion, at the Exact HH2 Ceiling
+**Expected**: Parent eligible — **Adults, $6,379/year** (via MHF — NOT the $7,445 Adult Expansion value). Child eligible — Children, $4,576/year.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1990 (age 36), `headOfHousehold`, biological parent living with and primarily responsible for Person 2, not pregnant/disabled, employment income $241/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2015 (age 11), `child`, no income
+
+**Why this matters**: At exactly the $241/mo flat MHF standard, this parent also comfortably clears AEG's much higher ceiling — a calculator that doesn't apply categorical precedence (MHF is mandatory and must be evaluated first) could wrongly default to AEG's $7,445 instead of MHF's $6,379. See Scenario 26 for one dollar over.
+
+---
+
+### Scenario 13: SSI Receipt Excludes Adult Expansion but Routes to MHABD
+**Expected**: Not eligible for Adult Expansion — SSI is an explicit exclusion (criterion 5). **Eligible via MHABD** — People with Disabilities, $30,410/year: SSI receipt is itself a sufficient disability-routing signal. His $500/mo SSI is deducted (§0805.015.35) before the MHABD test, leaving only $200/mo employment income — well under $1,131.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born June 1985 (age 41), `headOfHousehold`, not long_term_disability, not pregnant, employment income $200/mo, income type `sSI` $500/mo, not enrolled in Medicare
+
+**Why this matters**: Confirms SSI alone (with no separately-reported disability flag) still correctly routes to MHABD rather than a wrongful full denial.
+
+---
+
+### Scenario 14: Married-Couple MHABD — Combined Income Test
+**Expected**: Both spouses eligible — Seniors, $21,857/year each. Combined couple income ($1,300/mo) minus one $20 personal exemption per couple (§0805.015.35: "Only one $20.00 exemption is allowed even if the income of a couple is being considered") = $1,280 — under the $1,533 couple standard, confirming the couple standard governs each spouse's own determination.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 2 people
+- **Person 1**: born March 1959 (age 67), `headOfHousehold`, married, living with spouse, not long_term_disability, income type `sSRetirement` $600/mo
+- **Person 2**: born June 1960 (age 66), `spouse`, married, living with Person 1, income type `sSRetirement` $700/mo
+
+**Why this matters**: Combined income would fail the $1,131 individual standard if either spouse were wrongly evaluated alone, but passes the $1,533 couple standard that actually governs (§0805.015.05's default, since no SNC/SAB/SP field exists — see MAGI Household Composition).
+
+---
+
+### Scenario 15: MHABD Categorical Failure — Under 65, No Disability Signal
+**Expected**: Not eligible for MHABD (fails the categorical gate, criterion 6) or Adult Expansion (over the AEG ceiling).
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1980 (age 46), `headOfHousehold`, not long_term_disability, not visually_impaired, not pregnant, employment income $3,000/mo, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Confirms MHABD is never evaluated for someone who doesn't meet its categorical gate, regardless of income.
+
+---
+
+### Scenario 16: MHDC Categorical Failure — Child Has No Disability Signal
+**Expected**: Child not eligible — fails MHDC's categorical disability requirement (criterion 12) and ordinary children's Medicaid (over the $2,760 HH2 ceiling). Parent not eligible (over the $2,489 HH2 AEG ceiling).
+
+**Steps**:
+- **Location**: ZIP `65201`, County `Boone`
+- **Household**: 2 people
+- **Person 1**: born April 1985 (age 41), `headOfHousehold`, employment income $3,000/mo, not long_term_disability, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born March 2015 (age 11), `child`, not long_term_disability, not visually_impaired, no income
+
+**Why this matters**: Isolates MHDC's categorical gate — household income is set high enough that the child is unambiguously ineligible everywhere, not just for the higher-value category.
+
+---
+
+### Scenario 17: Parent + Child at Age 18 One Dollar Over the $2,760 HH2 Children's Ceiling
+**Expected**: Child not eligible — $2,761/mo exceeds the $2,760 HH2 ceiling by one dollar. Parent not eligible either.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1996 (age 30), `headOfHousehold`, not pregnant/disabled, employment income $2,761/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2008 (age 18), `child`, not long_term_disability, no income
+
+**Why this matters**: Paired with Scenario 4 — confirms the boundary is a true edge in a normal two-person household.
+
+---
+
+### Scenario 18: Disability Claim via SSDI — Non-Mandatory MHABD, Defaults to Adult Expansion
+**Expected**: Eligible — Adult Expansion, $7,445/year (not MHABD). $500/mo employment plus a $1,200/mo `sSDisability` income stream triggers a concurrent MHABD determination (same as a bare disability claim). Adjusted MHABD income: earned $500 − $65 = $435, ÷2 = $217.50; unearned $1,200 − $20 = $1,180; total = $1,397.50 — over $1,131, so only non-mandatory spend-down applies, defaulting to AEG.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1986 (age 40), `headOfHousehold`, not pregnant, income type `sSDisability` $1,200/mo, employment income $500/mo, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Confirms SSDI triggers the same concurrent MHABD evaluation as another disability signal; contrast Scenario 31.
+
+---
+
+### Scenario 19: Disability Claim — Mandatory MHABD Not Applied
+**Expected**: Adult Expansion, $7,445/year (committed PE result — see criterion 5). Adjusted MHABD income: ($1,600 − $65) ÷ 2 − $20 = $747.50, floored to $747 — under the $1,131 standard.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1986 (age 40), `headOfHousehold`, not pregnant, `disabled`: yes (`long_term_disability`: no, `visually_impaired`: no), employment income $1,600/mo, no unearned income, not enrolled in Medicare, not receiving SSI/SSDI
+
+**Why this matters**: Regression case for the committed PE result when Missouri's mandatory-MHABD priority would otherwise apply.
+
+---
+
+### Scenario 20: MHF Kinship — PE's Kinship-Blind Result Applies Regardless of Relationship Enum
+**Expected**: Adult eligible via MHF, $6,379/year (not Adult Expansion). Child eligible via children's Medicaid, $4,576/year.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1985 (age 41), `headOfHousehold`, employment income $150/mo, not pregnant/disabled, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2018 (age 8), `relatedOther` (the head's nephew), no income
+
+**Why this matters**: `relatedOther` is a real qualifying relative under Missouri's rule with no exact-match enum value, and MFB's own dependency logic treats it as dependent-eligible — confirms MHF eligibility per criterion 4's kinship data-gap handling.
+
+---
+
+### Scenario 21: Blind Applicant — Mandatory MHABD Not Applied
+**Expected**: Adult Expansion, $7,445/year (committed PE result — see criterion 5). Unearned income of $1,350/mo (`pension`) produces adjusted income of exactly **$1,330** after the $20 exemption — precisely the blind non-spend-down standard.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1980 (age 46), `headOfHousehold`, not pregnant, income type `pension` $1,350/mo, no earned income, not enrolled in Medicare, not receiving SSI, `visually_impaired`: yes, `long_term_disability`: no
+
+**Why this matters**: Exercises the same committed PE result at the blind MHABD boundary.
+
+---
+
+### Scenario 22: Pregnant Minor — MPW Eligibility Values at Children, Not Adults
+**Expected**: Eligible via MPW (criterion 3) — valued at **Children, $4,576/year**, not Adults. MPW has no age floor, and KFF's Children/Adults split is age-based alone for a non-disability-eligible, non-expansion enrollee.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 1 person
+- **Person 1**: born June 2009 (age 17), `headOfHousehold`, pregnant: yes, no other income
+
+**Why this matters**: Confirms KFF value selection follows the member's age, not the eligibility pathway.
+
+---
+
+### Scenario 23: MHF Minor Parent — Values at Children, Not Adults
+**Expected**: Parent eligible via MHF (criterion 4) — valued at **Children, $4,576/year** (MHF also has no age floor). Child independently eligible via criterion 2a (infant), $4,576/year.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born June 2009 (age 17), `headOfHousehold`, biological parent living with and primarily responsible for Person 2, not pregnant/disabled, employment income $100/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2026 (age 0), `child`, no income
+
+**Why this matters**: MHF equivalent of Scenario 22.
+
+---
+
+### Scenario 24: Disabled Senior — MHABD Values at Seniors, Not People with Disabilities
+**Expected**: Eligible via MHABD — valued at **Seniors, $21,857/year**, not People with Disabilities. KFF's Seniors definition is age 65+ regardless of disability.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1956 (age 70), `headOfHousehold`, `long_term_disability`: yes, income type `pension` $1,000/mo, no earned income, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Adjusted income ($1,000 − $20 = $980) clears $1,131 regardless of which standard applies, so eligibility isn't in question — this is the first scenario combining "aged" and "disabled" on one person, exercising the age-over-disability priority rather than merely stating it.
+
+---
+
+### Scenario 25: MHDC — Multiple Disabled Children, Equal Division of Deemed Income
+
+**Expected**: Both disabled children independently eligible — People with Disabilities/MHDC, $30,410/year each — **and the calculator must assert each child's own deemed-income figure**. Parent independently ineligible for MHF or Adult Expansion — $5,273/mo exceeds both the $301/mo HH3 MHF standard and the $3,142/mo HH3 AEG effective ceiling (MAGI Income Limits Appendix A, "133% of Poverty# AEG" row, HH3).
+
+No non-applying-sibling allocation applies (only the two disabled-child applicants). Calculation: $5,273 − $65 = $5,208, ÷ 2 = $2,604; − $20 = $2,584; − $994 one-parent living allowance = $1,590 undivided; divided equally per Missouri's rule: $1,590 ÷ 2 = **$795.00 per child**. Both remain under $1,131 (eligible, non-spend-down).
+
+**Steps**:
+- **Location**: ZIP `65201`, County `Boone`
+- **Household**: 3 people
+- **Person 1**: born March 1986 (age 40), `headOfHousehold` — the parent, no other children in the home, employment income $5,273/mo, no unearned income, not pregnant/disabled, not enrolled in Medicare or receiving SSI
+- **Person 2**: born March 2015 (age 11), `child`, `long_term_disability`: yes, no income
+- **Person 3**: born January 2018 (age 8), `child`, `long_term_disability`: yes, no income
+
+**Why this matters**: Proves the equal-division rule is independently load-bearing, distinct from Scenario 9's stepparent-exclusion test.
+
+---
+
+### Scenario 26: Parent One Dollar Over the $241 HH2 MHF Ceiling — Falls Through to Adult Expansion, Not Denied
+**Expected**: Parent not eligible for MHF ($242/mo, one dollar over) — but still **eligible: true via Adult Expansion, $7,445/year**, since $242/mo is nowhere near the $2,489/mo HH2 AEG ceiling. Child independently eligible via children's Medicaid, $4,576/year.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1990 (age 36), `headOfHousehold`, biological parent living with and primarily responsible for Person 2, not pregnant/disabled, employment income $242/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2015 (age 11), `child`, no income
+
+**Why this matters**: Paired with Scenario 12 — confirms failing MHF re-evaluates under AEG rather than denying the parent outright.
+
+---
+
+### Scenario 27: Infant Under Age 1 — the 201% Standard Is Load-Bearing, Not the 1–18 153% Ceiling
+**Expected**: Infant eligible — Children, $4,576/year — at the exact $3,625/mo HH2 ceiling for criterion 2a's 201% effective standard. This income is *above* the $2,760 HH2 ceiling that governs ages 1–18 — a calculator wrongly applying the 1–18 standard would incorrectly deny this child. Parent independently ineligible.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1996 (age 30), `headOfHousehold`, not pregnant/disabled, employment income $3,625/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2026 (age 0, under 1), `child`, no income
+
+**Why this matters**: Isolates the infant-specific 201% standard from the lower 1–18 ceiling.
+
+---
+
+### Scenario 28: Infant Under Age 1 — One Dollar Over the 201% Ceiling
+**Expected**: Infant not eligible — $3,626/mo is one dollar over the infant-specific ceiling. Parent remains ineligible.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born March 1996 (age 30), `headOfHousehold`, not pregnant/disabled, employment income $3,626/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2026 (age 0, under 1), `child`, no income
+
+**Why this matters**: Paired with Scenario 27 — confirms the infant-specific boundary is a true edge.
+
+---
+
+### Scenario 29: Pregnant Woman — the MPW 201% Ceiling Itself
+**Expected**: Eligible via MPW — Adults, $6,379/year — at the exact $3,625/mo ceiling for her own MAGI household size 2 (herself + unborn child).
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 1 person (MAGI size 2, counting the unborn child)
+- **Person 1**: born March 1994 (age 32), `headOfHousehold`, pregnant: yes, employment income $3,625/mo, not long_term_disability, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Pins the MPW comparator at its exact ceiling. See Scenario 30 for one dollar over.
+
+---
+
+### Scenario 30: Pregnant Woman — One Dollar Over the MPW Ceiling
+**Expected**: Not eligible. $3,626/mo is one dollar over. No AEG fallback — pregnancy is an explicit AEG exclusion (criterion 5), not a lower-priority pathway.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 1 person (MAGI size 2, counting the unborn child)
+- **Person 1**: born March 1994 (age 32), `headOfHousehold`, pregnant: yes, employment income $3,626/mo, not long_term_disability, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: Paired with Scenario 29 — confirms the MPW boundary is a true edge.
+
+---
+
+### Scenario 31: Disability Claim via SSDI — Mandatory MHABD Not Applied
+**Expected**: Adult Expansion, $7,445/year (committed PE result — see criterion 5). A $600/mo `sSDisability` stream plus $500/mo employment triggers the same concurrent determination as Scenario 18. Adjusted MHABD income: earned $500 − $65 = $435, ÷2 = $217.50; unearned $600 − $20 = $580; total = **$797.50** — under $1,131.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 1 person
+- **Person 1**: born March 1986 (age 40), `headOfHousehold`, not pregnant, income type `sSDisability` $600/mo, employment income $500/mo, not enrolled in Medicare, not receiving SSI
+
+**Why this matters**: The SSDI-specific analogue of Scenario 19 — confirms the accepted divergence holds via SSDI, not just a bare `disabled` flag, distinguishing it from Scenario 18's non-mandatory (agreeing) case.
+
+---
+
+### Scenario 32: Adult Expansion — the Exact $3,795/Month HH4 Ceiling
+**Expected**: Parent eligible — Adult Expansion, $7,445/year — at the exact $3,795/mo HH4 ceiling (MAGI Income Limits Appendix A, "133% of Poverty# AEG," HH4). Children independently eligible via children's Medicaid, $4,576/year each.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 4 people
+- **Person 1**: born March 1990 (age 36), `headOfHousehold`, single parent, not pregnant/disabled, employment income $3,795/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2015 (age 11), `child`, no income
+- **Person 3**: born January 2017 (age 9), `child`, no income
+- **Person 4**: born January 2019 (age 7), `child`, no income
+
+**Why this matters**: Confirms the AEG ceiling scales correctly to HH4, not just HH1 (Scenarios 2/5). See Scenario 33 for the over-ceiling case.
+
+---
+
+### Scenario 33: Adult Expansion — Two Dollars Over the HH4 Ceiling
+**Expected**: Parent not eligible for Adult Expansion — $3,797/mo is over the $3,795/mo HH4 ceiling and the flat MHF HH4 standard, with no other routing signal. Children remain independently eligible via children's Medicaid, $4,576/year each.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 4 people
+- **Person 1**: born March 1990 (age 36), `headOfHousehold`, single parent, not pregnant/disabled, employment income $3,797/mo, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born January 2015 (age 11), `child`, no income
+- **Person 3**: born January 2017 (age 9), `child`, no income
+- **Person 4**: born January 2019 (age 7), `child`, no income
+
+**Why this matters**: Uses $3,797 rather than $3,796 because the target PE behavior has a known precision edge at $3,796 (PR #9297); $3,797 is the stable over-limit regression point. Missouri's actual ceiling remains $3,795.
+
+---
+
+### Scenario 34: Disabled 18-Year-Old — MHDC's Under-18 Cutoff Ends, Adult MHABD Applies With No Parental Deeming
+
+**Expected**: Person 2 eligible — People with Disabilities, $30,410/year, via adult MHABD. Parental deeming ended after the month they turned 18, so eligibility is based on their own $0 income.
+
+**Steps**:
+- **Location**: ZIP `63101`, County `St. Louis City`
+- **Household**: 2 people
+- **Person 1**: born June 1978 (age 48), `headOfHousehold`, employment income $10,000/mo, not pregnant/disabled, not enrolled in Medicare, not receiving SSI
+- **Person 2**: born March 2008 (age 18), `child` (tie to the head), `long_term_disability`: yes, no income
+
+**Parent's own result**: Person 1 is independently ineligible for any pathway — $10,000/mo is far over the AEG HH2 ceiling and the flat MHF standard, with no disability/blindness/SSDI signal of his own.
+
+**Why this matters**: Confirms the transition from MHDC parental deeming to adult MHABD individual-income treatment after age 18.
+
+---
+
+## Source Documentation
+
+- [MO DSS "MAGI MO HealthNet Program Descriptions" (04/2026)](https://dssmanuals.mo.gov/wp-content/uploads/2020/03/MAGI-Appendix-I.pdf)
+- [MO DSS MAGI Income Limits Appendix A, Section 18.2.1](https://dssmanuals.mo.gov/wp-content/uploads/2019/03/MAGIappendix-a.pdf)
+- [MO DSS FSD manual, Section 1830.010.05 — Children's 148% FPL rule](https://dssmanuals.mo.gov/family-mo-healthnet-magi/1830-000-00/1830-010-00/1830-010-05/)
+- [MO DSS FSD manual, Section 1865.020.00 — Adult Expansion Eligibility Requirements](https://dssmanuals.mo.gov/family-mo-healthnet-magi/1865-000-00/1865-020-00/)
+- [MO DSS FSD manual, Section 1810.020.20.10 — Parent/Caretaker Relative Definition](https://dssmanuals.mo.gov/family-mo-healthnet-magi/1810-000-00/1810-020-00/1810-020-20/1810-020-20-10/)
+- [MO DSS FSD manual, Section 1805.030.10 — MAGI Household Composition](https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-030-00/1805-030-10/)
+- [MO DSS FSD manual, Section 1805.050.00 — Former Foster Care Youth](https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-050-00/)
+- [MHABD manual, Section 0805.020.00 — MHDC](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-020-00/); [Section 0805.020.05 — Definition of Living With a Parent](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-020-00/0805-020-05-definition-of-living-with-a-parent/); [Section 0805.020.15 — Deeming Parental Income](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-020-00/0805-020-15/)
+- [MHABD manual, Section 0805.015.45 — Income Maximum](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-45-income-maximum/); [Section 0805.015.30 — Unearned Income](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-30/); [Section 0805.015.35 — Income Exemptions/Deductions](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-35/); [Section 0805.015.00 — Financial Need](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/); [Section 0805.015.25 — Standard Deductions From Gross Earned Income](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-25/)
+- [MO DSS "Eligibility Standards for Non-MAGI Programs" (07/2026)](https://dssmanuals.mo.gov/wp-content/uploads/2022/07/mhabd-appendix-j.pdf)
+- [Missouri Revised Statutes, Section 208.146](https://revisor.mo.gov/main/OneSection.aspx?section=208.146); [Missouri Senate, HB 2372 bill tracker](https://www.senate.mo.gov/BillTracking/Bills/BillInformation?billid=12902414&year=2026)
+- [CMS Informational Bulletin CIB 122325 — Inmates and Medicaid Eligibility](https://www.medicaid.gov/federal-policy-guidance/downloads/cib122325.pdf)
+- [CMS SHO #26-001 — Alien Medicaid Eligibility, Section 71109](https://www.medicaid.gov/federal-policy-guidance/downloads/sho26001.pdf)
+- [KFF — Medicaid/CHIP Coverage of Lawfully-Residing Immigrant Children and Pregnant Women](https://www.kff.org/affordable-care-act/state-indicator/medicaid-chip-coverage-of-lawfully-residing-immigrant-children-and-pregnant-women/)
+- [SSA POMS SI 01715.020 — 209(b) States](https://secure.ssa.gov/poms.nsf/lnx/0501715020)
+- [KFF State Health Facts — "Medicaid Spending per Full-Benefit Enrollee by Enrollment Group," Missouri, CY2023 preliminary](https://www.kff.org/medicaid/state-indicator/medicaid-spending-per-full-benefit-enrollee/)
+- [Apply for MO HealthNet Coverage](https://mydss.mo.gov/healthcare/apply)

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_at_the_mhf_standard_is_valued_as_a_mandatory_adult.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_at_the_mhf_standard_is_valued_as_a_mandatory_adult.yaml
@@ -23,7 +23,7 @@ interactions:
       {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1", "2"], "tanf":
       {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
       {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
-      {"2026": false}}}, "marital_units": {}}, "version": "1.794.2"}'
+      {"2026": false}}}, "marital_units": {}}, "version": "1.815.1"}'
     headers:
       Accept:
       - '*/*'
@@ -66,7 +66,7 @@ interactions:
         "2"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
         {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
         {"2026": false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.794.2", "data_version": null, "dataset": null}}'
+        "1.815.1", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000
@@ -77,15 +77,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 26 Aug 2026 20:12:45 GMT
+      - Fri, 28 Aug 2026 12:00:42 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-276d0359f4d90003a037bf9ce199e8c5-30837f5d63eb0458-01
+      - 00-165da47b8070117c4f90225c5e37da8c-79c1e67ca2a11fe3-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 276d0359f4d90003a037bf9ce199e8c5;o=1
+      - 165da47b8070117c4f90225c5e37da8c
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -93,7 +93,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 2dd6045d-e86b-4a29-816c-d058ee40f0f9
+      - a4758376-eb93-420a-9d46-6b32e125f751
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_one_dollar_over_the_mhf_standard_falls_through_to_expansion.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetSmoke.test_parent_one_dollar_over_the_mhf_standard_falls_through_to_expansion.yaml
@@ -23,7 +23,7 @@ interactions:
       {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1", "2"], "tanf":
       {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
       {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
-      {"2026": false}}}, "marital_units": {}}, "version": "1.794.2"}'
+      {"2026": false}}}, "marital_units": {}}, "version": "1.815.1"}'
     headers:
       Accept:
       - '*/*'
@@ -66,10 +66,10 @@ interactions:
         "2"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
         {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
         {"2026": false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
-        "1.794.2", "data_version": null, "dataset": null}}'
+        "1.815.1", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
       - '2094'
       access-control-allow-origin:
@@ -77,15 +77,15 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 26 Aug 2026 20:12:48 GMT
+      - Fri, 28 Aug 2026 12:00:45 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-55f3d5186e1cd7e3dbe375ba24a103c9-fd44bc12aa33b262-00
+      - 00-58ac19aae1785e6066b808fab131b06a-b9a6745e918168a2-00
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 55f3d5186e1cd7e3dbe375ba24a103c9
+      - 58ac19aae1785e6066b808fab131b06a
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -93,7 +93,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - a82934af-af65-497d-bf8d-8e7fdb6d8f41
+      - 7f6f8bb3-7e84-4fc1-80b7-3cb1c2fd67e2
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_19_disabled_adult_routed_to_expansion_keeps_the_expansion_value.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_19_disabled_adult_routed_to_expansion_keeps_the_expansion_value.yaml
@@ -1,13 +1,13 @@
 interactions:
 - request:
-    body: '{"household": {"people": {"1": {"age": {"2026": 34}, "is_pregnant": {"2026":
-      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": null},
-      "employment_income": {"2026": 14400}, "self_employment_income": {"2026": 0},
+    body: '{"household": {"people": {"1": {"age": {"2026": 40}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": true},
+      "employment_income": {"2026": 19200}, "self_employment_income": {"2026": 0},
       "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
       {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
       {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null},
       "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
-      "meets_ssi_disability_criteria": {"2026": null}, "is_blind": {"2026": false},
+      "meets_ssi_disability_criteria": {"2026": true}, "is_blind": {"2026": false},
       "medicaid": {"2026": null}, "medicaid_category": {"2026": null}, "is_optional_senior_or_disabled_for_medicaid":
       {"2026": null}}}, "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families":
       {"family": {"members": ["1"]}}, "households": {"household": {"members": ["1"],
@@ -33,15 +33,15 @@ interactions:
   response:
     body:
       string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
-        {"2026": 34}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
-        0}, "is_disabled": {"2026": false}, "employment_income": {"2026": 14400},
-        "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income":
-        {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
-        {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
-        {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
-        {"2026": false}, "meets_ssi_disability_criteria": {"2026": false}, "is_blind":
+        {"2026": 40}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": true}, "employment_income": {"2026": 19200}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": true}, "is_blind":
         {"2026": false}, "medicaid": {"2026": 12559.627}, "medicaid_category": {"2026":
-        "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}}},
+        "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": true}}},
         "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family":
         {"members": ["1"]}}, "households": {"household": {"members": ["1"], "state_code":
         {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026":
@@ -51,23 +51,23 @@ interactions:
         "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
-      - '1325'
+      - '1322'
       access-control-allow-origin:
       - '*'
       content-type:
       - application/json
       date:
-      - Fri, 28 Aug 2026 12:00:38 GMT
+      - Fri, 28 Aug 2026 12:00:49 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-76b2b9b917ad911b2327eb711e6023b7-205113a7bafd5fb3-01
+      - 00-ee7e2652a6c99358e72275c09f81e1fc-f3d665dd660bd347-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - 76b2b9b917ad911b2327eb711e6023b7;o=1
+      - ee7e2652a6c99358e72275c09f81e1fc;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -75,7 +75,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 14b300ab-125c-445c-8027-bf62f8084f10
+      - 204e1a20-b9b7-4605-8dfe-672a1de4d2f5
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_21_blind_adult_at_the_mhabd_boundary_keeps_the_expansion_value.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_21_blind_adult_at_the_mhabd_boundary_keeps_the_expansion_value.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"age": {"2026": 46}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": true},
+      "employment_income": {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income":
+      {"2026": 0}, "taxable_pension_income": {"2026": 16200}, "social_security": {"2026":
+      0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+      0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null}, "receives_ssi":
+      {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "meets_ssi_disability_criteria":
+      {"2026": true}, "is_blind": {"2026": true}, "medicaid": {"2026": null}, "medicaid_category":
+      {"2026": null}, "is_optional_senior_or_disabled_for_medicaid": {"2026": null}}},
+      "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family": {"members":
+      ["1"]}}, "households": {"household": {"members": ["1"], "state_code": {"2026":
+      "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026": null},
+      "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026": false},
+      "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026": false}}},
+      "marital_units": {}}, "version": "1.815.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1215'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
+        {"2026": 46}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": true}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        16200}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": true}, "is_blind":
+        {"2026": true}, "medicaid": {"2026": 12559.627}, "medicaid_category": {"2026":
+        "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": true}}},
+        "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family":
+        {"members": ["1"]}}, "households": {"household": {"members": ["1"], "state_code":
+        {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026":
+        0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026":
+        false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026":
+        false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version": "1.815.1",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1321'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Fri, 28 Aug 2026 12:00:53 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-3c6fa5946620797da283a98ed40389b2-04481d5b181323a3-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 3c6fa5946620797da283a98ed40389b2
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - e561bdae-546b-4cce-b109-3dcac396077a
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_24_disabled_senior_is_valued_at_the_seniors_rate.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_24_disabled_senior_is_valued_at_the_seniors_rate.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"age": {"2026": 70}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": true},
+      "employment_income": {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income":
+      {"2026": 0}, "taxable_pension_income": {"2026": 12000}, "social_security": {"2026":
+      0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+      0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null}, "receives_ssi":
+      {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "meets_ssi_disability_criteria":
+      {"2026": true}, "is_blind": {"2026": false}, "medicaid": {"2026": null}, "medicaid_category":
+      {"2026": null}, "is_optional_senior_or_disabled_for_medicaid": {"2026": null}}},
+      "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family": {"members":
+      ["1"]}}, "households": {"household": {"members": ["1"], "state_code": {"2026":
+      "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026": null},
+      "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026": false},
+      "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026": false}}},
+      "marital_units": {}}, "version": "1.815.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
+        {"2026": 70}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": true}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        12000}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": true}, "is_blind":
+        {"2026": false}, "medicaid": {"2026": 12559.627}, "medicaid_category": {"2026":
+        "SENIOR_OR_DISABLED"}, "is_optional_senior_or_disabled_for_medicaid": {"2026":
+        true}}}, "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family":
+        {"members": ["1"]}}, "households": {"household": {"members": ["1"], "state_code":
+        {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026":
+        0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026":
+        false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026":
+        false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version": "1.815.1",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '1335'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Fri, 28 Aug 2026 12:00:57 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-21468d1bdd648e6d6e6cd7385e1eac45-c29ac9f8e9cad574-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 21468d1bdd648e6d6e6cd7385e1eac45
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 8dd009bf-f9fd-481b-9fe3-cc0a20c111c3
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_6_disabled_adult_over_the_mhabd_standard_falls_through_to_expansion.yaml
+++ b/programs/programs/cross_white_label/medicaid/tests/cassettes/TestMoHealthNetValueRouting.test_scenario_6_disabled_adult_over_the_mhabd_standard_falls_through_to_expansion.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"1": {"age": {"2026": 40}, "is_pregnant": {"2026":
+      false}, "ssi_countable_resources": {"2026": 0}, "is_disabled": {"2026": true},
+      "employment_income": {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income":
+      {"2026": 0}, "taxable_pension_income": {"2026": 20400}, "social_security": {"2026":
+      0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+      0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": null}, "receives_ssi":
+      {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "meets_ssi_disability_criteria":
+      {"2026": true}, "is_blind": {"2026": false}, "medicaid": {"2026": null}, "medicaid_category":
+      {"2026": null}, "is_optional_senior_or_disabled_for_medicaid": {"2026": null}}},
+      "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family": {"members":
+      ["1"]}}, "households": {"household": {"members": ["1"], "state_code": {"2026":
+      "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026": null},
+      "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026": false},
+      "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026": false}}},
+      "marital_units": {}}, "version": "1.815.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"1": {"age":
+        {"2026": 40}, "is_pregnant": {"2026": false}, "ssi_countable_resources": {"2026":
+        0}, "is_disabled": {"2026": true}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        20400}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "meets_ssi_disability_criteria": {"2026": true}, "is_blind":
+        {"2026": false}, "medicaid": {"2026": 12559.627}, "medicaid_category": {"2026":
+        "ADULT"}, "is_optional_senior_or_disabled_for_medicaid": {"2026": false}}},
+        "tax_units": {"main_tax_unit": {"members": ["1"]}}, "families": {"family":
+        {"members": ["1"]}}, "households": {"household": {"members": ["1"], "state_code":
+        {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["1"], "tanf": {"2026":
+        0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible": {"2026":
+        false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible": {"2026":
+        false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version": "1.815.1",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '1323'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Fri, 28 Aug 2026 12:01:01 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-5660578f87483e3b61a697604eabcc5d-e6b76657fb9d3936-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 5660578f87483e3b61a697604eabcc5d;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 1bce0b5c-5ea1-46d7-8f6b-d07ae80bfbbc
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/medicaid/tests/test_base.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_base.py
@@ -1,38 +1,48 @@
-"""
-Unit tests for federal Medicaid calculator eligibility logic.
+"""Unit tests for the shared Medicaid calculator's value routing.
 
-These tests verify that:
-1. Seniors (65+) and disabled individuals are correctly routed through the
-   aged/disabled pathway and not the ACA expansion pathway
-2. Non-senior, non-disabled members are routed through the appropriate
-   Medicaid category (ADULT, PARENT, PREGNANT, INFANT, CHILD, etc.)
+PolicyEngine answers Medicaid over two pathways and a member can clear either: the ordinary
+MAGI pathway (``medicaid`` plus ``medicaid_category``, naming the group that applied) and the
+optional aged/blind/disabled pathway (``is_optional_senior_or_disabled_for_medicaid``). These
+tests pin which of the two decides a member's value, and which rate that produces.
 
-ACA Medicaid expansion (138% FPL) only applies to adults under 65.
-Seniors must qualify through the aged/disabled pathway which uses
-state-specific FPL thresholds (typically 74-100%).
+PolicyEngine's own routing wins wherever it has an answer. The ABD pathway is the fallback for
+the members it does not reach, not an override applied ahead of it — reading it first is what
+produced the production failures the regression tests at the bottom of this file cover.
 """
 
 from django.test import TestCase
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
-from programs.framework.pe_dependencies import member as member_dependency
+from programs.framework.pe_dependencies import member as member_deps
 from programs.programs.cross_white_label.medicaid.base import Medicaid
-from programs.framework.pe_dependencies import member
 
 
-class TestMedicaidSeniorEligibility(TestCase):
-    """Tests for Medicaid calculator senior eligibility routing."""
+class MedicaidValueTestCase(TestCase):
+    """Shared setup: one calculator, one member, and a stand-in for PolicyEngine."""
 
-    def _create_calculator_with_mocks(self):
-        """Helper to create a Medicaid calculator with mocked dependencies."""
+    # Distinct rates so an assertion names exactly one category.
+    RATES = {
+        "NONE": 0,
+        "ADULT": 400,
+        "YOUNG_ADULT": 410,
+        "PARENT": 420,
+        "PREGNANT": 430,
+        "INFANT": 440,
+        "YOUNG_CHILD": 450,
+        "OLDER_CHILD": 460,
+        "SSI_RECIPIENT": 470,
+        "AGED": 480,
+        "DISABLED": 490,
+    }
+
+    def calculator(self, senior_value_takes_precedence=False):
         calculator = Medicaid(Mock(), Mock(), Mock())
         calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
+        calculator.medicaid_categories = dict(self.RATES)
+        calculator.senior_value_takes_precedence = senior_value_takes_precedence
         return calculator
 
-    def _create_member(self, age, is_disabled=False):
-        """Helper to create a mock member."""
+    def member(self, age, is_disabled=False):
         member = Mock()
         member.id = 1
         member.age = age
@@ -40,594 +50,279 @@ class TestMedicaidSeniorEligibility(TestCase):
         member.has_disability = Mock(return_value=is_disabled)
         return member
 
-    def test_senior_who_qualifies_via_aged_pathway_returns_aged_category(self):
+    def policyengine_says(self, calculator, medicaid=0, category="NONE", abd=False):
+        """Stand in for PolicyEngine's answer about one member.
+
+        Both variables are modelled on every call, not just the one a test is about: they are
+        read together, and stubbing only one lets a test pass against a combination
+        PolicyEngine would never return.
         """
-        Test that a senior (65+) who qualifies via the aged/disabled pathway
-        returns the AGED category value.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"AGED": 474, "ADULT": 474}
+        calculator.get_member_variable = Mock(return_value=medicaid)
 
-        # Senior qualifies via aged/disabled pathway
-        calculator.get_member_dependency_value.return_value = True
+        def dependency_value(dependency, member_id):
+            if dependency is member_deps.MedicaidSeniorOrDisabled:
+                return abd
+            if dependency is member_deps.MedicaidCategory:
+                return category
+            raise AssertionError(f"unexpected dependency read: {dependency}")
 
-        member = self._create_member(age=71)
-
-        result = calculator.member_value(member)
-
-        # Should return AGED category * 12
-        self.assertEqual(result, 474 * 12)
-
-        # Should have checked the aged/disabled pathway
-        calculator.get_member_dependency_value.assert_called_once_with(member_dependency.MedicaidSeniorOrDisabled, 1)
-
-    def test_senior_who_fails_aged_pathway_returns_zero(self):
-        """
-        Test that a senior (65+) who fails the aged/disabled pathway
-        returns 0 and does NOT fall through to ACA expansion.
-
-        This is the key bug fix - previously seniors could fall through
-        to the 138% FPL ACA adult pathway.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"AGED": 474, "ADULT": 474}
-
-        # Senior fails aged/disabled pathway (e.g., income > 100% FPL)
-        calculator.get_member_dependency_value.return_value = False
-
-        # Even if regular medicaid would return positive (138% FPL)
-        calculator.get_member_variable.return_value = 500
-
-        member = self._create_member(age=71)
-
-        result = calculator.member_value(member)
-
-        # Should return 0, NOT fall through to ACA adult pathway
-        self.assertEqual(result, 0)
-
-        # Should NOT have called get_member_variable (no ACA fallback)
-        calculator.get_member_variable.assert_not_called()
-
-    def test_senior_at_age_65_boundary_uses_aged_pathway(self):
-        """
-        Test that exactly 65 years old uses the aged/disabled pathway.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"AGED": 474, "ADULT": 474}
-
-        calculator.get_member_dependency_value.return_value = True
-
-        member = self._create_member(age=65)
-
-        result = calculator.member_value(member)
-
-        # Should use AGED pathway
-        self.assertEqual(result, 474 * 12)
-        calculator.get_member_dependency_value.assert_called_once()
-
-    def test_adult_age_64_uses_aca_pathway_not_aged(self):
-        """
-        Test that 64-year-old uses ACA expansion pathway, not aged pathway.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"AGED": 474, "ADULT": 474}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "ADULT"
-
-        member = self._create_member(age=64)
-
-        result = calculator.member_value(member)
-
-        # Should return ADULT category * 12
-        self.assertEqual(result, 474 * 12)
-
-        # Should have called get_member_variable for ACA check
-        calculator.get_member_variable.assert_called_once_with(1)
-
-    def test_member_with_none_age_uses_aca_pathway(self):
-        """
-        Test that members with None age are treated as non-seniors
-        and use the ACA expansion pathway.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"ADULT": 474}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "ADULT"
-
-        member = self._create_member(age=None)
-
-        result = calculator.member_value(member)
-
-        # Should use ACA pathway (not crash on None comparison)
-        self.assertEqual(result, 474 * 12)
-        calculator.get_member_variable.assert_called_once()
-
-
-class TestMedicaidDisabledEligibility(TestCase):
-    """Tests for Medicaid calculator disabled eligibility routing."""
-
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
+        calculator.get_member_dependency_value = Mock(side_effect=dependency_value)
         return calculator
 
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
+    def annual(self, category):
+        return self.RATES[category] * 12
 
-    def test_disabled_adult_uses_disabled_pathway(self):
+
+class TestOrdinaryPathway(MedicaidValueTestCase):
+    """A member PolicyEngine prices through ``medicaid_category``."""
+
+    def test_adult_is_valued_at_the_adult_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="ADULT")
+
+        self.assertEqual(calculator.member_value(self.member(age=35)), self.annual("ADULT"))
+
+    def test_parent_is_valued_at_the_parent_rate_not_the_adult_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="PARENT")
+
+        self.assertEqual(calculator.member_value(self.member(age=35)), self.annual("PARENT"))
+
+    def test_pregnant_member_is_valued_at_the_pregnant_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="PREGNANT")
+
+        self.assertEqual(calculator.member_value(self.member(age=30)), self.annual("PREGNANT"))
+
+    def test_each_child_category_is_valued_at_its_own_rate(self):
+        for category, age in (("INFANT", 0), ("YOUNG_CHILD", 4), ("OLDER_CHILD", 12)):
+            with self.subTest(category=category):
+                calculator = self.policyengine_says(self.calculator(), medicaid=500, category=category)
+
+                self.assertEqual(calculator.member_value(self.member(age=age)), self.annual(category))
+
+    def test_young_adult_is_valued_at_the_young_adult_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="YOUNG_ADULT")
+
+        self.assertEqual(calculator.member_value(self.member(age=20)), self.annual("YOUNG_ADULT"))
+
+    def test_member_with_unknown_age_is_treated_as_non_senior(self):
+        """``calc_age`` returns None when birth date is missing; it must not crash or age them up."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="ADULT")
+
+        self.assertEqual(calculator.member_value(self.member(age=None)), self.annual("ADULT"))
+
+    def test_ineligible_member_is_worth_nothing(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE")
+
+        self.assertEqual(calculator.member_value(self.member(age=50)), 0)
+
+    def test_none_category_is_worth_nothing(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="NONE")
+
+        self.assertEqual(calculator.member_value(self.member(age=35)), 0)
+
+    def test_unpriced_category_is_worth_nothing_rather_than_raising(self):
+        """PolicyEngine's enum is larger than any state prices and grows over time.
+
+        A KeyError here would fail the whole eligibility request for the household, not just
+        this program, so an unrecognised category has to read as $0 like any other ineligible
+        answer.
         """
-        Test that disabled adults (any age under 65) use the aged/disabled pathway.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"DISABLED": 474, "ADULT": 474}
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="MEDICALLY_NEEDY")
 
-        calculator.get_member_dependency_value.return_value = True
+        self.assertEqual(calculator.member_value(self.member(age=35)), 0)
 
-        member = self._create_member(age=45, is_disabled=True)
 
-        result = calculator.member_value(member)
+class TestAbdPathway(MedicaidValueTestCase):
+    """Members eligible on an age or disability basis."""
 
-        # Should return DISABLED category * 12
-        self.assertEqual(result, 474 * 12)
+    def test_senior_on_the_abd_pathway_is_valued_at_the_aged_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-    def test_disabled_adult_who_fails_disabled_pathway_returns_zero(self):
-        """
-        Test that disabled adults who fail the aged/disabled pathway
-        return 0 and do NOT fall through to ACA expansion.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"DISABLED": 474, "ADULT": 474}
+        self.assertEqual(calculator.member_value(self.member(age=66)), self.annual("AGED"))
 
-        # Disabled person fails aged/disabled pathway
-        calculator.get_member_dependency_value.return_value = False
+    def test_age_65_is_the_senior_boundary(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-        # Even if ACA would pass
-        calculator.get_member_variable.return_value = 500
+        self.assertEqual(calculator.member_value(self.member(age=65)), self.annual("AGED"))
 
-        member = self._create_member(age=45, is_disabled=True)
+    def test_age_64_is_not_a_senior(self):
+        """One year under the boundary, the ABD pathway pays the disabled rate, not the aged one."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-        result = calculator.member_value(member)
+        self.assertEqual(calculator.member_value(self.member(age=64, is_disabled=True)), self.annual("DISABLED"))
 
-        # Should return 0, NOT fall through
-        self.assertEqual(result, 0)
-        calculator.get_member_variable.assert_not_called()
+    def test_disabled_adult_on_the_abd_pathway_is_valued_at_the_disabled_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-    def test_disabled_senior_returns_disabled_not_aged(self):
-        """
-        Test that a disabled senior (65+) returns DISABLED category,
-        not AGED category. Disability takes priority.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"DISABLED": 500, "AGED": 474}
+        self.assertEqual(calculator.member_value(self.member(age=45, is_disabled=True)), self.annual("DISABLED"))
 
-        calculator.get_member_dependency_value.return_value = True
+    def test_disabled_child_on_the_abd_pathway_is_valued_at_the_disabled_rate(self):
+        """The disabled rate, not the child rate — the child's own facts decide the tier."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-        member = Mock()
-        member.id = 1
-        member.age = 70
-        member.calc_age = Mock(return_value=70)
-        member.has_disability = Mock(return_value=True)
+        self.assertEqual(calculator.member_value(self.member(age=10, is_disabled=True)), self.annual("DISABLED"))
 
-        result = calculator.member_value(member)
+    def test_senior_who_fails_the_abd_pathway_is_worth_nothing(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=False)
 
-        # Should return DISABLED (500 * 12), not AGED (474 * 12)
-        self.assertEqual(result, 500 * 12)
+        self.assertEqual(calculator.member_value(self.member(age=71)), 0)
 
-    def test_disabled_child_uses_disabled_pathway(self):
-        """
-        Test that a disabled child uses the aged/disabled pathway.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"DISABLED": 474, "OLDER_CHILD": 200}
+    def test_disabled_adult_who_fails_the_abd_pathway_is_worth_nothing(self):
+        """Failing ABD with nothing on the ordinary pathway either leaves them ineligible."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=False)
 
-        calculator.get_member_dependency_value.return_value = True
+        self.assertEqual(calculator.member_value(self.member(age=45, is_disabled=True)), 0)
 
-        member = self._create_member(age=10, is_disabled=True)
+    def test_neither_senior_nor_disabled_never_reads_the_abd_pathway(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-        result = calculator.member_value(member)
+        self.assertEqual(calculator.member_value(self.member(age=35)), 0)
 
-        # Should return DISABLED category * 12
-        self.assertEqual(result, 474 * 12)
 
+class TestAbdCategories(MedicaidValueTestCase):
+    """``SENIOR_OR_DISABLED`` and ``SSI_RECIPIENT`` carry no aged/disabled distinction.
 
-class TestMedicaidAdultEligibility(TestCase):
-    """Tests for Medicaid calculator adult (non-senior, non-disabled) eligibility."""
+    PolicyEngine reports both for members it found eligible on an age or disability basis
+    without saying which, so the value tier comes from the member's own age and disability
+    flags rather than from a rate keyed on the category name.
+    """
 
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
+    def test_senior_or_disabled_category_for_a_senior_is_the_aged_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="SENIOR_OR_DISABLED")
 
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
+        self.assertEqual(calculator.member_value(self.member(age=70)), self.annual("AGED"))
 
-    def test_adult_who_qualifies_returns_adult_category(self):
-        """
-        Test that an adult who qualifies via ACA expansion returns ADULT category.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"ADULT": 474}
+    def test_senior_or_disabled_category_for_a_disabled_child_is_the_disabled_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="SENIOR_OR_DISABLED")
 
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "ADULT"
+        self.assertEqual(calculator.member_value(self.member(age=11, is_disabled=True)), self.annual("DISABLED"))
 
-        member = self._create_member(age=35)
+    def test_ssi_recipient_category_for_a_disabled_adult_is_the_disabled_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="SSI_RECIPIENT")
 
-        result = calculator.member_value(member)
+        self.assertEqual(calculator.member_value(self.member(age=41, is_disabled=True)), self.annual("DISABLED"))
 
-        self.assertEqual(result, 474 * 12)
+    def test_ssi_recipient_category_with_no_disability_flag_is_the_disabled_rate(self):
+        """SSI receipt is itself the disability signal, so a working-age recipient who set no
+        screener flag must not fall to the aged rate."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="SSI_RECIPIENT")
 
-    def test_adult_who_fails_aca_returns_zero(self):
-        """
-        Test that adults who fail ACA expansion (income > 138% FPL) return 0.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"ADULT": 474}
+        self.assertEqual(calculator.member_value(self.member(age=41)), self.annual("DISABLED"))
 
-        # ACA expansion returns 0 (income > 138% FPL)
-        calculator.get_member_variable.return_value = 0
+    def test_ssi_recipient_category_for_a_senior_is_the_aged_rate(self):
+        """A 66-year-old on SSI is a senior enrollee, not a disabled one, whatever the route in."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="SSI_RECIPIENT")
 
-        member = self._create_member(age=50)
+        self.assertEqual(calculator.member_value(self.member(age=66)), self.annual("AGED"))
 
-        result = calculator.member_value(member)
+    def test_abd_category_for_a_child_with_no_disability_flag_is_the_disabled_rate(self):
+        """Neither senior nor flagged: the aged rate would be plainly wrong for a minor."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="SENIOR_OR_DISABLED")
 
-        self.assertEqual(result, 0)
+        self.assertEqual(calculator.member_value(self.member(age=11)), self.annual("DISABLED"))
 
+    def test_abd_category_is_not_read_off_the_rate_table(self):
+        """The category names have no key of their own; pricing them would be dead config."""
+        self.assertNotIn("SENIOR_OR_DISABLED", Medicaid.medicaid_categories)
+        self.assertEqual(Medicaid.abd_categories, ("SENIOR_OR_DISABLED", "SSI_RECIPIENT"))
 
-class TestMedicaidParentEligibility(TestCase):
-    """Tests for Medicaid calculator parent/caretaker eligibility."""
 
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
+class TestSeniorAndDisabledPrecedence(MedicaidValueTestCase):
+    """Which rate a member who is both 65+ and disability-eligible gets.
 
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
+    The two committed specs disagree and each is right about its own source table, so this is
+    per-state rather than uniform: specs/ks.md reads its per-enrollee groups as disjoint with
+    disability taking precedence, while MO follows KFF's Seniors definition of 65+ regardless
+    of disability.
+    """
 
-    def test_parent_who_qualifies_returns_parent_category(self):
-        """
-        Test that a parent/caretaker who qualifies returns PARENT category value.
-        PolicyEngine determines PARENT category based on having qualifying children.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"PARENT": 474, "ADULT": 400}
+    def test_disability_wins_by_default(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=0, category="NONE", abd=True)
 
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "PARENT"
+        value = calculator.member_value(self.member(age=68, is_disabled=True))
 
-        member = self._create_member(age=35)
+        self.assertEqual(value, self.annual("DISABLED"))
+        self.assertNotEqual(value, self.annual("AGED"))
 
-        result = calculator.member_value(member)
+    def test_age_wins_when_the_state_opts_in(self):
+        calculator = self.calculator(senior_value_takes_precedence=True)
+        self.policyengine_says(calculator, medicaid=0, category="NONE", abd=True)
 
-        # Should return PARENT category * 12
-        self.assertEqual(result, 474 * 12)
+        value = calculator.member_value(self.member(age=68, is_disabled=True))
 
-    def test_parent_category_has_different_value_than_adult(self):
-        """
-        Test that PARENT and ADULT categories can have different values.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"PARENT": 500, "ADULT": 400}
+        self.assertEqual(value, self.annual("AGED"))
+        self.assertNotEqual(value, self.annual("DISABLED"))
 
-        calculator.get_member_variable.return_value = 100
-        calculator.get_member_dependency_value.return_value = "PARENT"
+    def test_the_flag_only_affects_members_who_are_both(self):
+        """A senior who is not disabled, and a disabled member who is not a senior, are unmoved."""
+        for takes_precedence in (False, True):
+            calculator = self.calculator(senior_value_takes_precedence=takes_precedence)
+            self.policyengine_says(calculator, medicaid=0, category="NONE", abd=True)
 
-        member = self._create_member(age=30)
+            with self.subTest(senior_value_takes_precedence=takes_precedence):
+                self.assertEqual(calculator.member_value(self.member(age=70)), self.annual("AGED"))
+                self.assertEqual(
+                    calculator.member_value(self.member(age=40, is_disabled=True)), self.annual("DISABLED")
+                )
 
-        result = calculator.member_value(member)
+    def test_default_is_disability_first(self):
+        self.assertFalse(Medicaid.senior_value_takes_precedence)
 
-        self.assertEqual(result, 500 * 12)
 
+class TestExpansionIsNotForSeniors(MedicaidValueTestCase):
+    """ACA expansion is a 19-64 group (42 CFR 435.119)."""
 
-class TestMedicaidPregnantEligibility(TestCase):
-    """Tests for Medicaid calculator pregnant eligibility."""
+    def test_senior_is_never_valued_at_an_expansion_rate(self):
+        """Even if PolicyEngine hands back an expansion category for a 65+ member."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="ADULT", abd=False)
 
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
+        self.assertEqual(calculator.member_value(self.member(age=71)), 0)
 
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
+    def test_senior_routed_to_expansion_still_gets_the_abd_pathway(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="ADULT", abd=True)
 
-    def test_pregnant_member_who_qualifies_returns_pregnant_category(self):
-        """
-        Test that a pregnant member who qualifies returns PREGNANT category value.
-        PolicyEngine uses higher FPL thresholds for pregnant members (e.g., 213% for IL).
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"PREGNANT": 474, "ADULT": 400}
+        self.assertEqual(calculator.member_value(self.member(age=71)), self.annual("AGED"))
 
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "PREGNANT"
+    def test_senior_may_still_hold_a_magi_category_with_no_age_ceiling(self):
+        """Sec. 1931 parent/caretaker has no upper age bound, so it is not excluded."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="PARENT")
 
-        member = self._create_member(age=28)
+        self.assertEqual(calculator.member_value(self.member(age=66)), self.annual("PARENT"))
 
-        result = calculator.member_value(member)
+    def test_adult_just_under_the_boundary_is_valued_at_the_expansion_rate(self):
+        calculator = self.policyengine_says(self.calculator(), medicaid=500, category="ADULT")
 
-        self.assertEqual(result, 474 * 12)
+        self.assertEqual(calculator.member_value(self.member(age=64)), self.annual("ADULT"))
 
-    def test_pregnant_senior_uses_aged_pathway_not_pregnant(self):
-        """
-        Test that a pregnant senior (65+) still uses aged/disabled pathway.
-        Age routing takes precedence over pregnancy status.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"AGED": 474, "PREGNANT": 500}
 
-        calculator.get_member_dependency_value.return_value = True
+class TestProductionRegressions(MedicaidValueTestCase):
+    """Four routing failures found in production QA, as the shapes PolicyEngine returned.
 
-        member = self._create_member(age=66)
+    Each combination below was read off a production PolicyEngine payload for a Missouri screen,
+    so these fail against the routing that shipped and pass against this one. Scenario numbers
+    refer to the Test Scenarios in ``specs/mo.md``.
+    """
 
-        result = calculator.member_value(member)
+    def test_disabled_adult_who_fails_abd_falls_through_to_expansion(self):
+        """Scenario 6. PE: ADULT, ABD false. Shipped $0 — the program vanished from results."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=12_559, category="ADULT", abd=False)
 
-        # Should return AGED, not PREGNANT
-        self.assertEqual(result, 474 * 12)
+        self.assertEqual(calculator.member_value(self.member(age=40, is_disabled=True)), self.annual("ADULT"))
 
+    def test_disabled_adult_routed_to_expansion_is_not_repriced_as_disabled(self):
+        """Scenario 19. PE: ADULT, ABD true. Shipped the disabled rate over PE's own routing."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=12_559, category="ADULT", abd=True)
 
-class TestMedicaidChildEligibility(TestCase):
-    """Tests for Medicaid calculator child eligibility."""
+        self.assertEqual(calculator.member_value(self.member(age=40, is_disabled=True)), self.annual("ADULT"))
 
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
+    def test_blind_adult_routed_to_expansion_is_not_repriced_as_disabled(self):
+        """Scenario 21. Same shape as 19, reached through the blindness flag."""
+        calculator = self.policyengine_says(self.calculator(), medicaid=12_559, category="ADULT", abd=True)
 
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
+        self.assertEqual(calculator.member_value(self.member(age=46, is_disabled=True)), self.annual("ADULT"))
 
-    def test_infant_who_qualifies_returns_infant_category(self):
-        """
-        Test that an infant who qualifies returns INFANT category value.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"INFANT": 0, "YOUNG_CHILD": 0}
+    def test_disabled_senior_takes_the_aged_rate_where_the_state_says_age_wins(self):
+        """Scenario 24. PE: SENIOR_OR_DISABLED, ABD true. Shipped the under-65 disabled rate."""
+        calculator = self.calculator(senior_value_takes_precedence=True)
+        self.policyengine_says(calculator, medicaid=12_559, category="SENIOR_OR_DISABLED", abd=True)
 
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "INFANT"
-
-        member = self._create_member(age=0)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 0 * 12)
-
-    def test_young_child_who_qualifies_returns_young_child_category(self):
-        """
-        Test that a young child who qualifies returns YOUNG_CHILD category value.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"YOUNG_CHILD": 200}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "YOUNG_CHILD"
-
-        member = self._create_member(age=3)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 200 * 12)
-
-    def test_older_child_who_qualifies_returns_older_child_category(self):
-        """
-        Test that an older child who qualifies returns OLDER_CHILD category value.
-        PolicyEngine uses higher FPL thresholds for children (e.g., 318% for IL).
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"OLDER_CHILD": 284}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "OLDER_CHILD"
-
-        member = self._create_member(age=12)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 284 * 12)
-
-    def test_child_who_fails_income_returns_zero(self):
-        """
-        Test that a child who fails the income test returns 0.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"OLDER_CHILD": 284}
-
-        calculator.get_member_variable.return_value = 0
-
-        member = self._create_member(age=15)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 0)
-
-
-class TestMedicaidYoungAdultEligibility(TestCase):
-    """Tests for Medicaid calculator young adult eligibility."""
-
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
-
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
-
-    def test_young_adult_who_qualifies_returns_young_adult_category(self):
-        """
-        Test that a young adult (typically 19-20) who qualifies returns YOUNG_ADULT category.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"YOUNG_ADULT": 300, "ADULT": 474}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "YOUNG_ADULT"
-
-        member = self._create_member(age=19)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 300 * 12)
-
-
-class TestMedicaidSSIRecipientEligibility(TestCase):
-    """Tests for Medicaid calculator SSI recipient eligibility."""
-
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
-
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
-
-    def test_ssi_recipient_returns_ssi_recipient_category(self):
-        """
-        Test that an SSI recipient returns SSI_RECIPIENT category value.
-        SSI recipients are categorically eligible for Medicaid.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"SSI_RECIPIENT": 474, "ADULT": 400}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "SSI_RECIPIENT"
-
-        member = self._create_member(age=55)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 474 * 12)
-
-
-class TestMedicaidNoneCategory(TestCase):
-    """Tests for Medicaid calculator when no category applies."""
-
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
-
-    def _create_member(self, age, is_disabled=False):
-        member = Mock()
-        member.id = 1
-        member.age = age
-        member.calc_age = Mock(return_value=age)
-        member.has_disability = Mock(return_value=is_disabled)
-        return member
-
-    def test_none_category_returns_zero(self):
-        """
-        Test that NONE category returns 0 (no Medicaid eligibility).
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"NONE": 0, "ADULT": 474}
-
-        calculator.get_member_variable.return_value = 500
-        calculator.get_member_dependency_value.return_value = "NONE"
-
-        member = self._create_member(age=40)
-
-        result = calculator.member_value(member)
-
-        self.assertEqual(result, 0 * 12)
-
-
-class TestMedicaidUnknownCategory(TestCase):
-    """Tests for categories PolicyEngine can return that medicaid_categories does not price."""
-
-    def _create_calculator_with_mocks(self):
-        calculator = Medicaid(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_member_variable = Mock()
-        calculator.get_member_dependency_value = Mock()
-        return calculator
-
-    def _create_member(self):
-        """A non-senior, non-disabled member, so member_value reaches the category lookup."""
-        member = Mock()
-        member.id = 1
-        member.age = 40
-        member.calc_age = Mock(return_value=40)
-        member.has_disability = Mock(return_value=False)
-        return member
-
-    def test_unpriced_category_returns_zero_instead_of_raising(self):
-        """An unrecognized category is worth 0, not a KeyError.
-
-        PolicyEngine's medicaid_category enum is larger than the set of categories we price
-        and it grows over time. A KeyError here propagates out of member_value and fails the
-        entire eligibility request rather than just this program, so an unknown category has
-        to degrade to "no value" the same way any other ineligible answer does.
-        """
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"ADULT": 532}
-        calculator.get_member_variable.return_value = 12_559
-        calculator.get_member_dependency_value.return_value = "SECTION_1115_MEC_ADULT"
-
-        result = calculator.member_value(self._create_member())
-
-        self.assertEqual(result, 0)
-
-    def test_known_category_is_still_priced(self):
-        """The fallback doesn't swallow categories we do price."""
-        calculator = self._create_calculator_with_mocks()
-        calculator.medicaid_categories = {"ADULT": 532}
-        calculator.get_member_variable.return_value = 12_559
-        calculator.get_member_dependency_value.return_value = "ADULT"
-
-        result = calculator.member_value(self._create_member())
-
-        self.assertEqual(result, 532 * 12)
+        self.assertEqual(calculator.member_value(self.member(age=70, is_disabled=True)), self.annual("AGED"))

--- a/programs/programs/cross_white_label/medicaid/tests/test_ks.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_ks.py
@@ -31,19 +31,44 @@ class TestKsKanCareScenarios(TestCase):
         m.has_disability = Mock(return_value=is_disabled)
         return m
 
+    def _pe(self, calc, medicaid=0, category="NONE", abd=False):
+        """Stand in for PolicyEngine's answer about one member.
+
+        Both variables have to be modelled, not just the one a scenario is about: ``medicaid``
+        and ``medicaid_category`` are read together, and ``member_value`` consults the ABD flag
+        only for the members the ordinary pathway does not price.
+        """
+        calc.get_member_variable = Mock(return_value=medicaid)
+
+        def dependency_value(dependency, member_id):
+            if dependency is member_deps.MedicaidSeniorOrDisabled:
+                return abd
+            if dependency is member_deps.MedicaidCategory:
+                return category
+            raise AssertionError(f"unexpected dependency read: {dependency}")
+
+        calc.get_member_dependency_value = Mock(side_effect=dependency_value)
+
     def _magi_eligible(self, calc, category):
         """PE finds the member MAGI-eligible in ``category`` (non-senior, non-disabled path)."""
-        calc.get_member_variable = Mock(return_value=1)
-        calc.get_member_dependency_value = Mock(return_value=category)
+        self._pe(calc, medicaid=1, category=category)
 
     def _magi_ineligible(self, calc):
         """PE returns the member ineligible on the MAGI path."""
-        calc.get_member_variable = Mock(return_value=0)
-        calc.get_member_dependency_value = Mock(return_value="NONE")
+        self._pe(calc, medicaid=0, category="NONE")
 
     def _abd(self, calc, qualifies):
-        """PE's is_optional_senior_or_disabled_for_medicaid result for the ABD/senior path."""
-        calc.get_member_dependency_value = Mock(return_value=qualifies)
+        """PE finds the member eligible on the ABD pathway, or not.
+
+        specs/ks.md records that PE returns ``SSI_RECIPIENT`` for every KS ABD scenario, so an
+        ABD-eligible member is medicaid-eligible in PE's eyes too; an ineligible one is neither.
+        ``SSI_RECIPIENT`` carries no aged/disabled distinction of its own, which is exactly why
+        the value tier comes from the member's own age and disability flags.
+        """
+        if qualifies:
+            self._pe(calc, medicaid=1, category="SSI_RECIPIENT", abd=True)
+        else:
+            self._pe(calc, medicaid=0, category="NONE", abd=False)
 
     # --- Scenario 1 & 2: pregnant, low income / near boundary -> PREGNANT $3,648 ---
     def test_s1_pregnant_low_income_eligible(self):

--- a/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/medicaid/tests/test_mo_scenarios.py
@@ -5,16 +5,22 @@ Smoke test for MO Medicaid — proves Missouri's ``medicaid`` pathway resolves e
 ``medicaid`` calculator, so the federal math is already covered by the other states' medicaid
 tests and re-testing it per state would only duplicate them.
 
-This file is a smoke test rather than the per-scenario suite the ``specs/mo.md`` scenarios call
-for. Those scenarios exist and are not yet covered here.
-
-What this does pin is the one thing that is Missouri-specific and could silently break: that
+What this pins first is the one thing that is Missouri-specific and could silently break: that
 Missouri is read as an ACA expansion state, so a childless adult under 138% FPL comes back
 eligible in the ``ADULT`` category rather than $0. That is the distinction between MO and a
 non-expansion state like Kansas, and it is the whole reason the MO state code is wired in.
 
 The value asserted is KFF's ACA-expansion-adult rate, which is what PE's ``ADULT`` category
 maps to in an expansion state, so this also catches a category mapped to the wrong rate.
+
+``TestMoHealthNetValueRouting`` then covers the ``specs/mo.md`` scenarios where PolicyEngine's
+routing and the member's own age/disability flags disagree — the four that production QA found
+mis-valued. They run end to end so the assertion is against PolicyEngine's real answer rather
+than a stub of it; the same four are pinned as stubbed unit tests in ``test_base.py``, which is
+what keeps them covered when a cassette is re-recorded at a newer model version.
+
+The remaining ``specs/mo.md`` scenarios exercise the shared federal MAGI math and are covered by
+the other states' medicaid tests; they are not duplicated here.
 """
 
 import math
@@ -32,7 +38,7 @@ from programs.programs.testing_fixtures.pe_integration import (
     screener_value,
 )
 
-PE_VERSION = "1.794.2"
+PE_VERSION = "1.815.1"
 YEAR = "2026"
 
 
@@ -108,3 +114,77 @@ class TestMoHealthNetSmoke(PeIntegrationTestCase):
 
         self.assertEqual(values[1], MoHealthNet.KFF_EXPANSION_ADULTS)
         self.assertEqual(values[2], MoHealthNet.KFF_CHILDREN)
+
+
+@pytest.mark.integration
+class TestMoHealthNetValueRouting(PeIntegrationTestCase):
+    """specs/mo.md scenarios where PE's category and the member's own flags disagree.
+
+    Missouri's value-priority rule assigns the KFF group from the member's own facts, and PE's
+    routing decides which pathway found them eligible. Each scenario below is a case where
+    reading the aged/disabled pathway ahead of PE's category produced the wrong answer in
+    production: either the disabled rate over an expansion one, or no answer at all.
+    """
+
+    pe_version = PE_VERSION
+
+    def _single_adult(self, screen_id, age, income_type, monthly_amount, **flags):
+        """One-person Cole County household, as Scenarios 6/19/21/24 describe it."""
+        screen = make_screen(
+            screen_id=screen_id,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=1,
+            zipcode="65101",
+            county="Cole County",
+        )
+        member = add_member(screen, member_id=1, relationship="headOfHousehold", age=age, **flags)
+        add_income(member, amount=monthly_amount, income_type=income_type)
+        program = make_program("mo", "mo_medicaid", year=YEAR)
+
+        return calc_pe_program(screen, MoHealthNet, program)
+
+    def test_scenario_6_disabled_adult_over_the_mhabd_standard_falls_through_to_expansion(self):
+        """Scenario 6. Adjusted MHABD income $1,680 exceeds the $1,131 standard, so MHABD is
+        only reachable via spend-down and PE routes them to expansion instead. Gross income is
+        under the $1,836 HH1 expansion ceiling, so they must be shown the expansion value —
+        production returned $0 and dropped the program from results entirely.
+        """
+        eligibility = self._single_adult(10, age=40, income_type="pension", monthly_amount=1_700, disabled=True)
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(screener_value(eligibility), MoHealthNet.KFF_EXPANSION_ADULTS)
+
+    def test_scenario_19_disabled_adult_routed_to_expansion_keeps_the_expansion_value(self):
+        """Scenario 19. Adjusted MHABD income $747 is under the standard, so the aged/disabled
+        pathway does qualify — but PE still routes them to expansion, and PE's routing decides
+        the group. Production applied the disabled rate, overstating by $22,965.
+        """
+        eligibility = self._single_adult(11, age=40, income_type="wages", monthly_amount=1_600, disabled=True)
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(screener_value(eligibility), MoHealthNet.KFF_EXPANSION_ADULTS)
+
+    def test_scenario_21_blind_adult_at_the_mhabd_boundary_keeps_the_expansion_value(self):
+        """Scenario 21. $1,350/mo pension leaves adjusted income at exactly the $1,330 blind
+        non-spend-down standard, reaching the same routing as Scenario 19 through blindness
+        rather than a disability flag.
+        """
+        eligibility = self._single_adult(
+            12, age=46, income_type="pension", monthly_amount=1_350, visually_impaired=True
+        )
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(screener_value(eligibility), MoHealthNet.KFF_EXPANSION_ADULTS)
+
+    def test_scenario_24_disabled_senior_is_valued_at_the_seniors_rate(self):
+        """Scenario 24. KFF defines Seniors as 65+ regardless of disability, so a disabled
+        70-year-old on MHABD is a senior enrollee. Production applied the under-65 disabled
+        rate, overstating by $8,553.
+        """
+        eligibility = self._single_adult(
+            13, age=70, income_type="pension", monthly_amount=1_000, long_term_disability=True
+        )
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(screener_value(eligibility), MoHealthNet.KFF_SENIORS)

--- a/programs/programs/cross_white_label/medicaid/wa.py
+++ b/programs/programs/cross_white_label/medicaid/wa.py
@@ -63,9 +63,7 @@ class WaAppleHealthMedicaid(Medicaid):
                 qualifies = self.get_member_dependency_value(dependency.member.MedicaidSeniorOrDisabled, member.id)
                 if not qualifies:
                     return 0
-                if is_disabled:
-                    return self.medicaid_categories["DISABLED"] * 12
-                return self.medicaid_categories["AGED"] * 12
+                return self.abd_value(is_senior, is_disabled)
 
             # Medicare-entitled, not senior/disabled → ineligible for expansion
             return 0


### PR DESCRIPTION
Resolves MFB-1744.

`Medicaid.member_value` read the aged/disabled (ABD) pathway before PolicyEngine's `medicaid_category`, so PE's own routing was discarded for anyone who tripped `is_senior or is_disabled`. Production QA of MO HealthNet (MFB-1215) scored 29/34 against `specs/mo.md`, and four of the five failures came out of that one branch.

## What production actually returned

Read back from real screens via `?admin=1`, so PE's answer sits next to ours:

| Scenario | Member | PE `medicaid_category` | PE ABD pathway | Shipped | Spec |
|---|---|---|---|---|---|
| 6 | 40, self-reported disabled | `ADULT` | `False` | **$0 — program absent** | $7,445 |
| 19 | 40, self-reported disabled | `ADULT` | `True` | $30,410 | $7,445 |
| 21 | 46, blind | `ADULT` | `True` | $30,410 | $7,445 |
| 24 | 70, long-term disability | `SENIOR_OR_DISABLED` | `True` | $30,410 | $21,857 |

Three distinct defects:

- **`return 0` had no fall-through.** Scenario 6 is the user-visible one — PE found the member eligible under ACA expansion, but a self-reported disability plus a failed ABD test returned 0 and the program vanished from results. A disabled Missourian under 138% FPL who can't meet the ABD standard was shown nothing at all.
- **The branch overrode PE's category when ABD passed**, applying the disabled rate to members PE had routed to expansion — overstating by $22,965 each.
- **`is_disabled` was tested before `is_senior`**, so a 70-year-old took the under-65 disabled rate.

## The change

Consult the ordinary pathway first; the ABD pathway becomes the fallback for the members it doesn't reach.

`SENIOR_OR_DISABLED` and `SSI_RECIPIENT` name no aged/disabled distinction of their own — PE reports both for members it found eligible on an age or disability basis without saying which — so their tier is resolved from the member's own age and disability rather than a rate keyed on the category name. That resolution isn't cosmetic: `SENIOR_OR_DISABLED` has no key in any `medicaid_categories` dict, and production shows it's reachable (it's MO's normal ABD category, not an edge case). Without it, falling through would put those members on the `.get(..., 0)` fallback and drop the program — Scenario 6's failure mode relocated onto 65+ households.

ACA expansion stays a 19–64 group: a member past `aged_min_age` is never valued at an expansion rate, preserving the invariant the previous `return 0` existed to protect. Other MAGI categories have no upper age bound — a 66-year-old can genuinely be a §1931 parent/caretaker — so only the expansion groups are excluded.

## The one judgment call: 65+ *and* disability-eligible

The two committed specs disagree, and each is right about its own source table:

- `specs/ks.md:97` — "a person who is both 65+ and disabled gets the **DISABLED** value ($32,460)", asserted by KS Scenario 19 and by a test.
- `specs/mo.md` value-priority rule — "age 65+ → **Seniors**, even if disability-eligible", KFF's own definition.

So this is `senior_value_takes_precedence`, per state. The default keeps today's disability-first behaviour, and MO opts in. **No state's values move except Missouri's**, and neither spec has to be amended.

## Verification

**Replayed the new routing over PolicyEngine's recorded answers for all 34 MFB-1215 scenarios** — read-only re-reads of the screens that QA run already created, no new production records:

```
shipped: 29/34    with this change: 33/34

  S6:  FAIL -> PASS   0     -> 7445   (want 7445)
  S19: FAIL -> PASS   30410 -> 7445   (want 7445)
  S21: FAIL -> PASS   30410 -> 7445   (want 7445)
  S24: FAIL -> PASS   30410 -> 21857  (want 21857)
```

That replay is also what caught a regression the unit tests missed: an SSI recipient can have no screener disability flag at all, and an earlier draft of `abd_value` then fell through to the aged rate for a 41-year-old, breaking Scenario 13. The aged rate is now reserved for seniors and everything else on that pathway takes the disabled rate; there's a test for that exact shape.

Scenario 8 is the only one still failing. It needs applicant-specific MAGI households (`payload.py` builds one tax unit per screen), which is split out to MFB-1745 and annotated in the spec as a known gap rather than left unexplained.

Full suite under strict replay (`VCR_MODE=none`): **3,822 passed, 5 skipped, 0 failed**.

## Tests

- `test_base.py` rewritten around a shared helper that stubs **both** PE variables. The old per-class mocks stubbed only the one each test was about, which let a test pass against a combination PE would never return — that's how the shipped routing stayed green. Includes the four production regressions as the exact shapes PE returned.
- `test_ks.py`'s ABD helper now models the shape `specs/ks.md` records (PE returns `SSI_RECIPIENT`, so the member is medicaid-eligible in PE's eyes too). All 40 KS tests pass unchanged in intent, including Scenario 19's disability-first assertion.
- `test_mo_scenarios.py` gains the four scenarios end to end against real PE responses.
- `wa.py`'s duplicated copy of the branch now calls the shared `abd_value`; WA keeps the default, so its behaviour is unchanged.

## Also here

- **`specs/mo.md` committed** — it existed only as a ticket attachment, unlike `ks.md` and `wa.md`. Its acceptance criteria now record **33 of 34** scenarios passing, naming Scenario 8 as the accepted exception and marking the applicant-specific-household criterion it tests as not met today. Worth a look as its own decision: the spec now formally accepts the gap rather than asserting something the platform cannot do.
- **MO cassettes re-recorded at PE 1.815.1.** Not optional: PE no longer serves 1.794.2 (`current: 1.815.1`, `frontier: 1.821.2`), so new cassettes couldn't be recorded against the old pin. The three existing assertions are unchanged at the new version. Other MO programs still pin 1.794.2 and are left alone.

## Reviewer notes

- Blast radius is every Medicaid white label (`co` `il` `ks` `ma` `nc` `wa` `mo`) since they share the branch. The per-state flag keeps values still for the six, but the fall-through does change one thing everywhere: in expansion states a disabled adult who fails ABD but clears expansion now sees the program where they previously saw nothing. That's the Scenario 6 fix, and it's user-visible.
- Re-recording any of these cassettes needs a local Redis (`redis-server --daemonize yes`). `PE_RECORD=1` skips the placeholder-token seed, so the real bearer token is written to the Django cache and the run dies on `Error 61 connecting to 127.0.0.1:6379` before it ever reaches PolicyEngine — which reads as a PE problem and is not one.
- MFB-1744's "decide whether the `has_disability()` / `sSDisability` split is intended" is untouched — `has_disability()` still reads only the three screener flags. It no longer causes a value discrepancy, since both routes now defer to PE's category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Medicaid benefit value routing for aged, blind, disabled, and expansion-eligible individuals.
  * Missouri Medicaid now values seniors at the senior rate, including those who are also disability-eligible.
  * Added comprehensive Missouri Medicaid eligibility documentation and scenario coverage.

* **Bug Fixes**
  * Disabled and blind adults who qualify through expansion now retain the correct expansion value.
  * Prevented seniors from being incorrectly priced through expansion categories.
  * Standardized aged/blind/disabled valuation across applicable state programs.

* **Tests**
  * Expanded regression and integration coverage for Medicaid eligibility and valuation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
