### PR TITLE
MFB-1737: rename Benbot to Benji in the feature-flag admin label

### DIFF
--- a/screener/feature_flags.py
+++ b/screener/feature_flags.py
@@ -46,9 +46,11 @@ WHITELABEL_FEATURE_FLAGS: dict[str, FeatureFlagConfig] = {
         scope="frontend",
     ),
     "benbot": FeatureFlagConfig(
-        label="Benbot AI Assistant",
+        # The assistant was renamed Benji (MFB-1737); the flag KEY stays 'benbot'
+        # so existing white-label configs keep working.
+        label="Benji AI Assistant",
         description=(
-            "Show the Benbot AI assistant on the results page and enable the "
+            "Show the Benji AI assistant on the results page and enable the "
             "mfb-ai-service proxy endpoints for guided benefit applications."
         ),
         scope="both",  # frontend renders the widget; backend gates the proxy endpoints


### PR DESCRIPTION
## MFB-1737: rename Benbot to Benji in the feature-flag admin label

Companion to the benefits-calculator and ai-service Benji PRs. The admin-facing flag label and description now say "Benji AI Assistant".

The flag **key stays `benbot`** so existing white-label configs keep working — only what humans read in the admin changes. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `benbot` feature flag label and description to reference the renamed “Benji” assistant.
  * Feature flag behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->