### PR TITLE
MFB-1706: Move Trump Accounts and CollegeInvest First Step to Savings

### DIFF
--- a/programs/management/commands/import_program_config_data/data/co_collegeinvest_first_step_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_collegeinvest_first_step_initial_config.json
@@ -3,7 +3,9 @@
     "code": "co"
   },
   "program_category": {
-    "external_name": "child_care"
+    "external_name": "savings",
+    "name": "Savings",
+    "icon": "savings"
   },
   "program": {
     "name_abbreviated": "co_collegeinvest_first_step",

--- a/programs/management/commands/import_program_config_data/data/co_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "co"
     },
     "program_category": {
-        "external_name": "cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/il_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "il"
     },
     "program_category": {
-        "external_name": "il_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "il_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/ks_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "ks"
     },
     "program_category": {
-        "external_name": "ks_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "ks_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/ma_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "ma"
     },
     "program_category": {
-        "external_name": "ma_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "ma_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/mo_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "mo"
     },
     "program_category": {
-        "external_name": "mo_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "mo_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/nc_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "nc"
     },
     "program_category": {
-        "external_name": "nc_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "nc_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/tx_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "tx"
     },
     "program_category": {
-        "external_name": "tx_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "tx_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/management/commands/import_program_config_data/data/wa_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_trump_account_initial_config.json
@@ -3,9 +3,9 @@
         "code": "wa"
     },
     "program_category": {
-        "external_name": "wa_cash",
-        "name": "Cash Assistance",
-        "icon": "cash"
+        "external_name": "wa_savings",
+        "name": "Savings",
+        "icon": "savings"
     },
     "program": {
         "name_abbreviated": "trump_account",

--- a/programs/migrations/0171_move_savings_programs_to_savings_category.py
+++ b/programs/migrations/0171_move_savings_programs_to_savings_category.py
@@ -1,0 +1,211 @@
+# Moves savings/investment-account programs out of "Cash Assistance" (and, for
+# CollegeInvest First Step, out of "Child Care") into a per-white-label "Savings"
+# category, for MFB-1706.
+#
+# Why a migration and not the config importer: the program_category block in each
+# config JSON only takes effect the first time a program is created.
+# import_program_config skips a program that already exists, and its --reconcile
+# path deliberately leaves "Program fields, category and translations" untouched.
+# So editing those JSON files (done alongside this migration, to keep fresh
+# environments correct) never moves a program that is already live. Re-pointing an
+# existing program is a database change, and this is the reviewable way to make it
+# in every environment at once instead of hand-editing each program in the admin.
+#
+# Why the move: these are custodial investment accounts, not spendable income.
+# Trump Accounts are locked under traditional IRA rules until the child turns 18
+# and carry early-withdrawal penalties; grouping them under Cash Assistance
+# implies a household can spend the $1,000 alongside SNAP or TANF. It also
+# distorts the category total, which the results page divides by 12 to show a
+# monthly figure — a one-time $1,000 deposit was rendering as ~$83/month of
+# recurring cash.
+#
+# Strategy:
+#   1. Create the missing per-white-label Savings ProgramCategory rows, reusing
+#      ProgramCategoryManager.new_program_category() so they're built the same way
+#      as everywhere else, then set the English display name on the translation
+#      row it creates.
+#   2. Re-point each program at its white label's Savings category.
+#
+# CO uses unprefixed category external_names ("cash", "housing"), so its row is
+# "savings"; every other white label prefixes with its code ("ma_savings").
+# ma_savings already exists (BabySteps Savings Plan uses it) and is reused, not
+# recreated. The "savings" CategoryIconName is created by 0121_add_savings_icon,
+# so the icon exists in every environment, and the frontend already maps
+# savings -> piggy-bank in ICON_NAME_MAP.
+#
+# Unlike 0152, this migration overwrites a non-NULL category, so it cannot use
+# category__isnull=True to stay idempotent. It instead only moves a program whose
+# category is still one of the known "from" values below, which keeps it re-runnable
+# and means a category deliberately changed in the admin afterwards is left alone.
+
+from django.conf import settings
+from django.db import migrations
+
+from integrations.clients.google_translate import Translate
+
+WHITE_LABELS = ["co", "il", "ks", "ma", "mo", "nc", "tx", "wa"]
+
+SAVINGS_DISPLAY_NAME = "Savings"
+SAVINGS_ICON = "savings"
+
+# (white_label_code, program_name_abbreviated, expected_current_category_external_name).
+# The expected current category scopes the update so re-running is a no-op and an
+# admin's later re-categorization is never clobbered.
+PROGRAM_MOVES = [
+    ("co", "trump_account", "cash"),
+    ("il", "trump_account", "il_cash"),
+    ("ks", "trump_account", "ks_cash"),
+    ("ma", "trump_account", "ma_cash"),
+    ("mo", "trump_account", "mo_cash"),
+    ("nc", "trump_account", "nc_cash"),
+    ("tx", "trump_account", "tx_cash"),
+    ("wa", "trump_account", "wa_cash"),
+    # A 529 college-savings seed deposit with a dollar-for-dollar match, filed
+    # under child care. Surfaced by the audit MFB-1706 asks for.
+    ("co", "co_collegeinvest_first_step", "child_care"),
+]
+
+
+def savings_external_name(white_label_code):
+    """CO uses unprefixed category external_names; every other white label prefixes."""
+    return "savings" if white_label_code == "co" else f"{white_label_code}_savings"
+
+
+def forward(apps, schema_editor):
+    # Use the live model managers (not apps.get_model) because
+    # ProgramCategoryManager.new_program_category and
+    # TranslationManager.add_translation rely on parler internals that aren't
+    # available on historical models. Both managers set use_in_migrations = True,
+    # so this is safe. Mirrors what 0152_backfill_has_benefits_categories does.
+    # WhiteLabel lives in the screener app, not programs.
+    from programs.models import Program, ProgramCategory
+    from screener.models import WhiteLabel
+    from translations.models import Translation
+
+    wl_by_code = {wl.code: wl for wl in WhiteLabel.objects.all()}
+    created_names = []
+
+    # Step 1: create the Savings category for each white label that needs one.
+    for code in WHITE_LABELS:
+        wl = wl_by_code.get(code)
+        if wl is None:
+            # White label not present in this environment (e.g. a state that
+            # hasn't launched yet). Nothing to do.
+            continue
+
+        external_name = savings_external_name(code)
+
+        # external_name is globally unique on ProgramCategory, so check it
+        # unscoped — a filter on (white_label, external_name) would miss a
+        # colliding row and then fail on create.
+        if ProgramCategory.objects.filter(external_name=external_name).exists():
+            continue
+
+        category = ProgramCategory.objects.new_program_category(
+            white_label=code,
+            external_name=external_name,
+            icon=SAVINGS_ICON,
+        )
+
+        # new_program_category creates the name/description translation rows with a
+        # blank placeholder for English. Set the real display name. Description is
+        # left blank: the results page renders a category description only when it's
+        # non-empty, and there's no product-approved copy for it.
+        Translation.objects.add_translation(
+            label=category.name.label,
+            default_message=SAVINGS_DISPLAY_NAME,
+        )
+        created_names.append(category.name)
+
+    # add_translation only fills in English and leaves the other languages blank,
+    # which would render an empty category heading for non-English users. Machine
+    # translate the name the same way import_program_config does, and mark the
+    # results unedited so a human translation still overrides them later.
+    # Done in one bulk call for every category created above, since the display
+    # name is identical.
+    if created_names:
+        translated = Translate().bulk_translate(Translate.languages, [SAVINGS_DISPLAY_NAME])[SAVINGS_DISPLAY_NAME]
+        for name_translation in created_names:
+            for lang in Translate.languages:
+                if lang == settings.LANGUAGE_CODE:
+                    continue
+                Translation.objects.edit_translation_by_id(
+                    name_translation.id,
+                    lang,
+                    translated[lang],
+                    manual=False,
+                )
+
+    # Step 2: re-point the programs.
+    category_by_wl_name = {(pc.white_label_id, pc.external_name): pc for pc in ProgramCategory.objects.all()}
+
+    for code, program_name, from_external_name in PROGRAM_MOVES:
+        wl = wl_by_code.get(code)
+        if wl is None:
+            continue
+
+        target = category_by_wl_name.get((wl.id, savings_external_name(code)))
+        origin = category_by_wl_name.get((wl.id, from_external_name))
+        if target is None or origin is None:
+            # Defensive: don't crash a deploy on hand-edited environment state.
+            continue
+
+        Program.objects.filter(
+            white_label=wl,
+            name_abbreviated=program_name,
+            category=origin,
+        ).update(category=target)
+
+
+def reverse(apps, schema_editor):
+    # Undo only what this migration did:
+    #   1. Move each program back, matching on the Savings category we set so a
+    #      program re-categorized elsewhere in the meantime is left alone.
+    #   2. Delete the Savings categories that are empty afterwards. A pre-existing
+    #      row (ma_savings, which BabySteps uses) still has its own programs and so
+    #      won't match the emptiness check.
+    # Real models rather than apps.get_model, to match forward(). Note WhiteLabel
+    # lives in the screener app, not programs — apps.get_model("programs",
+    # "WhiteLabel") raises LookupError.
+    from programs.models import Program, ProgramCategory
+    from screener.models import WhiteLabel
+
+    wl_by_code = {wl.code: wl for wl in WhiteLabel.objects.all()}
+    category_by_wl_name = {(pc.white_label_id, pc.external_name): pc for pc in ProgramCategory.objects.all()}
+
+    for code, program_name, from_external_name in PROGRAM_MOVES:
+        wl = wl_by_code.get(code)
+        if wl is None:
+            continue
+
+        target = category_by_wl_name.get((wl.id, savings_external_name(code)))
+        origin = category_by_wl_name.get((wl.id, from_external_name))
+        if target is None or origin is None:
+            continue
+
+        Program.objects.filter(
+            white_label=wl,
+            name_abbreviated=program_name,
+            category=target,
+        ).update(category=origin)
+
+    for code in WHITE_LABELS:
+        wl = wl_by_code.get(code)
+        if wl is None:
+            continue
+        ProgramCategory.objects.filter(
+            white_label=wl,
+            external_name=savings_external_name(code),
+            programs__isnull=True,
+        ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0170_deactivate_il_rent_asst"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]


### PR DESCRIPTION
Closes [MFB-1706](https://linear.app/myfriendben/issue/MFB-1706/trump-accounts-dont-stack-under-cash-assistance-should-move-to-savings)

## Problem

Trump Accounts were filed under **Cash Assistance** in all eight white labels (CO, IL, KS, MA, MO, NC, TX, WA).

Two things go wrong with that:

1. **It misrepresents the benefit.** A 530A account is a custodial investment account (index funds/ETFs) locked under traditional IRA rules until the child turns 18, with early-withdrawal penalties. Grouping it with SNAP/TANF implies the household can spend the $1,000 now.
2. **It corrupts the category total** — the "doesn't stack" symptom in the report. `CategoryHeading` divides the category total by 12 to show a monthly figure, so a one-time $1,000 lump sum was being rendered as ~$83/month of recurring cash, mixed into a sum of genuinely monthly benefits.

MA already had a `ma_savings` category (BabySteps Savings Plan) but Trump Accounts weren't in it.

## Changes

**Savings category, per white label.** `savings` for CO (which uses unprefixed category names) and `<code>_savings` for the rest. `ma_savings` already exists and is reused, not recreated.

**Programs moved:**

| White label | Program | From | To |
|---|---|---|---|
| co | `trump_account` | `cash` | `savings` |
| il | `trump_account` | `il_cash` | `il_savings` |
| ks | `trump_account` | `ks_cash` | `ks_savings` |
| ma | `trump_account` | `ma_cash` | `ma_savings` |
| mo | `trump_account` | `mo_cash` | `mo_savings` |
| nc | `trump_account` | `nc_cash` | `nc_savings` |
| tx | `trump_account` | `tx_cash` | `tx_savings` |
| wa | `trump_account` | `wa_cash` | `wa_savings` |
| co | `co_collegeinvest_first_step` | `child_care` | `savings` |

**Audit result** (third acceptance criterion). Swept every program config and calculator for savings/matched-savings/investment-account products. Beyond Trump Accounts, exactly one was miscategorized: **CollegeInvest First Step** (CO) — a 529 college-savings seed deposit with a dollar-for-dollar match, sitting under Child Care. It moves here too. MA BabySteps was already correct. Everything else that pattern-matched was a false positive — *Medicare Savings Program* (IL/KS/MO/TX) is health coverage, and "Colorado Energy Savings Navigator" is the CESN brand name. No IDA, baby-bonds, or child-trust programs exist in the repo.

## Why both a migration and JSON edits

The two halves are not redundant — neither alone is sufficient:

- **JSON edits** (`program_category` block in 9 configs) only take effect when a program is *first created*. `import_program_config` skips a program that already exists, and its `--reconcile` path deliberately leaves "Program fields, category and translations" untouched. These keep a freshly built environment correct; without them a rebuild would silently reintroduce the bug.
- **Data migration** `0171_move_savings_programs_to_savings_category` moves the programs that are *already live*. This is the part that actually fixes production.

Category names are machine-translated into every supported language via the same `Translate().bulk_translate` path the importer uses, marked unedited so a human translation still overrides them.

## Admin portal changes required

**None — this ships entirely via the migration.** The Heroku release phase runs `migrate`, so deploying this branch creates the categories and moves the programs automatically in each environment. No manual admin work is needed, and there is intentionally no `import_program_config` step to run.

Two things worth knowing:

- The `savings` **icon** already exists everywhere (created by `0121_add_savings_icon`) and the frontend already maps `savings` → `piggy-bank` in `ICON_NAME_MAP`, so **no frontend change is needed**.
- Category **display names** are auto-translated, so no manual Translation rows are required. If you want copy other than "Savings", or a category **description** (left blank — the results page only renders a description when non-empty), set it in *Program Categories* in the admin after deploy.

Optional post-deploy check in the admin: confirm Trump Accounts appears under **Savings** on the results page for a household with a child born 2025–2028, and that Cash Assistance no longer includes the $1,000 in its monthly total.

## Out of scope

The audit surfaced pre-existing duplicate/drifted categories not touched here, to keep this reviewable: `ks_health_care`/`ks_healthcare`, `ks_tax`/`ks_tax_credit`, `mo_health_care`/`mo_healthcare`, and display-name drift on `ma_housing` ("Housing" vs "Housing and Utilities") and `wa_tax` (icon `tax` vs `tax_credit`). Happy to file a cleanup ticket.

## Testing

- `programs/` — 601 passed
- `screener/` + `validations/` — 401 passed
- Migration verified locally **forward → reverse → forward**: creates the 8 categories with the `savings` icon, moves all programs, reverse restores the original categories and deletes only the categories left empty (a pre-existing `ma_savings` with BabySteps in it survives the emptiness check).
- Re-running `forward` is a no-op: it only moves a program whose category is still the expected "from" value, so it is idempotent and won't clobber a later admin re-categorization.
- `makemigrations --check` clean; all 9 configs verified as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Savings and investment programs are now displayed under dedicated **Savings** categories instead of **Cash Assistance** or **Child Care**.
  * Updated category names, icons, and labels across supported state programs and Colorado CollegeInvest First Step.
  * Existing program categorization changes made by administrators are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->