### PR TITLE
MFB-1757: parallelize the test suite and stop Sentry-reporting every Translation save

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -52,10 +52,15 @@ runs:
 
         # pytest.ini runs the suite in parallel; conftest's pytest_configure drops any
         # recording mode back to a single process, so no mode handling is needed here.
+        #
+        # The coverage-uploading branch is PR validation: strict replay, 4k tests, where
+        # per-test output is noise. The other branch is the deploy path, which records
+        # against live APIs -- keep the verbose flags there, since a cassette or API
+        # failure is hardest to diagnose from a bare assertion.
         if [ "${{ inputs.upload-coverage }}" = "true" ]; then
           pytest --cov --cov-branch --cov-report=xml
         else
-          pytest --cov --cov-branch
+          pytest --cov --cov-branch --verbosity=2 --log-cli-level=INFO
         fi
 
     - name: Upload coverage to Codecov

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -50,10 +50,21 @@ runs:
           echo "Running tests with VCR - VCR_MODE=${{ inputs.vcr-mode }}"
         fi
 
-        if [ "${{ inputs.upload-coverage }}" = "true" ]; then
-          pytest --cov --cov-branch --cov-report=xml --verbosity=2 --log-cli-level=INFO
+        # pytest.ini runs the suite in parallel (-n auto). Recording modes must not:
+        # they issue real API calls, and concurrent workers would multiply the load on
+        # PolicyEngine and race to write the same cassette files. Force one worker for
+        # any mode that can record (-n 0 runs in-process), and keep the fan-out for
+        # pure playback.
+        if [ "${{ inputs.vcr-mode }}" = "all" ] || [ "${{ inputs.vcr-mode }}" = "new_episodes" ]; then
+          PARALLEL="-n 0"
         else
-          pytest --cov --cov-branch --verbosity=2
+          PARALLEL="-n auto --dist loadscope"
+        fi
+
+        if [ "${{ inputs.upload-coverage }}" = "true" ]; then
+          pytest $PARALLEL --cov --cov-branch --cov-report=xml
+        else
+          pytest $PARALLEL --cov --cov-branch
         fi
 
     - name: Upload coverage to Codecov

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -50,21 +50,12 @@ runs:
           echo "Running tests with VCR - VCR_MODE=${{ inputs.vcr-mode }}"
         fi
 
-        # pytest.ini runs the suite in parallel (-n auto). Recording modes must not:
-        # they issue real API calls, and concurrent workers would multiply the load on
-        # PolicyEngine and race to write the same cassette files. Force one worker for
-        # any mode that can record (-n 0 runs in-process), and keep the fan-out for
-        # pure playback.
-        if [ "${{ inputs.vcr-mode }}" = "all" ] || [ "${{ inputs.vcr-mode }}" = "new_episodes" ]; then
-          PARALLEL="-n 0"
-        else
-          PARALLEL="-n auto --dist loadscope"
-        fi
-
+        # pytest.ini runs the suite in parallel; conftest's pytest_configure drops any
+        # recording mode back to a single process, so no mode handling is needed here.
         if [ "${{ inputs.upload-coverage }}" = "true" ]; then
-          pytest $PARALLEL --cov --cov-branch --cov-report=xml
+          pytest --cov --cov-branch --cov-report=xml
         else
-          pytest $PARALLEL --cov --cov-branch
+          pytest --cov --cov-branch
         fi
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/run-tests
         with:
-          vcr-mode: new_episodes
+          # Same strict playback as PR validation. Every commit reaching main has
+          # already passed that gate, so there is nothing left for staging to record
+          # -- and recording would keep it serial (and ~4x slower) for no benefit.
+          vcr-mode: none
           upload-coverage: "false"
           hud-api-token: ${{ secrets.HUD_API_TOKEN }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,6 +20,10 @@ jobs:
       DB_HOST: localhost
       DB_PORT: 5432
       ENABLE_GOOGLE_INTEGRATIONS: false
+      # Without this, settings.py takes the LocMemCache branch, TestRedisBackend
+      # skips itself, and the entire django_redis path goes untested -- the exact
+      # gap that let a Redis config error reach staging with a green build.
+      REDIS_URL: redis://localhost:6379/0
 
     services:
       postgres:
@@ -32,6 +36,16 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd "pg_isready -U postgres -d test_benefits_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,7 +1,7 @@
 name: PR Validation
 
 # Validates pull requests to main branch with:
-# - Full test suite using VCR (replays existing cassettes, records new interactions)
+# - Full test suite using VCR in strict playback (cassettes only, never records)
 # - Coverage upload to Codecov (same-repo PRs only; fork PRs skip upload — no secrets)
 # - Code formatting checks
 
@@ -64,7 +64,10 @@ jobs:
       - name: Run tests with VCR and upload coverage
         uses: ./.github/actions/run-tests
         with:
-          vcr-mode: new_episodes
+          # Strict playback. A request with no matching cassette fails the build
+          # instead of being recorded live, so a PR can never go green by reaching
+          # a real API -- and no fork PR needs credentials to pass.
+          vcr-mode: none
           # Secrets (incl. CODECOV_TOKEN) are not available to workflows on fork PRs.
           # Still run the full suite; upload coverage only for same-repo PRs.
           upload-coverage: ${{ !github.event.pull_request.head.repo.fork && 'true' || 'false' }}

--- a/benefits/tests/test_xdist_cache_isolation.py
+++ b/benefits/tests/test_xdist_cache_isolation.py
@@ -7,13 +7,19 @@ the PolicyEngine bearer token ``seed_pe_token`` had just written and falling thr
 a live auth attempt.
 """
 
+import os
+from unittest import mock
+
 from django.test import SimpleTestCase, override_settings
 
 from conftest import (
     MAX_ISOLATED_WORKERS,
+    PE_RECORD_ENV_VAR,
+    _run_records_cassettes,
     _isolate_cache_per_xdist_worker,
     _rebuild_cache_connections,
     redis_url_for_database,
+    vcr_record_mode,
 )
 
 BASE_LOCATION = "redis://localhost:6379/0"
@@ -96,3 +102,35 @@ class TestWorkerIsolation(SimpleTestCase):
             _isolate_cache_per_xdist_worker("gw0")
 
             self.assertNotIn("LOCATION", settings.CACHES["default"])
+
+
+class TestRecordingModesRunSerially(SimpleTestCase):
+    """Which runs may write cassettes, and so must not fan out across workers.
+
+    Two workers recording the same cassette race to write one file, and each issues its
+    own live API call. Only modes that actually record belong here: "once" is the default
+    when VCR_MODE is unset and writes only when a whole cassette file is absent, so
+    treating it as recording silently made every default local run serial.
+    """
+
+    def _records(self, vcr_mode: str | None, pe_record: str | None = None) -> bool:
+        env = {"VCR_MODE": vcr_mode or "", PE_RECORD_ENV_VAR: pe_record or ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            return _run_records_cassettes(vcr_record_mode())
+
+    def test_replay_modes_stay_parallel(self):
+        self.assertFalse(self._records("none"))
+        self.assertFalse(self._records("once"))
+
+    def test_an_unset_mode_stays_parallel(self):
+        """The default. pytest.ini configures -n auto for exactly this case."""
+        self.assertFalse(self._records(None))
+
+    def test_recording_modes_go_serial(self):
+        self.assertTrue(self._records("all"))
+        self.assertTrue(self._records("new_episodes"))
+
+    def test_pe_record_makes_an_otherwise_replaying_run_serial(self):
+        """docs/TESTING.md records PolicyEngine cassettes with PE_RECORD=1 VCR_MODE=once,
+        which writes cassettes even though the mode alone would not."""
+        self.assertTrue(self._records("once", pe_record="1"))

--- a/benefits/tests/test_xdist_cache_isolation.py
+++ b/benefits/tests/test_xdist_cache_isolation.py
@@ -1,0 +1,80 @@
+"""Per-worker Redis isolation for parallel test runs.
+
+``clear_cache`` empties the cache before every test, and on django_redis ``clear()``
+issues FLUSHDB -- the whole database, ignoring KEY_PREFIX. Workers sharing a database
+therefore delete each other's entries mid-test, which surfaced in CI as a worker losing
+the PolicyEngine bearer token ``seed_pe_token`` had just written and falling through to
+a live auth attempt.
+"""
+
+import pytest
+from django.test import SimpleTestCase, override_settings
+
+from conftest import (
+    MAX_ISOLATED_WORKERS,
+    _isolate_cache_per_xdist_worker,
+    redis_url_for_database,
+)
+
+REDIS_CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": "redis://localhost:6379/0"}}
+
+
+class TestRedisUrlForDatabase(SimpleTestCase):
+    def test_replaces_a_plain_database_index(self):
+        self.assertEqual(redis_url_for_database("redis://localhost:6379/0", 3), "redis://localhost:6379/3")
+
+    def test_preserves_a_query_string(self):
+        """Heroku hands us rediss://...?ssl_cert_reqs=none; see benefits/cache_config.py.
+
+        Splitting on the last "/" would append the database to the query string and
+        produce a URL that still parses as a string but cannot connect.
+        """
+        self.assertEqual(
+            redis_url_for_database("rediss://h:6379/0?ssl_cert_reqs=none", 2),
+            "rediss://h:6379/2?ssl_cert_reqs=none",
+        )
+
+    def test_adds_a_database_to_a_url_that_omits_one(self):
+        self.assertEqual(
+            redis_url_for_database("redis://h:6379?ssl_cert_reqs=none", 1),
+            "redis://h:6379/1?ssl_cert_reqs=none",
+        )
+
+    def test_preserves_credentials(self):
+        self.assertEqual(redis_url_for_database("redis://user:pw@h:6380/7", 4), "redis://user:pw@h:6380/4")
+
+
+@override_settings(CACHES=REDIS_CACHES)
+class TestWorkerIsolation(SimpleTestCase):
+    def _location_for(self, worker_id: str) -> str:
+        from django.conf import settings
+
+        settings.CACHES["default"]["LOCATION"] = "redis://localhost:6379/0"
+        _isolate_cache_per_xdist_worker(worker_id)
+        return settings.CACHES["default"]["LOCATION"]
+
+    def test_workers_never_get_database_zero(self):
+        """Database 0 stays free for non-xdist runs and for test_redis_backend.py,
+        which pins REDIS_URL directly and flushes whatever it points at."""
+        databases = {self._location_for(f"gw{i}").rsplit("/", 1)[1] for i in range(MAX_ISOLATED_WORKERS)}
+
+        self.assertNotIn("0", databases)
+
+    def test_each_worker_gets_a_distinct_database(self):
+        databases = [self._location_for(f"gw{i}") for i in range(MAX_ISOLATED_WORKERS)]
+
+        self.assertEqual(len(set(databases)), MAX_ISOLATED_WORKERS)
+
+    def test_a_worker_beyond_the_database_count_is_an_error(self):
+        """Wrapping with % would put this worker back on database 0, where it would
+        flush the entries of whatever else is using it -- the bug this guards."""
+        with self.assertRaises(pytest.UsageError):
+            self._location_for(f"gw{MAX_ISOLATED_WORKERS}")
+
+    def test_a_non_redis_cache_is_left_alone(self):
+        from django.conf import settings
+
+        with override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}):
+            _isolate_cache_per_xdist_worker("gw0")
+
+            self.assertNotIn("LOCATION", settings.CACHES["default"])

--- a/benefits/tests/test_xdist_cache_isolation.py
+++ b/benefits/tests/test_xdist_cache_isolation.py
@@ -7,16 +7,19 @@ the PolicyEngine bearer token ``seed_pe_token`` had just written and falling thr
 a live auth attempt.
 """
 
-import pytest
 from django.test import SimpleTestCase, override_settings
 
 from conftest import (
     MAX_ISOLATED_WORKERS,
     _isolate_cache_per_xdist_worker,
+    _rebuild_cache_connections,
     redis_url_for_database,
 )
 
-REDIS_CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": "redis://localhost:6379/0"}}
+BASE_LOCATION = "redis://localhost:6379/0"
+# A fresh dict per test module: _isolate_cache_per_xdist_worker mutates
+# settings.CACHES in place, and override_settings does not copy it.
+REDIS_CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": BASE_LOCATION}}
 
 
 class TestRedisUrlForDatabase(SimpleTestCase):
@@ -46,30 +49,45 @@ class TestRedisUrlForDatabase(SimpleTestCase):
 
 @override_settings(CACHES=REDIS_CACHES)
 class TestWorkerIsolation(SimpleTestCase):
-    def _location_for(self, worker_id: str) -> str:
+    """Assertions here read the *resolved connection*, not settings.
+
+    Asserting on settings alone passes even when isolation does nothing: the connection
+    handler caches connection objects, and the default connection already exists before
+    pytest_configure runs (django-parler reads cache.default_timeout at import, so
+    django.setup() builds it). Rewriting settings without rebuilding the connection
+    leaves every worker flushing database 0 while settings claim otherwise.
+    """
+
+    def _resolved_database(self, worker_id: str) -> str:
+        from django.conf import settings
+        from django.core.cache import cache
+
+        settings.CACHES["default"]["LOCATION"] = BASE_LOCATION
+        _isolate_cache_per_xdist_worker(worker_id)
+        # cache is a proxy; touching .client resolves the real connection.
+        return cache.client._server[0].rsplit("/", 1)[1]
+
+    def tearDown(self):
         from django.conf import settings
 
-        settings.CACHES["default"]["LOCATION"] = "redis://localhost:6379/0"
-        _isolate_cache_per_xdist_worker(worker_id)
-        return settings.CACHES["default"]["LOCATION"]
+        settings.CACHES["default"]["LOCATION"] = BASE_LOCATION
+        _rebuild_cache_connections()
+
+    def test_the_connection_moves_not_just_the_setting(self):
+        """The regression: settings said db N while the connection stayed on db 0."""
+        self.assertEqual(self._resolved_database("gw3"), "4")
 
     def test_workers_never_get_database_zero(self):
         """Database 0 stays free for non-xdist runs and for test_redis_backend.py,
         which pins REDIS_URL directly and flushes whatever it points at."""
-        databases = {self._location_for(f"gw{i}").rsplit("/", 1)[1] for i in range(MAX_ISOLATED_WORKERS)}
+        databases = {self._resolved_database(f"gw{i}") for i in range(MAX_ISOLATED_WORKERS)}
 
         self.assertNotIn("0", databases)
 
     def test_each_worker_gets_a_distinct_database(self):
-        databases = [self._location_for(f"gw{i}") for i in range(MAX_ISOLATED_WORKERS)]
+        databases = [self._resolved_database(f"gw{i}") for i in range(MAX_ISOLATED_WORKERS)]
 
         self.assertEqual(len(set(databases)), MAX_ISOLATED_WORKERS)
-
-    def test_a_worker_beyond_the_database_count_is_an_error(self):
-        """Wrapping with % would put this worker back on database 0, where it would
-        flush the entries of whatever else is using it -- the bug this guards."""
-        with self.assertRaises(pytest.UsageError):
-            self._location_for(f"gw{MAX_ISOLATED_WORKERS}")
 
     def test_a_non_redis_cache_is_left_alone(self):
         from django.conf import settings

--- a/benefits/tests/test_xdist_cache_isolation.py
+++ b/benefits/tests/test_xdist_cache_isolation.py
@@ -16,11 +16,12 @@ from django.test import SimpleTestCase, override_settings
 
 from benefits.cache_config import redis_pool_kwargs
 from conftest import (
-    MAX_ISOLATED_WORKERS,
     PE_RECORD_ENV_VAR,
-    _run_records_cassettes,
+    _isolatable_database_count,
     _isolate_cache_per_xdist_worker,
     _rebuild_cache_connections,
+    _redis_database,
+    _run_records_cassettes,
     redis_url_for_database,
     vcr_record_mode,
 )
@@ -105,8 +106,6 @@ class TestWorkerIsolation(SimpleTestCase):
 
     def test_the_connection_moves_not_just_the_setting(self):
         """The regression: settings said db N while the connection stayed on the base."""
-        from conftest import _redis_database
-
         expected = _redis_database(BASE_LOCATION) + 1 + 3
 
         self.assertEqual(self._resolved_database("gw3"), str(expected))
@@ -115,16 +114,12 @@ class TestWorkerIsolation(SimpleTestCase):
         """The base database stays free for serial runs and for test_redis_backend.py,
         which pins REDIS_URL directly and flushes whatever it points at. Offsetting from
         0 rather than from the configured database put gw0 straight onto it."""
-        from conftest import _redis_database, _isolatable_database_count
-
         base = str(_redis_database(BASE_LOCATION))
         databases = {self._resolved_database(f"gw{i}") for i in range(_isolatable_database_count())}
 
         self.assertNotIn(base, databases)
 
     def test_each_worker_gets_a_distinct_database(self):
-        from conftest import _isolatable_database_count
-
         count = _isolatable_database_count()
         databases = [self._resolved_database(f"gw{i}") for i in range(count)]
 

--- a/benefits/tests/test_xdist_cache_isolation.py
+++ b/benefits/tests/test_xdist_cache_isolation.py
@@ -17,6 +17,7 @@ from django.test import SimpleTestCase, override_settings
 from benefits.cache_config import redis_pool_kwargs
 from conftest import (
     PE_RECORD_ENV_VAR,
+    REDIS_DATABASE_COUNT,
     _isolatable_database_count,
     _isolate_cache_per_xdist_worker,
     _rebuild_cache_connections,
@@ -47,9 +48,18 @@ def _redis_available() -> bool:
         return False
 
 
+# These tests only read back the database a connection resolved to; they never store
+# anything. Point them at the highest database rather than the one REDIS_URL names: the
+# autouse clear_cache fixture FLUSHDBs whatever this class resolves to, and FLUSHDB
+# ignores KEY_PREFIX, so targeting the base database would wipe the keys
+# benefits/tests/test_redis_backend.py is asserting on from a concurrent worker -- the
+# very cross-worker flush this module exists to verify is prevented.
+SCRATCH_DATABASE = REDIS_DATABASE_COUNT - 1
+SCRATCH_LOCATION = redis_url_for_database(BASE_LOCATION, SCRATCH_DATABASE)
+
 # A fresh dict per test module: _isolate_cache_per_xdist_worker mutates
 # settings.CACHES in place, and override_settings does not copy it.
-REDIS_CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": BASE_LOCATION}}
+REDIS_CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": SCRATCH_LOCATION}}
 
 
 class TestRedisUrlForDatabase(SimpleTestCase):
@@ -101,7 +111,9 @@ class TestWorkerIsolation(SimpleTestCase):
     def tearDown(self):
         from django.conf import settings
 
-        settings.CACHES["default"]["LOCATION"] = BASE_LOCATION
+        # Back to the scratch database, so the autouse clear_cache flush that follows
+        # cannot reach the base database or another worker's.
+        settings.CACHES["default"]["LOCATION"] = SCRATCH_LOCATION
         _rebuild_cache_connections()
 
     def test_the_connection_moves_not_just_the_setting(self):
@@ -164,3 +176,45 @@ class TestRecordingModesRunSerially(SimpleTestCase):
         """docs/TESTING.md records PolicyEngine cassettes with PE_RECORD=1 VCR_MODE=once,
         which writes cassettes even though the mode alone would not."""
         self.assertTrue(self._records("once", pe_record="1"))
+
+
+class TestOnceIsNotAWritePathUnderParallelism(SimpleTestCase):
+    """``once`` is write-protected only after a cassette has been loaded.
+
+    ``Cassette.write_protected`` is ``rewound and record_mode == ONCE``, and ``rewound``
+    is set only by a successful ``_load()``. A missing cassette therefore leaves ``once``
+    free to record, so two workers reaching the same missing cassette would each call the
+    live API and race to write one file. Downgrading to ``none`` in a worker removes the
+    write path while keeping the fan-out, which serializing every ``once`` run would not.
+    """
+
+    def _effective_mode(self, vcr_mode: str | None, worker: str | None, pe_record: str | None = None) -> str:
+        env = {
+            "VCR_MODE": vcr_mode or "",
+            "PYTEST_XDIST_WORKER": worker or "",
+            PE_RECORD_ENV_VAR: pe_record or "",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            if not worker:
+                os.environ.pop("PYTEST_XDIST_WORKER", None)
+            return vcr_record_mode()
+
+    def test_once_becomes_none_in_a_worker(self):
+        self.assertEqual(self._effective_mode("once", "gw0"), "none")
+
+    def test_an_unset_mode_becomes_none_in_a_worker(self):
+        """The default. Without this, a plain parallel `pytest` can record live."""
+        self.assertEqual(self._effective_mode(None, "gw3"), "none")
+
+    def test_once_is_preserved_in_a_serial_run(self):
+        """Serial runs keep the stricter-erroring behaviour `once` is chosen for."""
+        self.assertEqual(self._effective_mode("once", None), "once")
+
+    def test_an_opted_in_recording_run_keeps_once(self):
+        """PE_RECORD=1 VCR_MODE=once is the documented recording command; it is already
+        single-process by the time it runs, so there is nothing to protect against."""
+        self.assertEqual(self._effective_mode("once", "gw0", pe_record="1"), "once")
+
+    def test_explicit_recording_modes_are_untouched(self):
+        self.assertEqual(self._effective_mode("all", "gw0"), "all")
+        self.assertEqual(self._effective_mode("new_episodes", "gw0"), "new_episodes")

--- a/benefits/tests/test_xdist_cache_isolation.py
+++ b/benefits/tests/test_xdist_cache_isolation.py
@@ -8,10 +8,13 @@ a live auth attempt.
 """
 
 import os
+import unittest
 from unittest import mock
 
+from decouple import config
 from django.test import SimpleTestCase, override_settings
 
+from benefits.cache_config import redis_pool_kwargs
 from conftest import (
     MAX_ISOLATED_WORKERS,
     PE_RECORD_ENV_VAR,
@@ -22,7 +25,27 @@ from conftest import (
     vcr_record_mode,
 )
 
-BASE_LOCATION = "redis://localhost:6379/0"
+# Read the ambient URL like benefits/tests/test_redis_backend.py does, rather than
+# hardcoding a host: the connection assertions below open a real socket, so a developer
+# whose Redis lives elsewhere (or nowhere) should skip rather than error.
+REDIS_URL = config("REDIS_URL", default=None)
+BASE_LOCATION = REDIS_URL or "redis://127.0.0.1:6379/0"
+
+
+def _redis_available() -> bool:
+    if not REDIS_URL:
+        return False
+    try:
+        import redis
+
+        kwargs = redis_pool_kwargs(REDIS_URL)
+        ssl = {"ssl_cert_reqs": None} if "ssl_cert_reqs" in kwargs else {}
+        redis.from_url(REDIS_URL, socket_connect_timeout=2, **ssl).ping()
+        return True
+    except Exception:
+        return False
+
+
 # A fresh dict per test module: _isolate_cache_per_xdist_worker mutates
 # settings.CACHES in place, and override_settings does not copy it.
 REDIS_CACHES = {"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": BASE_LOCATION}}
@@ -53,6 +76,7 @@ class TestRedisUrlForDatabase(SimpleTestCase):
         self.assertEqual(redis_url_for_database("redis://user:pw@h:6380/7", 4), "redis://user:pw@h:6380/4")
 
 
+@unittest.skipUnless(_redis_available(), "REDIS_URL not set or Redis unreachable")
 @override_settings(CACHES=REDIS_CACHES)
 class TestWorkerIsolation(SimpleTestCase):
     """Assertions here read the *resolved connection*, not settings.
@@ -80,20 +104,31 @@ class TestWorkerIsolation(SimpleTestCase):
         _rebuild_cache_connections()
 
     def test_the_connection_moves_not_just_the_setting(self):
-        """The regression: settings said db N while the connection stayed on db 0."""
-        self.assertEqual(self._resolved_database("gw3"), "4")
+        """The regression: settings said db N while the connection stayed on the base."""
+        from conftest import _redis_database
 
-    def test_workers_never_get_database_zero(self):
-        """Database 0 stays free for non-xdist runs and for test_redis_backend.py,
-        which pins REDIS_URL directly and flushes whatever it points at."""
-        databases = {self._resolved_database(f"gw{i}") for i in range(MAX_ISOLATED_WORKERS)}
+        expected = _redis_database(BASE_LOCATION) + 1 + 3
 
-        self.assertNotIn("0", databases)
+        self.assertEqual(self._resolved_database("gw3"), str(expected))
+
+    def test_workers_never_get_the_base_database(self):
+        """The base database stays free for serial runs and for test_redis_backend.py,
+        which pins REDIS_URL directly and flushes whatever it points at. Offsetting from
+        0 rather than from the configured database put gw0 straight onto it."""
+        from conftest import _redis_database, _isolatable_database_count
+
+        base = str(_redis_database(BASE_LOCATION))
+        databases = {self._resolved_database(f"gw{i}") for i in range(_isolatable_database_count())}
+
+        self.assertNotIn(base, databases)
 
     def test_each_worker_gets_a_distinct_database(self):
-        databases = [self._resolved_database(f"gw{i}") for i in range(MAX_ISOLATED_WORKERS)]
+        from conftest import _isolatable_database_count
 
-        self.assertEqual(len(set(databases)), MAX_ISOLATED_WORKERS)
+        count = _isolatable_database_count()
+        databases = [self._resolved_database(f"gw{i}") for i in range(count)]
+
+        self.assertEqual(len(set(databases)), count)
 
     def test_a_non_redis_cache_is_left_alone(self):
         from django.conf import settings

--- a/conftest.py
+++ b/conftest.py
@@ -6,10 +6,13 @@ HTTP interactions during tests. It automatically scrubs sensitive information
 from cassettes using VCR's built-in filtering capabilities.
 
 VCR behavior controlled by VCR_MODE environment variable:
-- VCR_MODE=new_episodes (PRs): Replays existing interactions, records NEW HTTP requests not in cassette
-- VCR_MODE=all (push to main): Never replays, re-records ALL cassettes from scratch
+- VCR_MODE=none (PRs and push to main): Replays only, never records, errors on any new HTTP request
 - VCR_MODE=once (local default): Replays existing interactions, ERRORS if cassette missing new HTTP request
-- VCR_MODE=none (strict playback): Replays only, never records, errors on any new HTTP requests
+- VCR_MODE=new_episodes: Replays existing interactions, records NEW HTTP requests not in cassette
+- VCR_MODE=all (production deploy): Never replays, re-records ALL cassettes from scratch
+
+A run that may write a cassette is forced single-process (see pytest_configure): parallel
+workers would issue duplicate live calls and race to write the same file.
 
 All integration tests marked with @pytest.mark.integration automatically use VCR.
 
@@ -259,6 +262,12 @@ def redis_url_for_database(location: str, db: int) -> str:
     return urlunsplit(parts._replace(path=f"/{db}"))
 
 
+def _redis_database(location: str) -> int:
+    """The database index ``location`` names, or 0 when it names none."""
+    path = urlsplit(location).path.lstrip("/")
+    return int(path) if path.isdigit() else 0
+
+
 def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
     """Point this xdist worker at its own Redis database.
 
@@ -288,8 +297,13 @@ def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
 
     location = settings.CACHES["default"]["LOCATION"]
 
+    # Offset from the database REDIS_URL already names, not from 0. That database is the
+    # one a serial run uses and the one benefits/tests/test_redis_backend.py pins and
+    # FLUSHDBs, so a worker landing on it recreates the cross-process flush this function
+    # exists to prevent -- and the repo's own .env points at /1, not /0.
     index = int(worker_id.removeprefix("gw"))
-    settings.CACHES["default"]["LOCATION"] = redis_url_for_database(location, index + 1)
+    db = _redis_database(location) + 1 + index
+    settings.CACHES["default"]["LOCATION"] = redis_url_for_database(location, db)
     _rebuild_cache_connections()
 
 
@@ -313,6 +327,21 @@ def _rebuild_cache_connections() -> None:
     close_caches()
     caches._settings = caches.settings = caches.configure_settings(None)
     caches._connections = Local()
+
+
+def _isolatable_database_count() -> int:
+    """How many workers can get a database of their own.
+
+    Workers are offset above the database REDIS_URL names, so a URL pointing at a higher
+    database leaves fewer to hand out. Redis serves 0-15 by default.
+    """
+    from django.conf import settings
+
+    location = settings.CACHES.get("default", {}).get("LOCATION", "")
+    if not isinstance(location, str):
+        return MAX_ISOLATED_WORKERS
+
+    return max(0, REDIS_DATABASE_COUNT - 1 - _redis_database(location))
 
 
 def _run_records_cassettes(mode: str) -> bool:
@@ -362,13 +391,17 @@ def pytest_configure(config):
     # applies the cap when it builds config.option.tx and never rewrites numprocesses,
     # so on a machine with more cores than databases numprocesses still reports the
     # uncapped count and comparing against it aborts a run that was correctly capped.
+    # config.option.tx is likewise stale once the recording override above zeroes
+    # numprocesses, so a serial run is exempt regardless of what tx still holds.
+    running_parallel = bool(config.getoption("numprocesses", default=None))
     worker_count = len(config.option.tx or [])
-    if worker_count > MAX_ISOLATED_WORKERS and _cache_needs_per_worker_database():
+    available = _isolatable_database_count()
+    if running_parallel and worker_count > available and _cache_needs_per_worker_database():
         raise pytest.UsageError(
-            f"{worker_count} workers exceeds the {MAX_ISOLATED_WORKERS} Redis databases "
-            "available for per-worker cache isolation; workers would share a database and "
-            f"flush each other's entries. Pass --maxprocesses {MAX_ISOLATED_WORKERS} "
-            "(pytest.ini sets this by default)."
+            f"{worker_count} workers exceeds the {available} Redis databases available for "
+            "per-worker cache isolation; workers would share a database and flush each "
+            f"other's entries. Pass --maxprocesses {available}, or point REDIS_URL at a "
+            "lower database number to free more."
         )
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
@@ -472,10 +505,10 @@ def auto_vcr(request, vcr_config):
     This fixture:
     - Detects if a test is marked with @pytest.mark.integration
     - Automatically uses VCR to record/replay HTTP interactions
-    - VCR_MODE=new_episodes (PRs): Flexible - replays existing, records new HTTP requests not yet in cassette
-    - VCR_MODE=all (push to main): Fresh start - never replays, re-records all cassettes from scratch
+    - VCR_MODE=none (PRs and push to main): Read-only - replays only, never records, errors on new HTTP requests
     - VCR_MODE=once (local default): Strict - replays existing cassettes, errors if test makes new HTTP request
-    - VCR_MODE=none (strict playback): Read-only - replays only, never records, errors on new HTTP requests
+    - VCR_MODE=new_episodes: Flexible - replays existing, records new HTTP requests not yet in cassette
+    - VCR_MODE=all (production deploy): Fresh start - never replays, re-records all cassettes from scratch
 
     Cassettes are stored in: <test_dir>/cassettes/<TestClass>.<test_name>.yaml
     Example: integrations/clients/hud_income_limits/tests/cassettes/
@@ -497,7 +530,7 @@ def auto_vcr(request, vcr_config):
 
     # Determine VCR record mode based on VCR_MODE environment variable
     # Possible values:
-    #   - "new_episodes": Flexible - replays existing, records new HTTP requests (PRs in CI)
+    #   - "new_episodes": Flexible - replays existing, records new HTTP requests
     #   - "all": Fresh start - never replays, re-records everything from scratch (push to main in CI)
     #   - "once" (default): Strict - replays existing, errors if cassette missing new HTTP request (local dev)
     #   - "none": Read-only - replays only, never records, errors on new HTTP requests (strict mode)

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,9 @@ from cassettes using VCR's built-in filtering capabilities.
 
 VCR behavior controlled by VCR_MODE environment variable:
 - VCR_MODE=none (PRs and push to main): Replays only, never records, errors on any new HTTP request
-- VCR_MODE=once (local default): Replays existing interactions, ERRORS if cassette missing new HTTP request
+- VCR_MODE=once (local default): Replays existing interactions, ERRORS if cassette missing new HTTP
+  request. Downgraded to `none` inside an xdist worker unless PE_RECORD is set, so a parallel
+  run cannot record a missing cassette live (see vcr_record_mode)
 - VCR_MODE=new_episodes: Replays existing interactions, records NEW HTTP requests not in cassette
 - VCR_MODE=all (production deploy): Never replays, re-records ALL cassettes from scratch
 
@@ -63,6 +65,11 @@ VALID_VCR_MODES = ("none", "new_episodes", "all", "once")
 DEFAULT_VCR_MODE = "once"
 
 
+def _in_xdist_worker() -> bool:
+    """Whether this process is one of several running tests concurrently."""
+    return bool(os.environ.get("PYTEST_XDIST_WORKER"))
+
+
 def vcr_record_mode() -> str:
     """The record mode this run uses. Raises on a VCR_MODE we don't recognize.
 
@@ -79,10 +86,20 @@ def vcr_record_mode() -> str:
     mode = os.getenv("VCR_MODE", "").strip().lower()
 
     if not mode:
-        return DEFAULT_VCR_MODE
-
-    if mode not in VALID_VCR_MODES:
+        mode = DEFAULT_VCR_MODE
+    elif mode not in VALID_VCR_MODES:
         raise ValueError(f"Unrecognized VCR_MODE {mode!r}. Expected one of: {', '.join(VALID_VCR_MODES)}.")
+
+    # "once" is write-protected only once a cassette has been loaded --
+    # Cassette.write_protected is `rewound and record_mode == ONCE`, and `rewound` is set
+    # only by a successful _load(). So a missing cassette file makes "once" record live,
+    # and two workers reaching the same missing cassette would both call the live API and
+    # race to write one file. Serializing every "once" run would make the default run
+    # (VCR_MODE unset) single-process; downgrading to "none" instead keeps the fan-out and
+    # removes the write path altogether, turning a missing cassette into a failure rather
+    # than a live call. Recording is unaffected: it is single-process by then.
+    if mode == "once" and _in_xdist_worker() and not _recording_opted_in():
+        return "none"
 
     return mode
 
@@ -344,19 +361,27 @@ def _isolatable_database_count() -> int:
     return max(0, REDIS_DATABASE_COUNT - 1 - _redis_database(location))
 
 
+def _recording_opted_in() -> bool:
+    """Whether this run explicitly asked to record PolicyEngine cassettes."""
+    return os.getenv(PE_RECORD_ENV_VAR, "").lower() in PE_RECORD_TRUTHY
+
+
 def _run_records_cassettes(mode: str) -> bool:
     """Whether this run may write a cassette, and so must not fan out across workers.
 
-    ``all`` and ``new_episodes`` record on a cassette miss. ``once`` does not qualify on
-    its own: it is the default when VCR_MODE is unset and writes only when an entire
-    cassette file is absent, so treating it as recording would make every default run
-    serial. ``PE_RECORD`` is the explicit opt-in that turns a ``once`` run into a
-    recording one -- see docs/TESTING.md.
+    ``all`` and ``new_episodes`` record on a cassette miss, and ``PE_RECORD`` is the
+    explicit opt-in that makes an otherwise-replaying run record -- see docs/TESTING.md.
+
+    ``once`` does not qualify on its own. It is the default when VCR_MODE is unset, and
+    a run of a fully-recorded suite only replays; treating it as recording would make
+    every default run serial. It *can* still write when a cassette file is missing
+    entirely, which is why ``vcr_record_mode`` downgrades it to ``none`` on a parallel
+    run rather than this function claiming such a run is safe.
     """
     if mode in ("all", "new_episodes"):
         return True
 
-    return os.getenv(PE_RECORD_ENV_VAR, "").lower() in PE_RECORD_TRUTHY
+    return _recording_opted_in()
 
 
 def pytest_configure(config):
@@ -506,7 +531,8 @@ def auto_vcr(request, vcr_config):
     - Detects if a test is marked with @pytest.mark.integration
     - Automatically uses VCR to record/replay HTTP interactions
     - VCR_MODE=none (PRs and push to main): Read-only - replays only, never records, errors on new HTTP requests
-    - VCR_MODE=once (local default): Strict - replays existing cassettes, errors if test makes new HTTP request
+    - VCR_MODE=once (local default): Strict - replays existing cassettes, errors if test makes new HTTP
+      request. Becomes `none` in a parallel worker unless PE_RECORD is set
     - VCR_MODE=new_episodes: Flexible - replays existing, records new HTTP requests not yet in cassette
     - VCR_MODE=all (production deploy): Fresh start - never replays, re-records all cassettes from scratch
 

--- a/conftest.py
+++ b/conftest.py
@@ -232,8 +232,36 @@ def policy_engine_body(r1, r2):
     return True
 
 
+def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
+    """Point this xdist worker at its own Redis database.
+
+    ``clear_cache`` flushes the whole cache before every test, and on django_redis that
+    flushes the entire database rather than just this run's keys. Workers sharing one
+    database therefore delete each other's entries mid-test: the symptom is a worker
+    losing the bearer token ``seed_pe_token`` just wrote and trying to authenticate
+    against live PolicyEngine ("client id or secret not configured" in CI).
+
+    Redis serves databases 0-15 by default, which bounds how many workers can be
+    isolated this way; beyond that they wrap and share again.
+    """
+    from django.conf import settings
+
+    location = settings.CACHES.get("default", {}).get("LOCATION", "")
+    if not location.startswith(("redis://", "rediss://")):
+        return
+
+    base, _, tail = location.rpartition("/")
+    if not tail.isdigit():
+        base, tail = location.rstrip("/"), "0"
+
+    # worker_id is "gw0", "gw1", ...; offset from the configured database so a worker
+    # never lands on the one a non-xdist run would use.
+    db = (int(tail) + 1 + int(worker_id.removeprefix("gw"))) % 16
+    settings.CACHES["default"]["LOCATION"] = f"{base}/{db}"
+
+
 def pytest_configure(config):
-    """Reject an unrecognized VCR_MODE before any test runs.
+    """Reject an unrecognized VCR_MODE before any test runs, and isolate per-worker state.
 
     vcr_record_mode() would raise anyway at the point of use, but that surfaces as an error on
     each integration test partway into the run. Checking at startup fails the whole session
@@ -244,6 +272,10 @@ def pytest_configure(config):
         vcr_record_mode()
     except ValueError as e:
         raise pytest.UsageError(str(e)) from e
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id:
+        _isolate_cache_per_xdist_worker(worker_id)
 
 
 @pytest.hookimpl(wrapper=True, tryfirst=True)

--- a/conftest.py
+++ b/conftest.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
 import pytest
 import vcr as vcrpy
@@ -232,17 +233,37 @@ def policy_engine_body(r1, r2):
     return True
 
 
+# Redis serves databases 0-15 by default. Database 0 is reserved for whatever a
+# non-xdist run uses, so workers get 1-15 and at most 15 can be isolated.
+REDIS_DATABASE_COUNT = 16
+MAX_ISOLATED_WORKERS = REDIS_DATABASE_COUNT - 1
+
+
+def redis_url_for_database(location: str, db: int) -> str:
+    """``location`` with its database index replaced by ``db``.
+
+    Split on the URL structure rather than the last "/": a Heroku-style
+    ``rediss://host:6379/0?ssl_cert_reqs=none`` carries a query string, and treating
+    that as part of the path produces ``...?ssl_cert_reqs=none/1`` -- an unusable URL
+    that still parses as a string. See benefits/cache_config.py for that shape.
+    """
+    parts = urlsplit(location)
+    return urlunsplit(parts._replace(path=f"/{db}"))
+
+
 def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
     """Point this xdist worker at its own Redis database.
 
-    ``clear_cache`` flushes the whole cache before every test, and on django_redis that
-    flushes the entire database rather than just this run's keys. Workers sharing one
+    ``clear_cache`` flushes the cache before every test, and on django_redis ``clear()``
+    issues FLUSHDB -- the whole database, not just this run's prefix. Workers sharing a
     database therefore delete each other's entries mid-test: the symptom is a worker
-    losing the bearer token ``seed_pe_token`` just wrote and trying to authenticate
-    against live PolicyEngine ("client id or secret not configured" in CI).
+    losing the bearer token ``seed_pe_token`` just wrote and authenticating against live
+    PolicyEngine ("client id or secret not configured" in CI).
 
-    Redis serves databases 0-15 by default, which bounds how many workers can be
-    isolated this way; beyond that they wrap and share again.
+    Workers map to databases 1..15, leaving database 0 to non-xdist runs and to
+    ``benefits/tests/test_redis_backend.py``, which pins REDIS_URL directly and flushes
+    it. Beyond 15 workers there is no database left to hand out, so fail loudly rather
+    than wrap onto a database another worker is already flushing.
     """
     from django.conf import settings
 
@@ -250,14 +271,15 @@ def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
     if not location.startswith(("redis://", "rediss://")):
         return
 
-    base, _, tail = location.rpartition("/")
-    if not tail.isdigit():
-        base, tail = location.rstrip("/"), "0"
+    index = int(worker_id.removeprefix("gw"))
+    if index >= MAX_ISOLATED_WORKERS:
+        raise pytest.UsageError(
+            f"xdist worker {worker_id} exceeds the {MAX_ISOLATED_WORKERS} Redis databases "
+            f"available for per-worker cache isolation. Run with -n {MAX_ISOLATED_WORKERS} "
+            "or fewer, or point REDIS_URL at a server with more databases."
+        )
 
-    # worker_id is "gw0", "gw1", ...; offset from the configured database so a worker
-    # never lands on the one a non-xdist run would use.
-    db = (int(tail) + 1 + int(worker_id.removeprefix("gw"))) % 16
-    settings.CACHES["default"]["LOCATION"] = f"{base}/{db}"
+    settings.CACHES["default"]["LOCATION"] = redis_url_for_database(location, index + 1)
 
 
 def pytest_configure(config):
@@ -269,9 +291,18 @@ def pytest_configure(config):
     message about the environment rather than an internal traceback.
     """
     try:
-        vcr_record_mode()
+        mode = vcr_record_mode()
     except ValueError as e:
         raise pytest.UsageError(str(e)) from e
+
+    # Every mode except "none" records on a cassette miss, which means real API calls
+    # and concurrent writes to the same cassette file. pytest.ini turns on -n auto for
+    # the common case (offline replay), so any recording run has to drop back to a
+    # single process -- enforced here rather than in CI alone, so it also covers the
+    # recording commands in docs/TESTING.md.
+    if mode != "none" and config.getoption("numprocesses", default=None):
+        config.option.numprocesses = 0
+        config.option.dist = "no"
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     if worker_id:

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,8 @@ import re
 from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
+from asgiref.local import Local
+
 import pytest
 import vcr as vcrpy
 from decouple import config
@@ -262,8 +264,16 @@ def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
 
     Workers map to databases 1..15, leaving database 0 to non-xdist runs and to
     ``benefits/tests/test_redis_backend.py``, which pins REDIS_URL directly and flushes
-    it. Beyond 15 workers there is no database left to hand out, so fail loudly rather
-    than wrap onto a database another worker is already flushing.
+    whatever it points at. More workers than databases wrap around and share, so
+    ``pytest_configure`` caps the worker count instead of letting that happen.
+
+    Rewriting ``settings.CACHES`` is not enough on its own: the connection handler caches
+    connection objects, and the default connection already exists by this point --
+    django-parler evaluates ``cache.default_timeout`` as a default argument at import
+    (``parler/cache.py``), so ``django.setup()`` builds it, and pytest-django calls that
+    from ``pytest_load_initial_conftests``, before any ``pytest_configure``. The rebuild
+    below is what actually moves the connection; without it the mutation is visible in
+    settings while every worker keeps flushing database 0.
     """
     from django.conf import settings
 
@@ -272,14 +282,30 @@ def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
         return
 
     index = int(worker_id.removeprefix("gw"))
-    if index >= MAX_ISOLATED_WORKERS:
-        raise pytest.UsageError(
-            f"xdist worker {worker_id} exceeds the {MAX_ISOLATED_WORKERS} Redis databases "
-            f"available for per-worker cache isolation. Run with -n {MAX_ISOLATED_WORKERS} "
-            "or fewer, or point REDIS_URL at a server with more databases."
-        )
-
     settings.CACHES["default"]["LOCATION"] = redis_url_for_database(location, index + 1)
+    _rebuild_cache_connections()
+
+
+def _cache_needs_per_worker_database() -> bool:
+    """Whether the configured cache is a Redis one workers would otherwise share."""
+    from django.conf import settings
+
+    location = settings.CACHES.get("default", {}).get("LOCATION", "")
+    return isinstance(location, str) and location.startswith(("redis://", "rediss://"))
+
+
+def _rebuild_cache_connections() -> None:
+    """Drop cached cache connections so the next access reads current settings.
+
+    Mirrors Django's own ``clear_cache_handlers`` (``django/test/signals.py``), which is
+    what fires when ``override_settings`` changes CACHES. Called directly here because
+    mutating ``settings.CACHES`` in place sends no ``setting_changed`` signal.
+    """
+    from django.core.cache import caches, close_caches
+
+    close_caches()
+    caches._settings = caches.settings = caches.configure_settings(None)
+    caches._connections = Local()
 
 
 def pytest_configure(config):
@@ -303,6 +329,20 @@ def pytest_configure(config):
     if mode != "none" and config.getoption("numprocesses", default=None):
         config.option.numprocesses = 0
         config.option.dist = "no"
+
+    # The worker count is capped by --maxprocesses in pytest.ini, which xdist applies
+    # before it spawns anything. It cannot be enforced from here: pytest_cmdline_main
+    # has already turned numprocesses into the worker list (config.option.tx) by the
+    # time pytest_configure runs, so changing it now spawns the original count anyway.
+    # Assert the cap held rather than silently wrapping onto a shared database.
+    worker_count = config.getoption("numprocesses", default=None)
+    if worker_count and worker_count > MAX_ISOLATED_WORKERS and _cache_needs_per_worker_database():
+        raise pytest.UsageError(
+            f"-n {worker_count} exceeds the {MAX_ISOLATED_WORKERS} Redis databases available "
+            "for per-worker cache isolation; workers would share a database and flush each "
+            f"other's entries. Pass --maxprocesses {MAX_ISOLATED_WORKERS} (pytest.ini sets "
+            "this by default)."
+        )
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     if worker_id:

--- a/conftest.py
+++ b/conftest.py
@@ -49,6 +49,12 @@ HUD_TEST_PATH_FRAGMENT = "hud_income_limits"
 # programs/framework/tests/integration_test_helpers.py).
 VCR_IGNORE_HOSTS = ["policyengine.uk.auth0.com"]
 
+# Recording PolicyEngine cassettes is an explicit opt-in rather than a VCR_MODE, so the
+# serial-run check below has to consider it too. Mirrors
+# programs/programs/testing_fixtures/pe_integration.py.
+PE_RECORD_ENV_VAR = "PE_RECORD"
+PE_RECORD_TRUTHY = ("1", "true", "yes")
+
 # Record modes VCR_MODE may name. Anything else falls back to "once".
 VALID_VCR_MODES = ("none", "new_episodes", "all", "once")
 DEFAULT_VCR_MODE = "once"
@@ -277,9 +283,10 @@ def _isolate_cache_per_xdist_worker(worker_id: str) -> None:
     """
     from django.conf import settings
 
-    location = settings.CACHES.get("default", {}).get("LOCATION", "")
-    if not location.startswith(("redis://", "rediss://")):
+    if not _cache_needs_per_worker_database():
         return
+
+    location = settings.CACHES["default"]["LOCATION"]
 
     index = int(worker_id.removeprefix("gw"))
     settings.CACHES["default"]["LOCATION"] = redis_url_for_database(location, index + 1)
@@ -308,6 +315,21 @@ def _rebuild_cache_connections() -> None:
     caches._connections = Local()
 
 
+def _run_records_cassettes(mode: str) -> bool:
+    """Whether this run may write a cassette, and so must not fan out across workers.
+
+    ``all`` and ``new_episodes`` record on a cassette miss. ``once`` does not qualify on
+    its own: it is the default when VCR_MODE is unset and writes only when an entire
+    cassette file is absent, so treating it as recording would make every default run
+    serial. ``PE_RECORD`` is the explicit opt-in that turns a ``once`` run into a
+    recording one -- see docs/TESTING.md.
+    """
+    if mode in ("all", "new_episodes"):
+        return True
+
+    return os.getenv(PE_RECORD_ENV_VAR, "").lower() in PE_RECORD_TRUTHY
+
+
 def pytest_configure(config):
     """Reject an unrecognized VCR_MODE before any test runs, and isolate per-worker state.
 
@@ -321,27 +343,32 @@ def pytest_configure(config):
     except ValueError as e:
         raise pytest.UsageError(str(e)) from e
 
-    # Every mode except "none" records on a cassette miss, which means real API calls
-    # and concurrent writes to the same cassette file. pytest.ini turns on -n auto for
-    # the common case (offline replay), so any recording run has to drop back to a
-    # single process -- enforced here rather than in CI alone, so it also covers the
-    # recording commands in docs/TESTING.md.
-    if mode != "none" and config.getoption("numprocesses", default=None):
+    # A run that may write cassettes has to be single-process: workers would issue
+    # duplicate live calls and race to write the same file. Enforced here rather than in
+    # CI alone so it also covers the recording commands in docs/TESTING.md.
+    #
+    # "once" is deliberately not treated as recording on its own. It is the default when
+    # VCR_MODE is unset, and it only writes when an entire cassette file is absent --
+    # every fully-recorded run replays. Treating it as recording made the default local
+    # run serial, contradicting the parallel-by-default behaviour pytest.ini configures.
+    # PE_RECORD is the explicit opt-in that turns a "once" run into a recording one
+    # (docs/TESTING.md records PolicyEngine cassettes with PE_RECORD=1 VCR_MODE=once).
+    if _run_records_cassettes(mode) and config.getoption("numprocesses", default=None):
         config.option.numprocesses = 0
         config.option.dist = "no"
 
-    # The worker count is capped by --maxprocesses in pytest.ini, which xdist applies
-    # before it spawns anything. It cannot be enforced from here: pytest_cmdline_main
-    # has already turned numprocesses into the worker list (config.option.tx) by the
-    # time pytest_configure runs, so changing it now spawns the original count anyway.
-    # Assert the cap held rather than silently wrapping onto a shared database.
-    worker_count = config.getoption("numprocesses", default=None)
-    if worker_count and worker_count > MAX_ISOLATED_WORKERS and _cache_needs_per_worker_database():
+    # --maxprocesses in pytest.ini caps the fan-out to the databases available for
+    # per-worker cache isolation. Read the worker list rather than numprocesses: xdist
+    # applies the cap when it builds config.option.tx and never rewrites numprocesses,
+    # so on a machine with more cores than databases numprocesses still reports the
+    # uncapped count and comparing against it aborts a run that was correctly capped.
+    worker_count = len(config.option.tx or [])
+    if worker_count > MAX_ISOLATED_WORKERS and _cache_needs_per_worker_database():
         raise pytest.UsageError(
-            f"-n {worker_count} exceeds the {MAX_ISOLATED_WORKERS} Redis databases available "
-            "for per-worker cache isolation; workers would share a database and flush each "
-            f"other's entries. Pass --maxprocesses {MAX_ISOLATED_WORKERS} (pytest.ini sets "
-            "this by default)."
+            f"{worker_count} workers exceeds the {MAX_ISOLATED_WORKERS} Redis databases "
+            "available for per-worker cache isolation; workers would share a database and "
+            f"flush each other's entries. Pass --maxprocesses {MAX_ISOLATED_WORKERS} "
+            "(pytest.ini sets this by default)."
         )
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,9 +26,11 @@ roughly three minutes to under one. Two things follow from that:
   `conftest.py` detects these and disables the fan-out, so the recording commands below
   need no extra flags. (`once` — the default when `VCR_MODE` is unset — only writes when
   a whole cassette file is absent, so it keeps the fan-out.)
-- **Each worker gets its own Redis database** (1-15) when `REDIS_URL` is set, because
+- **Each worker gets its own Redis database** when `REDIS_URL` is set, because
   `clear_cache` issues FLUSHDB and would otherwise wipe other workers' entries mid-test.
-  Database 0 is left to serial runs and to `benefits/tests/test_redis_backend.py`.
+  Workers are numbered *above* the database `REDIS_URL` names, leaving that one to serial
+  runs and to `benefits/tests/test_redis_backend.py`, which flushes it directly. Pointing
+  `REDIS_URL` at a higher database leaves fewer to hand out.
   `pytest.ini` therefore caps the fan-out with `--maxprocesses 15`, which is what keeps
   `-n auto` safe on a large machine: it counts *logical* cores here (xdist prefers
   physical via `psutil`, which is not installed). Raising the cap past 15 fails with a

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,14 +24,20 @@ roughly three minutes to under one. Two things follow from that:
   `VCR_MODE=new_episodes`, and any run with `PE_RECORD=1` may write cassettes, and
   parallel workers would issue duplicate live API calls and race to write the same file.
   `conftest.py` detects these and disables the fan-out, so the recording commands below
-  need no extra flags. (`once` — the default when `VCR_MODE` is unset — only writes when
-  a whole cassette file is absent, so it keeps the fan-out.)
+  need no extra flags.
+- **`once` is downgraded to `none` inside a worker.** `once` is write-protected only
+  after a cassette has been loaded, so a *missing* cassette lets it record live — and two
+  workers hitting the same missing cassette would both call the API and race to write it.
+  A parallel run that has not opted into recording therefore replays strictly instead:
+  a missing cassette fails rather than being recorded. Serial runs keep `once` as-is, so
+  `pytest -n 0` still reports the "cassette missing, recorded it" behaviour if you want
+  it.
 - **Each worker gets its own Redis database** when `REDIS_URL` is set, because
   `clear_cache` issues FLUSHDB and would otherwise wipe other workers' entries mid-test.
   Workers are numbered *above* the database `REDIS_URL` names, leaving that one to serial
   runs and to `benefits/tests/test_redis_backend.py`, which flushes it directly. Pointing
   `REDIS_URL` at a higher database leaves fewer to hand out.
-  `pytest.ini` therefore caps the fan-out with `--maxprocesses 15`, which is what keeps
+  `pytest.ini` therefore caps the fan-out with `--maxprocesses 14`, which is what keeps
   `-n auto` safe on a large machine: it counts *logical* cores here (xdist prefers
   physical via `psutil`, which is not installed). Raising the cap past 15 fails with a
   message naming the limit rather than letting workers share a database.
@@ -74,7 +80,7 @@ Controlled by the `VCR_MODE` environment variable:
 | **PRs** (`pr-validation`) | `none` | **Read-only:** Replays only. A request with no matching cassette fails the build rather than being recorded live, so a PR cannot pass by reaching a real API. | ❌ No (never records) |
 | **Push to main** (`deploy-staging`) | `none` | Same as PRs: replay-only, parallel. Every commit here already passed the PR gate. | ❌ No (never records) |
 | **Release** (`deploy-production`) | `all` | **Fresh start:** Never replays. Re-records ALL cassettes from scratch. PolicyEngine spec-scenario tests skip (see below). | ✅ Yes (every non-skipped test hits the live API) |
-| **Local (default)** | `once` | **Strict:** Replays existing cassettes. **Errors if test makes new HTTP request not in cassette.** | Only if entire cassette file missing |
+| **Local (default)** | `once` | **Strict:** Replays existing cassettes. **Errors if test makes new HTTP request not in cassette.** In a parallel run (the default) this is downgraded to `none`, so a missing cassette fails instead of recording. | Only if entire cassette file missing, and only when running serially |
 | **Strict playback** | `none` | **Read-only:** Replays only. Never records. Errors on any new HTTP requests. | ❌ No (never records) |
 
 Re-recording in CI is never committed — no workflow commits cassettes — so a CI run in `new_episodes` or `all` mode does not refresh what's in the repo. It only changes what that run tests against.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,6 +17,19 @@ pytest
 pytest --cov --cov-report=html
 ```
 
+The suite runs in parallel by default (`-n auto` in `pytest.ini`), which takes it from
+roughly three minutes to under one. Two things follow from that:
+
+- **Recording drops back to one process automatically.** Any `VCR_MODE` other than `none`
+  can record, and parallel workers would issue duplicate live API calls and race to write
+  the same cassette file. `conftest.py` detects this and disables the fan-out, so the
+  recording commands below need no extra flags.
+- **Each worker gets its own Redis database** (1-15) when `REDIS_URL` is set, because
+  `clear_cache` issues FLUSHDB and would otherwise wipe other workers' entries mid-test.
+  Runs above 15 workers fail with a clear message rather than sharing a database.
+
+Pass `-n 0` to force a serial run when debugging test interdependence.
+
 ### Unit Tests Only
 ```bash
 # Skip integration tests
@@ -50,8 +63,8 @@ Controlled by the `VCR_MODE` environment variable:
 
 | Environment | VCR_MODE | Behavior | API Calls |
 |------------|----------|----------|-----------|
-| **PRs** (`pr-validation`) | `new_episodes` | **Flexible:** Replays existing interactions. Records new HTTP requests not yet in cassette. | ✅ Yes (only for new HTTP requests) |
-| **Push to main** (`deploy-staging`) | `new_episodes` | Same as PRs. | ✅ Yes (only for new HTTP requests) |
+| **PRs** (`pr-validation`) | `none` | **Read-only:** Replays only. A request with no matching cassette fails the build rather than being recorded live, so a PR cannot pass by reaching a real API. | ❌ No (never records) |
+| **Push to main** (`deploy-staging`) | `none` | Same as PRs: replay-only, parallel. Every commit here already passed the PR gate. | ❌ No (never records) |
 | **Release** (`deploy-production`) | `all` | **Fresh start:** Never replays. Re-records ALL cassettes from scratch. PolicyEngine spec-scenario tests skip (see below). | ✅ Yes (every non-skipped test hits the live API) |
 | **Local (default)** | `once` | **Strict:** Replays existing cassettes. **Errors if test makes new HTTP request not in cassette.** | Only if entire cassette file missing |
 | **Strict playback** | `none` | **Read-only:** Replays only. Never records. Errors on any new HTTP requests. | ❌ No (never records) |
@@ -216,20 +229,22 @@ git diff integrations/**/cassettes/*.yaml
 
 ## CI/CD Testing Strategy
 
-### Pull Requests (VCR_MODE=new_episodes)
+### Pull Requests (VCR_MODE=none)
 ```yaml
-- Records new interactions only
-- Replays existing cassettes
-- Fast feedback for existing tests
-- Only makes API calls for new test scenarios
-- Requires HUD_API_TOKEN secret
+- Replays existing cassettes only
+- Never records; no API calls, no credentials needed
+- A request with no matching cassette fails the build
+- Runs in parallel (-n auto)
 ```
 
-**If new tests added**: New cassettes will be recorded automatically in CI.
+**If new tests added**: record their cassettes locally and commit them. CI will not record
+on your behalf — a missing cassette is a build failure, which is the point: it keeps a PR
+from passing against a live API.
 
-### Push to Main (VCR_MODE=new_episodes)
+### Push to Main (VCR_MODE=none)
 
-`deploy-staging` runs the same mode as PR validation — it does not re-record everything.
+`deploy-staging` runs the same strict playback as PR validation. Every commit reaching
+main has already passed that gate, so there is nothing left to record.
 
 ### Release / Production Deploy (VCR_MODE=all)
 ```yaml

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,7 +26,11 @@ roughly three minutes to under one. Two things follow from that:
   recording commands below need no extra flags.
 - **Each worker gets its own Redis database** (1-15) when `REDIS_URL` is set, because
   `clear_cache` issues FLUSHDB and would otherwise wipe other workers' entries mid-test.
-  Runs above 15 workers fail with a clear message rather than sharing a database.
+  Database 0 is left to serial runs and to `benefits/tests/test_redis_backend.py`.
+  `pytest.ini` therefore caps the fan-out with `--maxprocesses 15`; an explicit `-n`
+  above that fails with a message naming the limit. Note `-n auto` counts *logical*
+  cores here (xdist prefers physical via `psutil`, which is not installed), so it can
+  exceed 15 on a large machine -- hence the cap.
 
 Pass `-n 0` to force a serial run when debugging test interdependence.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,17 +20,19 @@ pytest --cov --cov-report=html
 The suite runs in parallel by default (`-n auto` in `pytest.ini`), which takes it from
 roughly three minutes to under one. Two things follow from that:
 
-- **Recording drops back to one process automatically.** Any `VCR_MODE` other than `none`
-  can record, and parallel workers would issue duplicate live API calls and race to write
-  the same cassette file. `conftest.py` detects this and disables the fan-out, so the
-  recording commands below need no extra flags.
+- **Recording drops back to one process automatically.** `VCR_MODE=all`,
+  `VCR_MODE=new_episodes`, and any run with `PE_RECORD=1` may write cassettes, and
+  parallel workers would issue duplicate live API calls and race to write the same file.
+  `conftest.py` detects these and disables the fan-out, so the recording commands below
+  need no extra flags. (`once` — the default when `VCR_MODE` is unset — only writes when
+  a whole cassette file is absent, so it keeps the fan-out.)
 - **Each worker gets its own Redis database** (1-15) when `REDIS_URL` is set, because
   `clear_cache` issues FLUSHDB and would otherwise wipe other workers' entries mid-test.
   Database 0 is left to serial runs and to `benefits/tests/test_redis_backend.py`.
-  `pytest.ini` therefore caps the fan-out with `--maxprocesses 15`; an explicit `-n`
-  above that fails with a message naming the limit. Note `-n auto` counts *logical*
-  cores here (xdist prefers physical via `psutil`, which is not installed), so it can
-  exceed 15 on a large machine -- hence the cap.
+  `pytest.ini` therefore caps the fan-out with `--maxprocesses 15`, which is what keeps
+  `-n auto` safe on a large machine: it counts *logical* cores here (xdist prefers
+  physical via `psutil`, which is not installed). Raising the cap past 15 fails with a
+  message naming the limit rather than letting workers share a database.
 
 Pass `-n 0` to force a serial run when debugging test interdependence.
 

--- a/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
+++ b/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
@@ -9,12 +9,18 @@ without an exemption a recording run mints one token per test that reaches the n
 from unittest import mock
 
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
+from benefits.tests.cache_override import LOCAL_CACHE
 from conftest import _preserved_cache_entries
 from integrations.clients.policyengine.engines import _PE_TOKEN_CACHE_KEY
 
 
+# Every test here reads and writes the one global token key. On the ambient Redis
+# that key is shared with every other concurrently running test process, which can
+# set or clear it mid-test; pin these to a per-process cache so they observe only
+# their own writes.
+@override_settings(CACHES=LOCAL_CACHE)
 class TestPeTokenSurvivesTestCacheFlush(TestCase):
     def test_token_is_carried_across_a_flush(self):
         """The whole point: a token set before the flush is still readable after it."""

--- a/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
+++ b/integrations/clients/policyengine/tests/test_token_cache_survives_test_flush.py
@@ -71,19 +71,33 @@ class TestPeTokenSurvivesTestCacheFlush(TestCase):
         with mock.patch.object(cache, "ttl", return_value=None, create=True):
             self.assertEqual(_preserved_cache_entries(), [(_PE_TOKEN_CACHE_KEY, "token-abc", None)])
 
-    def test_remaining_expiry_is_preserved_not_extended(self):
+    def test_remaining_expiry_is_carried_not_extended(self):
         """Restoring must not hand a stale token a fresh 30-day lease.
 
         Carrying the remaining TTL keeps the cache entry expiring when the token really does. A
         token that outlives its lease would 401, and ``PrivateApiSim`` evicts the key on 401 and
         requests a new one - self-healing, but only if the entry expires roughly on time.
+
+        ``ttl()`` is mocked because this class pins LocMemCache, which has no ``ttl`` at all --
+        so without the mock the assertion below would silently fall through to the no-expiry
+        case and this branch would go untested.
+        """
+        cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
+
+        with mock.patch.object(cache, "ttl", return_value=450, create=True):
+            ((_, _, timeout),) = _preserved_cache_entries()
+
+        self.assertEqual(timeout, 450)
+
+    def test_a_backend_without_ttl_restores_with_no_expiry(self):
+        """LocMemCache has no ttl() to consult, so there is no remaining lease to carry.
+
+        Falling back to no expiry keeps the token usable; a 401 evicts it if it really is
+        dead. This is the path the pinned LocMemCache in this class actually takes.
         """
         cache.set(_PE_TOKEN_CACHE_KEY, "token-abc", timeout=600)
 
         ((_, _, timeout),) = _preserved_cache_entries()
 
-        if hasattr(cache, "ttl"):
-            self.assertIsNotNone(timeout)
-            self.assertLessEqual(timeout, 600)
-        else:
-            self.assertIsNone(timeout)
+        self.assertFalse(hasattr(cache, "ttl"), "this test covers the no-ttl fallback")
+        self.assertIsNone(timeout)

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,13 +7,20 @@ python_files = tests.py test_*.py *_tests.py
 # built once per class rather than once per test.
 #
 # --maxprocesses caps the fan-out at the number of Redis databases conftest can hand
-# out for per-worker cache isolation (1-15, reserving 0). Past that, workers wrap onto
-# a database another worker is already flushing and stomp each other's entries. The cap
-# has to be an option xdist reads before it spawns workers, which rules out adjusting it
-# from pytest_configure. -n auto overshoots easily: xdist prefers physical cores via
-# psutil, which is not installed, and os.sched_getaffinity does not exist on macOS, so
-# it falls back to os.cpu_count() and counts logical cores.
-addopts = --reuse-db --nomigrations -n auto --dist loadscope --maxprocesses 15
+# out for per-worker cache isolation. Past that, workers would share a database and
+# FLUSHDB each other's entries, so conftest refuses to start instead. The cap has to be
+# an option xdist reads before it spawns workers, which rules out setting it from
+# pytest_configure. -n auto overshoots easily: xdist prefers physical cores via psutil,
+# which is not installed, and os.sched_getaffinity does not exist on macOS, so it falls
+# back to os.cpu_count() and counts logical cores.
+#
+# 14, not 15: Redis serves databases 0-15, and workers are numbered *above* the database
+# REDIS_URL names (see _isolate_cache_per_xdist_worker), so the count available depends
+# on that index. CI uses /0 and could take 15; the committed developer .env uses /1,
+# which leaves 14. This is the value that works for both -- raising it to 15 makes a bare
+# pytest refuse to start on a >=15-core machine for anyone whose REDIS_URL is not /0.
+# If REDIS_URL moves to a higher database, this has to come down to match.
+addopts = --reuse-db --nomigrations -n auto --dist loadscope --maxprocesses 14
 markers =
     integration: marks tests as integration tests (require external API access)
 env =

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,15 @@ python_files = tests.py test_*.py *_tests.py
 # worker its own test database (suffixed _gwN), so --reuse-db stays safe.
 # loadscope keeps a TestCase's methods on one worker, so class-level fixtures are
 # built once per class rather than once per test.
-addopts = --reuse-db --nomigrations -n auto --dist loadscope
+#
+# --maxprocesses caps the fan-out at the number of Redis databases conftest can hand
+# out for per-worker cache isolation (1-15, reserving 0). Past that, workers wrap onto
+# a database another worker is already flushing and stomp each other's entries. The cap
+# has to be an option xdist reads before it spawns workers, which rules out adjusting it
+# from pytest_configure. -n auto overshoots easily: xdist prefers physical cores via
+# psutil, which is not installed, and os.sched_getaffinity does not exist on macOS, so
+# it falls back to os.cpu_count() and counts logical cores.
+addopts = --reuse-db --nomigrations -n auto --dist loadscope --maxprocesses 15
 markers =
     integration: marks tests as integration tests (require external API access)
 env =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,11 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = benefits.settings
 python_files = tests.py test_*.py *_tests.py
-addopts = --reuse-db --nomigrations
+# -n auto fans the suite across every available core; pytest-django gives each
+# worker its own test database (suffixed _gwN), so --reuse-db stays safe.
+# loadscope keeps a TestCase's methods on one worker, so class-level fixtures are
+# built once per class rather than once per test.
+addopts = --reuse-db --nomigrations -n auto --dist loadscope
 markers =
     integration: marks tests as integration tests (require external API access)
 env =

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ pytest==8.4.2
 pytest-django==4.11.1
 pytest-cov==7.0.0
 pytest-env==1.2.0
+pytest-xdist==3.8.0
 protobuf==5.29.6
 psycopg2==2.9.10
 psycopg2-binary==2.9.10

--- a/screener/tests/test_assistant_context.py
+++ b/screener/tests/test_assistant_context.py
@@ -21,13 +21,14 @@ from unittest import mock
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import translation
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from benefits.tests.cache_override import LOCAL_CACHE
 from programs.models import Program
 from screener.assistant import (
     CONTEXT_PREFETCH,
@@ -823,14 +824,16 @@ class AssistantStartViewTests(APITestCase):
         self.assertEqual(response.status_code, 403)
 
 
+@override_settings(CACHES=LOCAL_CACHE)
 class AssistantThrottleTests(APITestCase):
     """The throttles are on AllowAny endpoints that proxy to a paid LLM, so "it's
     configured" isn't enough — assert one actually engages and returns 429.
 
-    Throttle history is cache-backed and LocMemCache is shared for the whole test
-    session, so every test here clears it. Without that, `AssistantStartViewTests`
-    spending part of the 30/hour budget would eventually make these fail for unrelated
-    reasons — and vice versa.
+    Throttle history is cache-backed, so these tests pin the cache to a per-process
+    LocMemCache. Left on the ambient backend they share one Redis with every other
+    test process, and a concurrent run spending part of the 30/hour budget makes the
+    429 assertion fail for reasons unrelated to throttling. The clears below keep the
+    budget clean between tests within this process.
     """
 
     def setUp(self):

--- a/translations/models.py
+++ b/translations/models.py
@@ -296,13 +296,16 @@ class Translation(TranslatableModel):
 
         for lang_code, _ in settings.LANGUAGES:
             try:
-                self.set_current_language(lang_code)
-                new_text = self.text
-                new_edited = self.edited
-
+                # Nothing to diff against means nothing to record, so bail before
+                # touching self.text -- reading a language that has no translation
+                # row raises, and this loop covers every configured language.
                 old = old_translations.get(lang_code)
                 if old is None:
                     continue
+
+                self.set_current_language(lang_code)
+                new_text = self.text
+                new_edited = self.edited
 
                 if old["text"] != new_text:
                     latest_history = self.history.first()

--- a/translations/tests.py
+++ b/translations/tests.py
@@ -331,3 +331,38 @@ class TestAdminAutoTranslateFailurePaths(TestCase):
         self.assertEqual(parent.text, "es-text")
         # fr was omitted by the guard, so no row should have been written for it.
         self.assertFalse(parent.has_translation("fr"))
+
+
+class TestTranslationSaveDoesNotReportExpectedMisses(TestCase):
+    """`Translation.save()` diffs each configured language against its pre-save text
+    to fill in the latest history row's `affected_language`/`original_text` fields.
+
+    A brand-new Translation has no prior text for any language, so there is nothing
+    to diff. The languages must be skipped before the descriptor read that would
+    raise for them -- otherwise every save reports a swallowed DoesNotExist per
+    language to Sentry, which both floods the error budget and dominates the cost of
+    creating a Translation.
+    """
+
+    def test_creating_a_translation_reports_nothing_to_sentry(self):
+        with patch.object(translation_models, "capture_exception") as capture:
+            Translation.objects.add_translation("test.save_reports_nothing", default_message="hello")
+
+        self.assertEqual(
+            capture.call_args_list,
+            [],
+            "creating a Translation should not funnel expected missing-language reads to Sentry",
+        )
+
+    def test_editing_a_translation_still_records_the_language_it_changed(self):
+        translation = Translation.objects.add_translation("test.save_records_diff", default_message="before")
+
+        with patch.object(translation_models, "capture_exception") as capture:
+            Translation.objects.edit_translation("test.save_records_diff", DEFAULT_LANG, "after")
+
+        self.assertEqual(capture.call_args_list, [])
+
+        latest = Translation.objects.get(pk=translation.pk).history.first()
+        self.assertEqual(latest.affected_language, DEFAULT_LANG)
+        self.assertEqual(latest.original_text, "before")
+        self.assertEqual(latest.changed_text, "after")


### PR DESCRIPTION
Closes [MFB-1757](https://linear.app/myfriendben/issue/MFB-1757/speed-up-the-ci-test-suite-parallelize-pytest-and-stop-sentry)

The `Run tests with VCR and upload coverage` step takes **~13 minutes** on every PR and gets worse as we add cassettes. It turns out VCR isn't the problem.

## What the profiling showed

From run [33563779523](https://github.com/MyFriendBen/benefits-api/actions/runs/33563779523):

| Phase | Time |
| --- | --- |
| Container init + checkout | 29s |
| pip install | 30s |
| Django checks + migrate | 23s |
| **pytest** | **668s (11m08s)** |
| Codecov upload | ~10s |

Setup is only ~80s, so trimming CI steps wasn't going to help. 3,928 tests in 668s is ~170ms average — no slow-network signature. The slowest file (`screener/tests/test_assistant_context.py`, 132s) makes no external calls at all.

Two actual causes:

### 1. The suite ran on one core

`pytest-xdist` wasn't installed, so ~3,930 tests ran single-threaded on a 4-core runner. `pytest.ini` now runs `-n auto --dist loadscope`. `loadscope` keeps a TestCase's methods on one worker, so class-level fixtures build once per class rather than once per test.

### 2. `Translation.save()` sent a swallowed exception to Sentry per language, per save

The history-diff loop read `self.text` *before* checking whether there was anything to diff against:

```python
self.set_current_language(lang_code)
new_text = self.text          # raises for any language with no translation row
new_edited = self.edited

old = old_translations.get(lang_code)
if old is None:
    continue                  # ...the value was never needed
```

A newly created `Translation` has no prior value for any language, so this raised `DoesNotExist` for all 18 configured languages and funnelled each one to `sentry_sdk.capture_exception` — then threw the value away at the guard immediately below.

Profiling `seed_program()` ×10:

- `Translation.save()` was **2.83s of 3.52s** total
- **1,800** `capture_exception` calls = **0.92s** (~26% of the time spent building and shipping exception objects)

Hoisting the guard above the read: `save()` **2.83s → 1.08s (-62%)**, `seed_program` **3.52s → 2.56s (-27%)**, `capture_exception` calls → **0**.

Worth flagging separately: this was also happening in production. Every translation write — admin edits and the bulk auto-translate commands — sent a burst of spurious exceptions to Sentry, eating error budget and burying real errors. Distinct from [MFB-166](https://linear.app/myfriendben/issue/MFB-166/central-clean-up-strategy-for-translation-history), which is about the `HistoricalTranslation` *table* growing unbounded; this is the wasted exception handling in the save path.

## Two tests that were only safe because the suite was serial

Parallelism surfaced two classes sharing global cache keys via the ambient Redis, where a concurrent worker can change the key mid-test:

- **`AssistantThrottleTests`** — throttle history is cache-backed, so another worker spending part of the 30/hour budget breaks the 429 assertion. Its docstring already warned about exactly this, but it had no `CACHES` override.
- **`TestPeTokenSurvivesTestCacheFlush`** — all six tests read/write the one global PE token key.

Both now use `@override_settings(CACHES=LOCAL_CACHE)`, the pattern `benefits/tests/cache_override.py` already documents. These were latent bugs, not new ones.

## Recording modes stay serial

`deploy-production.yml` runs `vcr-mode: all`, which re-records every cassette against live APIs. Parallel workers there would multiply load on PolicyEngine and race to write the same cassette files, so the action pins any recording mode to `-n 0` and keeps the fan-out for pure playback.

## PR validation moves to strict playback

`vcr-mode: new_episodes` → `none`. This one is about correctness, not speed: `new_episodes` silently records live calls when no cassette matches, so a PR could go green by hitting a real API, and it needed `HUD_API_TOKEN` to pass. Strict playback fails loudly on a missing cassette instead.

## Results

3,930 passed, 0 failed. Ran the full suite three consecutive times to rule out parallelism flake, and verified both CI paths.

| | Before | After |
| --- | --- | --- |
| Full suite, parallel playback | — | **45s** |
| Full suite, serial (deploy path) | 179s | 179s (unchanged) |
| `test_assistant_context.py` | 56s | 25s |

Expect CI to go from ~13min to **~3min**, and it now scales with cores as cassette coverage grows.

## Considered and skipped

- **Dropping `--cov` on PRs** — costs ~40% (43s → 60s), but losing Codecov PR deltas isn't worth it now that the suite is under a minute.
- **Selecting tests by changed files** — cross-white-label calculators and shared config mean an unrelated-looking edit genuinely can break MO or TX. Parallelism gets the same speedup without giving up the safety net.

## Where to focus review: per-worker Redis cache isolation

The largest and subtlest part of this diff isn't the parallelism switch — it's making the
suite *safe* to run in parallel. `clear_cache` empties the cache before every test, and on
django_redis `clear()` issues **FLUSHDB**: the whole database, ignoring `KEY_PREFIX`. Workers
sharing one Redis therefore delete each other's entries mid-test. That's what produced the
first CI failure here — a worker lost the PolicyEngine bearer token `seed_pe_token` had just
written and fell through to a live auth attempt (`client id or secret not configured`).

Worth reading closely, in `conftest.py`:

- **`_isolate_cache_per_xdist_worker`** — gives each worker its own Redis database. Two
  non-obvious constraints: it must **rebuild the connection handler**, because the default
  connection already exists by the time `pytest_configure` runs (django-parler reads
  `cache.default_timeout` at import, so `django.setup()` builds it, and pytest-django calls
  that from `pytest_load_initial_conftests`); and workers are numbered **above** the database
  `REDIS_URL` names, so the base stays free for serial runs and for `test_redis_backend.py`,
  which flushes it directly.
- **`redis_url_for_database`** — splits on URL structure rather than the last `/`, so the
  Heroku `rediss://…?ssl_cert_reqs=none` shape doesn't get mangled into `…none/1`.
- **`_run_records_cassettes`** — which runs may write a cassette, and so must not fan out.
  `once` is deliberately excluded (it's the unset default and only writes when a whole
  cassette file is absent); `PE_RECORD=1` is included, since that's how PE cassettes get
  recorded.
- **The `--maxprocesses` cap** — bounded by available Redis databases, and read from
  `config.option.tx` rather than `numprocesses`, which xdist never rewrites.
- **`benefits/tests/test_xdist_cache_isolation.py`** — asserts on the *resolved connection*,
  not on `settings.CACHES`. An earlier version asserted only on settings and passed while
  isolation did nothing.

Two test classes that were only safe because the suite was serial (`AssistantThrottleTests`,
`TestPeTokenSurvivesTestCacheFlush`) are pinned to `LOCAL_CACHE` — latent bugs, not new ones.

## Known gap: CI no longer makes live API calls

Worth stating plainly, since it's a real coverage change: with PR validation and
`deploy-staging` on strict playback, **nothing in CI exercises a live API**. Cassette drift
against real PolicyEngine responses is now undetected until someone runs it by hand.

Two things make this less alarming than it sounds, but it should be tracked rather than
assumed:

1. `deploy-production` appears to provide a live-API gate, but **it has never run**. Its
   `test` job is `if: github.event.release.draft == true` while `deploy` is
   `if: github.event.action == 'published'`, and `deploy` has no `needs: test` — mutually
   exclusive for a single event, so on a real publish the live suite is skipped and deploy
   proceeds regardless. Broken since `da637712` (MFB-459, 2025-11-25); pre-existing and not
   touched here.
2. So this PR removes *incidental* live coverage (PRs/staging recording on a cassette miss),
   not a deliberate gate.

Tracked on [MFB-1565](https://linear.app/myfriendben/issue/MFB-1565/test-machinery-ci-vcr-mode-enforcement-cassette-refresh-policy),
which owns the scheduled drift job (M6) that should own live runs. The broken-gate finding and
the credentials answer are recorded there. `VCR_MODE=all` stays on `deploy-production` in this
PR — removing it belongs with M6, once there's somewhere for live runs to live.

## Reviewer notes

- The regression test was verified to fail without the `models.py` fix, and it also asserts history diffs are still recorded on edit — so the fix doesn't quietly disable the feature.
- Recording modes are forced serial from `pytest_configure` rather than in the CI action, so the behaviour also covers the recording commands in `docs/TESTING.md`.
- `--maxprocesses 14`, not 15: workers are numbered above the `REDIS_URL` database, and the committed developer `.env` uses `/1`, which leaves 14. `.env` is gitignored, so this can't be fixed there. `pytest.ini` documents the coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation saving when configured languages do not yet have translations.
  * Prevented expected missing translations from being reported as errors.
  * Preserved accurate translation history when existing translations are edited.

* **Quality Improvements**
  * Improved parallel test reliability through worker isolation and process limits.
  * Strengthened validation by requiring recorded interactions to match expected scenarios.
  * Added Redis-backed testing for more representative staging validation.

* **Documentation**
  * Updated testing guidance for parallel execution, recording workflows, and strict replay mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
