### PR TITLE
Materialize the FPL thresholds into a table analytics can read [MFB-1182]

### DIFF
--- a/.github/actions/heroku-migrations/action.yml
+++ b/.github/actions/heroku-migrations/action.yml
@@ -45,6 +45,30 @@ runs:
           exit $STATUS
         fi
 
+    - name: Sync FPL values
+      id: fpl-values
+      shell: bash
+      env:
+        HEROKU_API_KEY: ${{ inputs.heroku-api-key }}
+      run: |
+        # FederalPovertyLimitValue mirrors the _FPL_DEFAULTS constant into a table
+        # so SQL-only consumers (the analytics pipeline) can compute a
+        # percent-of-FPL band. Migration 0173 does the initial fill, but a
+        # migration only runs once -- adding a year to the constant later would
+        # leave the table behind, and the dashboard would band households against
+        # stale thresholds. Syncing on every deploy means that cannot be
+        # forgotten. Idempotent: a no-op when nothing changed.
+        echo "Syncing FPL values..."
+        set +e
+        OUTPUT=$(heroku run --exit-code -a ${{ inputs.heroku-app-name }} "python manage.py sync_fpl_values" 2>&1)
+        STATUS=$?
+        set -e
+        echo "$OUTPUT"
+
+        if [ $STATUS -ne 0 ]; then
+          exit $STATUS
+        fi
+
     - name: Sync feature flags
       id: feature-flags
       shell: bash

--- a/programs/fpl_values.py
+++ b/programs/fpl_values.py
@@ -1,26 +1,13 @@
-"""Materialize the FPL table into the database so SQL-only consumers can read it.
+"""Sync the FederalPovertyLimitValue mirror from the _FPL_DEFAULTS constant.
 
-The thresholds themselves live in `_FPL_DEFAULTS`, a module constant in
-programs.models, and `FederalPoveryLimit` stores only a year and a period that
-point into it. That is fine for the calculators, which go through
-`FederalPoveryLimit.get_limit()` in Python, but it leaves anything that can only
-read the database with no way to compute a percent-of-FPL figure -- the analytics
-pipeline (dbt over Postgres, feeding Metabase) among them.
-
-This module writes `get_limit()`'s output to `FederalPovertyLimitValue`, one row
-per (period, household size). It is deliberately a mirror, not a new source of
-truth: the constant stays authoritative, the calculators keep reading it, and a
-test asserts the two agree so they cannot drift silently.
-
-Sizes above `MAX_DEFINED_SIZE` are extrapolated exactly as `get_limit()` does,
-up to `MAX_MATERIALIZED_SIZE`, so a consumer joining on household size never has
-to reimplement the per-additional-person arithmetic.
+See the FederalPovertyLimitValue docstring in programs/models.py for why the
+mirror exists and what it guarantees to consumers.
 """
 
 from typing import Optional, Type
 
-# Imported lazily inside the functions so a data migration can hand in its own
-# historical model class via apps.get_model().
+# Largest household size given a row. Consumers must clamp to this; see the
+# CONTRACT WITH CONSUMERS note on the model.
 MAX_MATERIALIZED_SIZE = 20
 
 
@@ -31,6 +18,8 @@ def limits_for_period(table: dict, max_size: int = MAX_MATERIALIZED_SIZE) -> dic
     the per-additional-person amount once per extra member.
     """
     defined = sorted(size for size in table if isinstance(size, int))
+    if not defined:
+        raise ValueError("FPL table defines no household sizes; cannot expand it.")
     largest_defined = defined[-1]
 
     limits = {size: table[size] for size in defined}
@@ -44,11 +33,16 @@ def sync_fpl_values(
     value_model: Optional[Type] = None,
     fpl_table: Optional[dict] = None,
     max_size: int = MAX_MATERIALIZED_SIZE,
+    dry_run: bool = False,
 ) -> dict[str, int]:
     """Upsert one row per (period, household size). Idempotent.
 
     Returns a {created, updated, deleted} count so the management command and the
     migration can report what they did.
+
+    `dry_run` returns the same counts without writing. The diff is computed once
+    either way -- a separate preview implementation would drift from the real one
+    and start lying about what a sync would do.
 
     `value_model` and `fpl_table` are injectable so a data migration can pass the
     historical model from apps.get_model() rather than importing the live one.
@@ -76,22 +70,24 @@ def sync_fpl_values(
     for (period, household_size), annual_limit in wanted.items():
         row = existing.get((period, household_size))
         if row is None:
-            value_model.objects.create(
-                period=period,
-                household_size=household_size,
-                annual_limit=annual_limit,
-            )
             created += 1
+            if not dry_run:
+                value_model.objects.create(
+                    period=period,
+                    household_size=household_size,
+                    annual_limit=annual_limit,
+                )
         elif row.annual_limit != annual_limit:
-            row.annual_limit = annual_limit
-            row.save(update_fields=["annual_limit"])
             updated += 1
+            if not dry_run:
+                row.annual_limit = annual_limit
+                row.save(update_fields=["annual_limit"])
 
     # Drop rows for periods or sizes the constant no longer defines, so a removed
     # year cannot linger and be joined against.
     stale = [row.pk for key, row in existing.items() if key not in wanted]
     deleted = len(stale)
-    if stale:
+    if stale and not dry_run:
         value_model.objects.filter(pk__in=stale).delete()
 
     return {"created": created, "updated": updated, "deleted": deleted}

--- a/programs/fpl_values.py
+++ b/programs/fpl_values.py
@@ -1,0 +1,97 @@
+"""Materialize the FPL table into the database so SQL-only consumers can read it.
+
+The thresholds themselves live in `_FPL_DEFAULTS`, a module constant in
+programs.models, and `FederalPoveryLimit` stores only a year and a period that
+point into it. That is fine for the calculators, which go through
+`FederalPoveryLimit.get_limit()` in Python, but it leaves anything that can only
+read the database with no way to compute a percent-of-FPL figure -- the analytics
+pipeline (dbt over Postgres, feeding Metabase) among them.
+
+This module writes `get_limit()`'s output to `FederalPovertyLimitValue`, one row
+per (period, household size). It is deliberately a mirror, not a new source of
+truth: the constant stays authoritative, the calculators keep reading it, and a
+test asserts the two agree so they cannot drift silently.
+
+Sizes above `MAX_DEFINED_SIZE` are extrapolated exactly as `get_limit()` does,
+up to `MAX_MATERIALIZED_SIZE`, so a consumer joining on household size never has
+to reimplement the per-additional-person arithmetic.
+"""
+
+from typing import Optional, Type
+
+# Imported lazily inside the functions so a data migration can hand in its own
+# historical model class via apps.get_model().
+MAX_MATERIALIZED_SIZE = 20
+
+
+def limits_for_period(table: dict, max_size: int = MAX_MATERIALIZED_SIZE) -> dict[int, int]:
+    """Expand one year's FPL table to a flat {household_size: annual_limit} map.
+
+    Mirrors FederalPoveryLimit.get_limit(): sizes past the last defined one add
+    the per-additional-person amount once per extra member.
+    """
+    defined = sorted(size for size in table if isinstance(size, int))
+    largest_defined = defined[-1]
+
+    limits = {size: table[size] for size in defined}
+    for size in range(largest_defined + 1, max_size + 1):
+        limits[size] = table[largest_defined] + table["additional"] * (size - largest_defined)
+
+    return limits
+
+
+def sync_fpl_values(
+    value_model: Optional[Type] = None,
+    fpl_table: Optional[dict] = None,
+    max_size: int = MAX_MATERIALIZED_SIZE,
+) -> dict[str, int]:
+    """Upsert one row per (period, household size). Idempotent.
+
+    Returns a {created, updated, deleted} count so the management command and the
+    migration can report what they did.
+
+    `value_model` and `fpl_table` are injectable so a data migration can pass the
+    historical model from apps.get_model() rather than importing the live one.
+    """
+    if value_model is None:
+        from programs.models import FederalPovertyLimitValue
+
+        value_model = FederalPovertyLimitValue
+
+    if fpl_table is None:
+        from programs.models import _get_fpl_data
+
+        fpl_table = _get_fpl_data()
+
+    wanted: dict[tuple[str, int], int] = {}
+    for period, table in fpl_table.items():
+        for household_size, annual_limit in limits_for_period(table, max_size).items():
+            wanted[(period, household_size)] = annual_limit
+
+    existing = {(row.period, row.household_size): row for row in value_model.objects.all()}
+
+    created = 0
+    updated = 0
+
+    for (period, household_size), annual_limit in wanted.items():
+        row = existing.get((period, household_size))
+        if row is None:
+            value_model.objects.create(
+                period=period,
+                household_size=household_size,
+                annual_limit=annual_limit,
+            )
+            created += 1
+        elif row.annual_limit != annual_limit:
+            row.annual_limit = annual_limit
+            row.save(update_fields=["annual_limit"])
+            updated += 1
+
+    # Drop rows for periods or sizes the constant no longer defines, so a removed
+    # year cannot linger and be joined against.
+    stale = [row.pk for key, row in existing.items() if key not in wanted]
+    deleted = len(stale)
+    if stale:
+        value_model.objects.filter(pk__in=stale).delete()
+
+    return {"created": created, "updated": updated, "deleted": deleted}

--- a/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
+++ b/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
@@ -312,8 +312,40 @@ class TestTheConflictReport(PayloadConflictTestBase):
         )
 
         report = plan.conflicts[0]
-        self.assertNotIn("40", report)
-        self.assertNotIn("41", report)
+        # Word-boundary match, not a substring: the report names the entity as
+        # people/<pk>, and a primary key like 404 contains "40". A bare
+        # assertNotIn passes or fails on whatever id the sequence happened to
+        # hand out, which varies with how xdist distributes the suite -- so it
+        # would fail for a reason that has nothing to do with a leaked age.
+        self.assertNotRegex(report, r"\b40\b")
+        self.assertNotRegex(report, r"\b41\b")
+
+    def test_an_id_containing_the_age_does_not_look_like_a_leak(self):
+        """Regression: the privacy check must key on values, not on digits anywhere.
+
+        The report names the entity as people/<pk>. A member whose pk contains 40
+        -- 404, 1400, 40 itself -- used to trip the substring assertion, so the
+        test failed or passed depending on what the sequence handed out, which
+        shifts whenever xdist redistributes the suite.
+        """
+        self.head.delete()
+        self.head = HouseholdMember.objects.create(id=404, screen=self.screen, relationship="headOfHousehold", age=40)
+        self.head_id = str(self.head.id)
+
+        plan = build_pe_input(
+            self.screen,
+            [fake_program("wants_forty", [FortyYearOld]), fake_program("wants_forty_one", [FortyOneYearOld])],
+        )
+
+        report = plan.conflicts[0]
+        self.assertIn("people/404", report, "precondition: the id must be in the report")
+        self.assertNotRegex(report, r"\b40\b")
+        self.assertNotRegex(report, r"\b41\b")
+
+    def test_the_privacy_check_would_catch_a_real_leak(self):
+        """Guards the guard: \b40\b has to still match an age printed as a value."""
+        self.assertRegex("age at 2026 for people/7: 40 vs 41", r"\b40\b")
+        self.assertRegex("age at 2026 for people/7: 40 vs 41", r"\b41\b")
 
     def test_an_agreeing_screen_reports_nothing(self):
         plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld])])

--- a/programs/management/commands/sync_fpl_values.py
+++ b/programs/management/commands/sync_fpl_values.py
@@ -1,0 +1,48 @@
+from django.core.management.base import BaseCommand
+
+from programs.fpl_values import sync_fpl_values
+
+
+class Command(BaseCommand):
+    help = (
+        "Rewrite the FederalPovertyLimitValue table from the _FPL_DEFAULTS constant. "
+        "Run this after adding a year to the constant so SQL-only consumers (the "
+        "analytics pipeline) see the new thresholds. Idempotent."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything.",
+        )
+
+    def handle(self, *args, **options):
+        if options["dry_run"]:
+            from programs.fpl_values import MAX_MATERIALIZED_SIZE, limits_for_period
+            from programs.models import FederalPovertyLimitValue, _get_fpl_data
+
+            wanted = {
+                (period, size): limit
+                for period, table in _get_fpl_data().items()
+                for size, limit in limits_for_period(table, MAX_MATERIALIZED_SIZE).items()
+            }
+            existing = {
+                (row.period, row.household_size): row.annual_limit for row in FederalPovertyLimitValue.objects.all()
+            }
+
+            created = sum(1 for key in wanted if key not in existing)
+            updated = sum(1 for key, limit in wanted.items() if key in existing and existing[key] != limit)
+            deleted = sum(1 for key in existing if key not in wanted)
+
+            self.stdout.write(f"Would create {created}, update {updated}, delete {deleted} row(s).")
+            return
+
+        counts = sync_fpl_values()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"FPL values synced: {counts['created']} created, "
+                f"{counts['updated']} updated, {counts['deleted']} deleted."
+            )
+        )

--- a/programs/management/commands/sync_fpl_values.py
+++ b/programs/management/commands/sync_fpl_values.py
@@ -6,43 +6,33 @@ from programs.fpl_values import sync_fpl_values
 class Command(BaseCommand):
     help = (
         "Rewrite the FederalPovertyLimitValue table from the _FPL_DEFAULTS constant. "
-        "Run this after adding a year to the constant so SQL-only consumers (the "
-        "analytics pipeline) see the new thresholds. Idempotent."
+        "Runs on deploy; run it by hand after adding a year to the constant outside "
+        "a release. Idempotent. --dry-run reports the diff and exits non-zero if the "
+        "table is out of date, so it can be used as a drift check."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Report what would change without writing anything.",
+            help="Report what would change without writing. Exits 1 if anything would change.",
         )
 
     def handle(self, *args, **options):
-        if options["dry_run"]:
-            from programs.fpl_values import MAX_MATERIALIZED_SIZE, limits_for_period
-            from programs.models import FederalPovertyLimitValue, _get_fpl_data
+        dry_run = options["dry_run"]
+        counts = sync_fpl_values(dry_run=dry_run)
+        changed = counts["created"] + counts["updated"] + counts["deleted"]
+        summary = f"{counts['created']} created, {counts['updated']} updated, {counts['deleted']} deleted"
 
-            wanted = {
-                (period, size): limit
-                for period, table in _get_fpl_data().items()
-                for size, limit in limits_for_period(table, MAX_MATERIALIZED_SIZE).items()
-            }
-            existing = {
-                (row.period, row.household_size): row.annual_limit for row in FederalPovertyLimitValue.objects.all()
-            }
-
-            created = sum(1 for key in wanted if key not in existing)
-            updated = sum(1 for key, limit in wanted.items() if key in existing and existing[key] != limit)
-            deleted = sum(1 for key in existing if key not in wanted)
-
-            self.stdout.write(f"Would create {created}, update {updated}, delete {deleted} row(s).")
+        if not dry_run:
+            self.stdout.write(self.style.SUCCESS(f"FPL values synced: {summary}."))
             return
 
-        counts = sync_fpl_values()
+        if changed:
+            # Non-zero so this can be wired up as a drift alarm. A table that is out
+            # of date means the dashboard is banding households against stale
+            # thresholds, which is a wrong number rather than a missing one.
+            self.stderr.write(self.style.ERROR(f"FPL values are OUT OF DATE: would be {summary}."))
+            raise SystemExit(1)
 
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"FPL values synced: {counts['created']} created, "
-                f"{counts['updated']} updated, {counts['deleted']} deleted."
-            )
-        )
+        self.stdout.write(self.style.SUCCESS("FPL values are up to date."))

--- a/programs/migrations/0171_federal_poverty_limit_value.py
+++ b/programs/migrations/0171_federal_poverty_limit_value.py
@@ -1,0 +1,68 @@
+from django.db import migrations, models
+
+from programs.fpl_values import MAX_MATERIALIZED_SIZE, limits_for_period
+
+
+# The FPL thresholds live in the _FPL_DEFAULTS constant in programs/models.py;
+# FederalPoveryLimit stores only a year and a period pointing into it. That works for
+# the calculators, which resolve limits in Python through get_limit(), but it means
+# anything reading the database alone -- the dbt/Metabase analytics pipeline -- cannot
+# compute a percent-of-FPL band. MFB-1182 needs exactly that, to segment the CESN
+# dashboard by income without ever exposing a household's actual income.
+#
+# This creates the mirror table and fills it from the constant. Nothing about the
+# eligibility path changes: get_limit() and as_dict() still read the constant, and a
+# test asserts the table reproduces get_limit() for every period and size so the two
+# cannot drift. When a new year is added to the constant, `manage.py sync_fpl_values`
+# brings the table forward -- this migration is the initial fill, not the mechanism.
+#
+# The constant is imported here rather than inlined. A data migration that reads app
+# code is normally a smell, because the code can change under a migration that already
+# ran. It is safe in this direction: the table is a derived mirror, re-running the sync
+# is idempotent, and the parity test fails loudly if the two ever disagree.
+def populate(apps, schema_editor):
+    from programs.models import _get_fpl_data
+
+    FederalPovertyLimitValue = apps.get_model("programs", "FederalPovertyLimitValue")
+
+    rows = [
+        FederalPovertyLimitValue(period=period, household_size=size, annual_limit=limit)
+        for period, table in _get_fpl_data().items()
+        for size, limit in limits_for_period(table, MAX_MATERIALIZED_SIZE).items()
+    ]
+
+    FederalPovertyLimitValue.objects.bulk_create(rows, ignore_conflicts=True)
+    print(f"✅ materialized {len(rows)} FPL threshold rows")
+
+
+def clear(apps, schema_editor):
+    FederalPovertyLimitValue = apps.get_model("programs", "FederalPovertyLimitValue")
+    FederalPovertyLimitValue.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("programs", "0170_deactivate_il_rent_asst"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FederalPovertyLimitValue",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("period", models.CharField(db_index=True, max_length=32)),
+                ("household_size", models.PositiveSmallIntegerField()),
+                ("annual_limit", models.PositiveIntegerField()),
+            ],
+            options={
+                "ordering": ("period", "household_size"),
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="federalpovertylimitvalue",
+            constraint=models.UniqueConstraint(
+                fields=("period", "household_size"), name="unique_fpl_value_per_size"
+            ),
+        ),
+        migrations.RunPython(populate, clear),
+    ]

--- a/programs/migrations/0173_federal_poverty_limit_value.py
+++ b/programs/migrations/0173_federal_poverty_limit_value.py
@@ -3,23 +3,13 @@ from django.db import migrations, models
 from programs.fpl_values import MAX_MATERIALIZED_SIZE, limits_for_period
 
 
-# The FPL thresholds live in the _FPL_DEFAULTS constant in programs/models.py;
-# FederalPoveryLimit stores only a year and a period pointing into it. That works for
-# the calculators, which resolve limits in Python through get_limit(), but it means
-# anything reading the database alone -- the dbt/Metabase analytics pipeline -- cannot
-# compute a percent-of-FPL band. MFB-1182 needs exactly that, to segment the CESN
-# dashboard by income without ever exposing a household's actual income.
+# Creates the FederalPovertyLimitValue mirror and does its initial fill. See the
+# model docstring for why it exists; MFB-1182 needs it to band the CESN dashboard
+# by income without exposing a household's actual income.
 #
-# This creates the mirror table and fills it from the constant. Nothing about the
-# eligibility path changes: get_limit() and as_dict() still read the constant, and a
-# test asserts the table reproduces get_limit() for every period and size so the two
-# cannot drift. When a new year is added to the constant, `manage.py sync_fpl_values`
-# brings the table forward -- this migration is the initial fill, not the mechanism.
-#
-# The constant is imported here rather than inlined. A data migration that reads app
-# code is normally a smell, because the code can change under a migration that already
-# ran. It is safe in this direction: the table is a derived mirror, re-running the sync
-# is idempotent, and the parity test fails loudly if the two ever disagree.
+# A migration runs once, so it is the initial fill and not the mechanism: the
+# deploy runs `manage.py sync_fpl_values` on every release to keep the table
+# current as years are added to the constant.
 def populate(apps, schema_editor):
     from programs.models import _get_fpl_data
 
@@ -31,7 +21,7 @@ def populate(apps, schema_editor):
         for size, limit in limits_for_period(table, MAX_MATERIALIZED_SIZE).items()
     ]
 
-    FederalPovertyLimitValue.objects.bulk_create(rows, ignore_conflicts=True)
+    FederalPovertyLimitValue.objects.bulk_create(rows)
     print(f"✅ materialized {len(rows)} FPL threshold rows")
 
 
@@ -42,7 +32,7 @@ def clear(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("programs", "0170_deactivate_il_rent_asst"),
+        ("programs", "0172_consolidate_shared_program_categories"),
     ]
 
     operations = [

--- a/programs/models.py
+++ b/programs/models.py
@@ -99,19 +99,35 @@ class FederalPoveryLimit(models.Model):
 class FederalPovertyLimitValue(models.Model):
     """A database mirror of FederalPoveryLimit.get_limit(), one row per size.
 
-    FederalPoveryLimit stores a year and a period; the dollar thresholds live in
-    the _FPL_DEFAULTS constant above, so a consumer that can only read the
-    database -- the dbt/Metabase analytics pipeline -- cannot compute a
-    percent-of-FPL band. This table exists for those consumers.
+    The canonical explanation of this table lives here; other modules point back
+    rather than restate it.
 
-    It is a mirror, not a second source of truth. The constant stays
-    authoritative and the calculators keep reading it through get_limit();
-    programs.fpl_values.sync_fpl_values() rewrites this table from the constant,
-    and a test asserts the two agree so they cannot drift apart unnoticed. If you
-    add a year to _FPL_DEFAULTS, run `manage.py sync_fpl_values`.
+    WHY: FederalPoveryLimit stores a year and a period, while the dollar
+    thresholds live in the _FPL_DEFAULTS constant above. A consumer that can only
+    read the database -- the dbt/Metabase analytics pipeline -- therefore cannot
+    compute a percent-of-FPL band. This table is for those consumers.
 
-    Sizes beyond MAX_DEFINED_SIZE are materialized with the per-additional-person
-    amount already applied, so joins do not have to reimplement that arithmetic.
+    NOT A SECOND SOURCE OF TRUTH: the constant stays authoritative and the
+    calculators keep reading it through get_limit(). sync_fpl_values() rewrites
+    this table from the constant and runs on every deploy, so adding a year to
+    the constant cannot leave the table behind. Unit tests verify sync produces a
+    table matching get_limit(); they cannot verify a given environment has been
+    synced, which is why the deploy hook rather than the tests is what keeps prod
+    honest.
+
+    CONTRACT WITH CONSUMERS:
+      * Sizes beyond MAX_DEFINED_SIZE are materialized with the
+        per-additional-person amount already applied, so a join does not have to
+        reimplement that arithmetic.
+      * Rows stop at fpl_values.MAX_MATERIALIZED_SIZE. get_limit() extrapolates
+        without limit, so a household larger than the cap has no row. Consumers
+        must clamp to the largest available size rather than joining loosely and
+        reading a NULL as "no band". The dbt bridge model does this.
+      * Keyed on `period`, deliberately not a FK. FederalPoveryLimit.period is
+        not unique (only `year` is), so there is no single row to point at, and
+        an analytics mirror should not gain a write-path constraint. The cost is
+        that a FederalPoveryLimit whose period has no rows here is possible;
+        as_dict() already raises KeyError for that case.
     """
 
     period = models.CharField(max_length=32, db_index=True)

--- a/programs/models.py
+++ b/programs/models.py
@@ -96,6 +96,38 @@ class FederalPoveryLimit(models.Model):
         return self.year
 
 
+class FederalPovertyLimitValue(models.Model):
+    """A database mirror of FederalPoveryLimit.get_limit(), one row per size.
+
+    FederalPoveryLimit stores a year and a period; the dollar thresholds live in
+    the _FPL_DEFAULTS constant above, so a consumer that can only read the
+    database -- the dbt/Metabase analytics pipeline -- cannot compute a
+    percent-of-FPL band. This table exists for those consumers.
+
+    It is a mirror, not a second source of truth. The constant stays
+    authoritative and the calculators keep reading it through get_limit();
+    programs.fpl_values.sync_fpl_values() rewrites this table from the constant,
+    and a test asserts the two agree so they cannot drift apart unnoticed. If you
+    add a year to _FPL_DEFAULTS, run `manage.py sync_fpl_values`.
+
+    Sizes beyond MAX_DEFINED_SIZE are materialized with the per-additional-person
+    amount already applied, so joins do not have to reimplement that arithmetic.
+    """
+
+    period = models.CharField(max_length=32, db_index=True)
+    household_size = models.PositiveSmallIntegerField()
+    annual_limit = models.PositiveIntegerField()
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["period", "household_size"], name="unique_fpl_value_per_size"),
+        ]
+        ordering = ("period", "household_size")
+
+    def __str__(self):
+        return f"{self.period} / {self.household_size} person: ${self.annual_limit:,}"
+
+
 class LegalStatus(models.Model):
     status = models.CharField(max_length=256)
     parent = models.ForeignKey(

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -1,6 +1,8 @@
+from importlib import import_module
 from io import StringIO
 from unittest.mock import patch
 
+from django.apps import apps as global_apps
 from django.core.management import call_command
 from django.db.utils import IntegrityError
 from django.test import SimpleTestCase, TestCase
@@ -112,10 +114,33 @@ class FederalPovertyLimitValueTests(TestCase):
     _FPL_DEFAULTS, so the risk it introduces is drift: someone adds a year to the
     constant and the table silently keeps answering with the old one. These tests
     are what make that a CI failure instead of a wrong number on a dashboard.
+
+    setUp syncs the table rather than relying on migration 0171 having filled it:
+    pytest.ini runs with --nomigrations, so pytest-django builds the schema from
+    the models and never executes a RunPython. Depending on the migration here
+    would pass under `manage.py test` and fail in CI. The migration's own
+    populate() is covered separately below, by calling it directly.
     """
 
-    def test_migration_populated_every_period_and_size(self):
+    def setUp(self):
+        sync_fpl_values()
+
+    def test_sync_populates_every_period_and_size(self):
         expected = len(_FPL_DEFAULTS) * MAX_MATERIALIZED_SIZE
+
+        self.assertEqual(FederalPovertyLimitValue.objects.count(), expected)
+
+    def test_migration_populate_fills_the_table(self):
+        """Covers migration 0171's RunPython, which --nomigrations skips.
+
+        This is what fills the table on a real deploy, so it needs a test that
+        does not depend on the migration runner having run.
+        """
+        expected = len(_FPL_DEFAULTS) * MAX_MATERIALIZED_SIZE
+        FederalPovertyLimitValue.objects.all().delete()
+        migration = import_module("programs.migrations.0171_federal_poverty_limit_value")
+
+        migration.populate(global_apps, None)
 
         self.assertEqual(FederalPovertyLimitValue.objects.count(), expected)
 

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -7,7 +7,7 @@ from django.core.management import call_command
 from django.db.utils import IntegrityError
 from django.test import SimpleTestCase, TestCase
 
-from programs.fpl_values import MAX_MATERIALIZED_SIZE, sync_fpl_values
+from programs.fpl_values import MAX_MATERIALIZED_SIZE, limits_for_period, sync_fpl_values
 from programs.models import (
     _FPL_DEFAULTS,
     FederalPoveryLimit,
@@ -108,18 +108,16 @@ class FederalPovertyLimitTests(SimpleTestCase):
 class FederalPovertyLimitValueTests(TestCase):
     """The materialized FPL table must reproduce get_limit() exactly.
 
-    FederalPovertyLimitValue exists so SQL-only consumers (the dbt/Metabase
-    analytics pipeline) can compute a percent-of-FPL band, which they cannot do
-    while the thresholds live only in a Python constant. It is a mirror of
-    _FPL_DEFAULTS, so the risk it introduces is drift: someone adds a year to the
-    constant and the table silently keeps answering with the old one. These tests
-    are what make that a CI failure instead of a wrong number on a dashboard.
+    These verify that sync_fpl_values() produces a table matching get_limit().
+    They deliberately do NOT claim to catch a given environment drifting out of
+    sync -- CI builds a fresh database and syncs it here, so it can never observe
+    prod's state. Keeping prod current is the deploy hook's job (see the Sync FPL
+    values step in .github/actions/heroku-migrations), with
+    `sync_fpl_values --dry-run` available as a drift check that exits non-zero.
 
-    setUp syncs the table rather than relying on migration 0171 having filled it:
-    pytest.ini runs with --nomigrations, so pytest-django builds the schema from
-    the models and never executes a RunPython. Depending on the migration here
-    would pass under `manage.py test` and fail in CI. The migration's own
-    populate() is covered separately below, by calling it directly.
+    setUp syncs rather than relying on migration 0173: pytest.ini runs with
+    --nomigrations, so pytest-django builds the schema from the models and never
+    executes a RunPython. The migration's own populate() is covered separately.
     """
 
     def setUp(self):
@@ -138,7 +136,7 @@ class FederalPovertyLimitValueTests(TestCase):
         """
         expected = len(_FPL_DEFAULTS) * MAX_MATERIALIZED_SIZE
         FederalPovertyLimitValue.objects.all().delete()
-        migration = import_module("programs.migrations.0171_federal_poverty_limit_value")
+        migration = import_module("programs.migrations.0173_federal_poverty_limit_value")
 
         migration.populate(global_apps, None)
 
@@ -188,6 +186,11 @@ class FederalPovertyLimitValueTests(TestCase):
         with self.assertRaises(IntegrityError):
             FederalPovertyLimitValue.objects.create(period="2026", household_size=4, annual_limit=1)
 
+    def test_expanding_a_table_with_no_sizes_raises(self):
+        """defined[-1] would otherwise be an IndexError on a malformed table."""
+        with self.assertRaises(ValueError):
+            limits_for_period({"additional": 5_000})
+
     def test_command_reports_a_clean_sync(self):
         out = StringIO()
 
@@ -195,14 +198,51 @@ class FederalPovertyLimitValueTests(TestCase):
 
         self.assertIn("0 created, 0 updated, 0 deleted", out.getvalue())
 
-    def test_dry_run_reports_drift_without_writing(self):
+    def test_dry_run_reports_drift_and_exits_non_zero(self):
+        """--dry-run is usable as a drift alarm, so drift must fail the command."""
         row = FederalPovertyLimitValue.objects.get(period="2026", household_size=4)
         row.annual_limit = 1
         row.save(update_fields=["annual_limit"])
+        err = StringIO()
+
+        with self.assertRaises(SystemExit) as raised:
+            call_command("sync_fpl_values", "--dry-run", stderr=err)
+        row.refresh_from_db()
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("OUT OF DATE", err.getvalue())
+        self.assertEqual(row.annual_limit, 1, "dry run must not write")
+
+    def test_dry_run_is_quiet_and_succeeds_when_in_sync(self):
         out = StringIO()
 
         call_command("sync_fpl_values", "--dry-run", stdout=out)
-        row.refresh_from_db()
 
-        self.assertIn("update 1", out.getvalue())
-        self.assertEqual(row.annual_limit, 1, "dry run must not write")
+        self.assertIn("up to date", out.getvalue())
+
+    def test_dry_run_counts_match_a_real_sync(self):
+        """The preview and the write share one diff, so they cannot disagree.
+
+        A separate preview implementation would drift from the real one and start
+        lying about what a sync would do -- the point of threading dry_run through
+        sync_fpl_values rather than recomputing the diff in the command.
+        """
+        FederalPovertyLimitValue.objects.filter(period="2026", household_size__in=[4, 5]).delete()
+        row = FederalPovertyLimitValue.objects.get(period="2025", household_size=1)
+        row.annual_limit = 1
+        row.save(update_fields=["annual_limit"])
+        FederalPovertyLimitValue.objects.create(period="1999", household_size=1, annual_limit=1)
+
+        previewed = sync_fpl_values(dry_run=True)
+        actual = sync_fpl_values()
+
+        self.assertEqual(previewed, {"created": 2, "updated": 1, "deleted": 1})
+        self.assertEqual(previewed, actual)
+
+    def test_dry_run_writes_nothing(self):
+        FederalPovertyLimitValue.objects.filter(period="2026").delete()
+        before = FederalPovertyLimitValue.objects.count()
+
+        sync_fpl_values(dry_run=True)
+
+        self.assertEqual(FederalPovertyLimitValue.objects.count(), before)

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -1,8 +1,18 @@
+from io import StringIO
 from unittest.mock import patch
 
+from django.core.management import call_command
+from django.db.utils import IntegrityError
 from django.test import SimpleTestCase, TestCase
 
-from programs.models import _FPL_DEFAULTS, FederalPoveryLimit, Program, _get_fpl_data
+from programs.fpl_values import MAX_MATERIALIZED_SIZE, sync_fpl_values
+from programs.models import (
+    _FPL_DEFAULTS,
+    FederalPoveryLimit,
+    FederalPovertyLimitValue,
+    Program,
+    _get_fpl_data,
+)
 from screener.models import WhiteLabel
 
 
@@ -91,3 +101,83 @@ class FederalPovertyLimitTests(SimpleTestCase):
                     list(range(1, FederalPoveryLimit.MAX_DEFINED_SIZE + 1)),
                 )
                 self.assertIn("additional", table)
+
+
+class FederalPovertyLimitValueTests(TestCase):
+    """The materialized FPL table must reproduce get_limit() exactly.
+
+    FederalPovertyLimitValue exists so SQL-only consumers (the dbt/Metabase
+    analytics pipeline) can compute a percent-of-FPL band, which they cannot do
+    while the thresholds live only in a Python constant. It is a mirror of
+    _FPL_DEFAULTS, so the risk it introduces is drift: someone adds a year to the
+    constant and the table silently keeps answering with the old one. These tests
+    are what make that a CI failure instead of a wrong number on a dashboard.
+    """
+
+    def test_migration_populated_every_period_and_size(self):
+        expected = len(_FPL_DEFAULTS) * MAX_MATERIALIZED_SIZE
+
+        self.assertEqual(FederalPovertyLimitValue.objects.count(), expected)
+
+    def test_every_row_matches_get_limit(self):
+        """The mirror agrees with the calculators' own lookup, size by size."""
+        for period in _FPL_DEFAULTS:
+            fpl = FederalPoveryLimit(year=period, period=period)
+            for size in range(1, MAX_MATERIALIZED_SIZE + 1):
+                with self.subTest(period=period, household_size=size):
+                    row = FederalPovertyLimitValue.objects.get(period=period, household_size=size)
+                    self.assertEqual(row.annual_limit, fpl.get_limit(size))
+
+    def test_sync_is_idempotent(self):
+        counts = sync_fpl_values()
+
+        self.assertEqual(counts, {"created": 0, "updated": 0, "deleted": 0})
+
+    def test_sync_repairs_a_drifted_row(self):
+        row = FederalPovertyLimitValue.objects.get(period="2026", household_size=4)
+        row.annual_limit = 1
+        row.save(update_fields=["annual_limit"])
+
+        counts = sync_fpl_values()
+        row.refresh_from_db()
+
+        self.assertEqual(counts["updated"], 1)
+        self.assertEqual(row.annual_limit, _FPL_DEFAULTS["2026"][4])
+
+    def test_sync_removes_a_period_no_longer_in_the_constant(self):
+        FederalPovertyLimitValue.objects.create(period="1999", household_size=1, annual_limit=1)
+
+        counts = sync_fpl_values()
+
+        self.assertEqual(counts["deleted"], 1)
+        self.assertFalse(FederalPovertyLimitValue.objects.filter(period="1999").exists())
+
+    def test_extrapolated_sizes_apply_the_additional_amount(self):
+        table = _FPL_DEFAULTS["2026"]
+        row = FederalPovertyLimitValue.objects.get(period="2026", household_size=10)
+
+        self.assertEqual(row.annual_limit, table[8] + table["additional"] * 2)
+
+    def test_duplicate_period_and_size_is_rejected(self):
+        """The uniqueness constraint is what lets analytics join without fanning out."""
+        with self.assertRaises(IntegrityError):
+            FederalPovertyLimitValue.objects.create(period="2026", household_size=4, annual_limit=1)
+
+    def test_command_reports_a_clean_sync(self):
+        out = StringIO()
+
+        call_command("sync_fpl_values", stdout=out)
+
+        self.assertIn("0 created, 0 updated, 0 deleted", out.getvalue())
+
+    def test_dry_run_reports_drift_without_writing(self):
+        row = FederalPovertyLimitValue.objects.get(period="2026", household_size=4)
+        row.annual_limit = 1
+        row.save(update_fields=["annual_limit"])
+        out = StringIO()
+
+        call_command("sync_fpl_values", "--dry-run", stdout=out)
+        row.refresh_from_db()
+
+        self.assertIn("update 1", out.getvalue())
+        self.assertEqual(row.annual_limit, 1, "dry run must not write")


### PR DESCRIPTION
## Context & Motivation

The Federal Poverty Limit dollar amounts are not in the database. `FederalPoveryLimit` stores only a `year` and a `period`; the thresholds themselves are `_FPL_DEFAULTS`, a module constant in `programs/models.py`, and `as_dict()` just looks the period up in it. The table named for the concept holds no values, which means anything that can only read Postgres cannot compute a percent-of-FPL figure.

MFB-1182 needs exactly that. The CESN heat pump dashboard has to segment by income band, and the analytics pipeline (dbt over Postgres, feeding Metabase) reads the database directly. This unblocks that without ever exposing a household's actual income — only which band it falls in.

- Related ticket: [MFB-1182](https://linear.app/myfriendben/issue/MFB-1182/cesn-heat-pump-user-engagement-analytics)
- Related PR: MyFriendBen/data-queries#136 (the consumer)

## Changes Made

- **New `FederalPovertyLimitValue` model** — one row per (period, household size) holding the output of `FederalPoveryLimit.get_limit()`. Sizes beyond `MAX_DEFINED_SIZE` are materialized with the per-additional-person amount already applied, up to 20, so a consumer joining on household size never reimplements that arithmetic. Unique constraint on (period, household_size).
- **`programs/fpl_values.py`** — `sync_fpl_values()` rewrites the table from the constant. Idempotent, deletes rows for periods the constant no longer defines, and takes a `dry_run` flag so the preview and the write share one diff implementation. Model class and FPL table are injectable so the data migration can pass its historical model from `apps.get_model()`.
- **Migration `0173`** — creates the table and performs the initial fill. Reversible.
- **`manage.py sync_fpl_values`** — with `--dry-run`, which reports the diff and **exits non-zero when the table is out of date**, so it can be wired up as a drift check.
- **Deploy hook** — `sync_fpl_values` now runs on every release, in `.github/actions/heroku-migrations` alongside the existing `sync_feature_flags` step. A migration runs once; this is what keeps the table current when a year is later added to the constant.
- **Tests** — 24 pass, covering the sync's correctness against `get_limit()`, idempotency, drift repair, stale-period deletion, extrapolated sizes, the uniqueness constraint, the migration's `populate()` called directly, and that `--dry-run` writes nothing while returning counts identical to a real sync.

**Nothing on the eligibility path changed.** `as_dict()` and `get_limit()` still read the constant, and every production calculator keeps resolving limits through them. This table is a read-only mirror for analytics.

## Testing

- Migrations to run: `python manage.py migrate programs` (applies `0173`, inserts 80 rows — 4 periods x 20 sizes)
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. `python -m pytest programs/tests.py` — 24 pass. **Use pytest, not `manage.py test`**: `pytest.ini` sets `--nomigrations`, so the two runners build the schema differently and only pytest matches CI.
  2. `python manage.py migrate programs`
  3. `python manage.py sync_fpl_values --dry-run` — should print "FPL values are up to date." and exit 0
  4. Spot-check against the constant — a 4-person household in 2026 should be `33000`:
     `python manage.py shell -c "from programs.models import FederalPovertyLimitValue as V; print(V.objects.get(period='2026', household_size=4).annual_limit)"`
  5. Confirm eligibility is untouched: run an FPL-dependent program (`co_legal_services`, `ks_liheap`, `wa_head_start`) and check results are unchanged.
  6. Prove the drift alarm works: change one row's `annual_limit`, re-run `--dry-run`, confirm it reports OUT OF DATE and exits 1, then `sync_fpl_values` repairs it.

## Deployment

- Post-deployment scripts needed: none. The migration fills the table and the deploy hook keeps it current.
- Production config updates: none
- Admin updates needed: none. The model is deliberately not registered in Django admin — it is a derived mirror, and an editable copy of the constant is exactly the drift this PR prevents.
- Notify team/users of: nothing user-facing. Worth flagging to anyone editing `_FPL_DEFAULTS` that the table syncs automatically on deploy, and `sync_fpl_values --dry-run` will tell them whether an environment is behind.
- **Ordering:** data-queries#136 depends on this. Its bridge model reads `programs_federalpovertylimitvalue`, so this must reach **production** (Thursday's release, not the staging auto-deploy) before that PR merges. Merging them the other way round fails the nightly Postgres build, which aborts the job before the BigQuery build and Metabase sync — breaking the pipeline for every tenant, not just CESN.

## Notes for Reviewers

Addressed from @catonph's review: migration renumbered to `0173` off `0172`; `--dry-run` no longer reimplements the diff; `bulk_create(ignore_conflicts=True)` dropped; `limits_for_period` guarded against a table with no integer sizes; the consumer contract documented on the model; duplicated rationale collapsed into the model docstring.

- **The parity claim in the original description was wrong and has been removed.** It said adding a year to the constant without syncing would fail CI. It would not: `setUp` syncs the table from the constant, so the assertion is a tautology over `sync_fpl_values`, and CI's freshly-built database can never observe production's state. That is an environment invariant no unit test can close. The fix is the deploy hook, not a cleverer test — the tests now say explicitly what they do and do not cover.
- **Two review points were not adopted, with reasons.** The migration's `print` stays: migrations `0129`, `0166`, `0168` and `0169` all print progress, so it is house style. And `period` did not become a FK: `FederalPoveryLimit.period` is not unique (only `year` is), so there is no single row to point at; the model now documents why the loose key is intentional.
- **One review premise did not hold.** The concern that a household above the size cap "joins to nothing and gets a NULL band" does not apply to the actual consumer — the dbt bridge clamps with `least(greatest(household_size, 1), max(household_size))`, so it gets the largest available band. The cap is nonetheless now documented as a contract, since it is a cross-repo coupling.
- Known limitations: the constant remains the source of truth, so there are two representations of the same numbers. Deliberate here, to keep the eligibility path untouched.
- Future considerations: `as_dict()` could be collapsed onto this table so there is a single source of truth, which would also fix the oddity that a `period` pointing at a non-existent key fails at eligibility time rather than at save time. The read path is unusually well positioned for it — 61 call sites, all through `get_limit()`/`as_dict()`, none touching `_FPL_DEFAULTS` directly — so it is two method bodies rather than 61 call sites. The obstacle is performance: `as_dict()` runs ~56x per screen and is currently a dict lookup on a module constant, so a DB read needs prefetching or a request-scoped cache, and this codebase has been burned there before (see the `_get_fpl_data` docstring). Worth its own ticket.
