### PR TITLE
Add state-code subclasses for CO, IL, MA and NC Lifeline; drop non_citizen/gc_5less from the Lifeline configs

### DIFF
--- a/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
@@ -8,7 +8,7 @@
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "lifeline",
+        "name_abbreviated": "co_lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",

--- a/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
@@ -8,7 +8,7 @@
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "lifeline",
+        "name_abbreviated": "il_lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",

--- a/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
@@ -8,7 +8,7 @@
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "lifeline",
+        "name_abbreviated": "ma_lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",

--- a/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
@@ -8,7 +8,7 @@
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "lifeline",
+        "name_abbreviated": "nc_lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",

--- a/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -12,9 +12,7 @@
         "year": "2026",
         "legal_status_required": [
             "citizen",
-            "non_citizen",
             "gc_5plus",
-            "gc_5less",
             "refugee",
             "otherWithWorkPermission"
         ],

--- a/programs/management/commands/tests/test_five_year_bar_legal_statuses.py
+++ b/programs/management/commands/tests/test_five_year_bar_legal_statuses.py
@@ -41,9 +41,9 @@ CALCULATED = {
 }
 KNOWN_LABELS = USER_SELECTED | CALCULATED
 
-# Every program whose config this change edits, plus wa_fap, which the wa_snap edit has to stay
-# disjoint from — pinned to the exact statuses each should declare. Pinning the whole set is what
-# stops a later config pass from quietly re-adding `gc_5less` to any of them.
+# Programs pinned to the exact statuses each should declare — plus wa_fap, which the wa_snap edit
+# has to stay disjoint from. Pinning the whole set is what stops a later config pass from quietly
+# re-adding `gc_5less` to any of them.
 #
 # SNAP exempts LPRs under 18 from the bar regardless of the status they adjusted from, so
 # `gc_under18_no5` replaces bare `gc_5less`. TANF has no age-based exemption, so `gc_5less` simply
@@ -69,6 +69,20 @@ EDITED_PROGRAMS = {
     },
     "tx_medicaid_for_pregnant_women": {"citizen", "gc_5plus", "refugee"},
     "il_mpe": {"citizen", "gc_5plus", "gc_5less", "refugee", "otherWithWorkPermission"},
+    # Lifeline, every white label. DOJ's Office of Legal Counsel concluded PRWORA reaches Lifeline
+    # as both a federal public benefit and a federal means-tested public benefit, so `non_citizen`
+    # comes off under the first finding and `gc_5less` under the second. `otherWithWorkPermission`
+    # stays: the bucket mixes qualified aliens subject only to the five-year clock with lawfully
+    # present statuses that never clear the qualified-alien gate at all, so removing it would
+    # over-exclude. A scoped warning banner carries that distinction instead.
+    "co_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "il_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "ks_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "ma_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "mo_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "nc_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "tx_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
+    "wa_lifeline": {"citizen", "gc_5plus", "refugee", "otherWithWorkPermission"},
 }
 
 # The subset this change narrows for the bar, where bare `gc_5less` is the reported bug.
@@ -86,6 +100,18 @@ BAR_SUBJECT_PROGRAMS = (
     "mo_tanf",
     "ks_tanf",
     "wa_apple_health_medicaid",
+    # Lifeline is means-tested under PRWORA §403, so the bar applies. The age-split labels are not
+    # an exempt subset here the way they are for SNAP — they are `gc_5less` proxies via
+    # `linkedFilters`, so leaving either on would re-admit the population `gc_5less` removal
+    # excludes. None of the eight declares them.
+    "co_lifeline",
+    "il_lifeline",
+    "ks_lifeline",
+    "ma_lifeline",
+    "mo_lifeline",
+    "nc_lifeline",
+    "tx_lifeline",
+    "wa_lifeline",
 )
 
 # Federal SNAP does not reach refugee or asylee status. Washington serves that group through

--- a/programs/programs/cross_white_label/lifeline/co.py
+++ b/programs/programs/cross_white_label/lifeline/co.py
@@ -1,0 +1,19 @@
+"""CO Lifeline."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+import programs.framework.pe_dependencies as dependency
+
+
+class CoLifeline(Lifeline):
+    """Colorado carries no PolicyEngine state supplement, so the value is federal-only.
+
+    ``CoStateCodeDependency`` is still load-bearing: ``pe_input()`` never sends
+    ``state_code`` on its own, and without it PE falls back to its own default state.
+    """
+
+    program_code = "co_lifeline"
+
+    pe_inputs = [
+        *Lifeline.pe_inputs,
+        dependency.household.CoStateCodeDependency,
+    ]

--- a/programs/programs/cross_white_label/lifeline/il.py
+++ b/programs/programs/cross_white_label/lifeline/il.py
@@ -1,0 +1,19 @@
+"""IL Lifeline."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+import programs.framework.pe_dependencies as dependency
+
+
+class IlLifeline(Lifeline):
+    """Illinois carries no PolicyEngine state supplement, so the value is federal-only.
+
+    ``IlStateCodeDependency`` is still load-bearing: ``pe_input()`` never sends
+    ``state_code`` on its own, and without it PE falls back to its own default state.
+    """
+
+    program_code = "il_lifeline"
+
+    pe_inputs = [
+        *Lifeline.pe_inputs,
+        dependency.household.IlStateCodeDependency,
+    ]

--- a/programs/programs/cross_white_label/lifeline/ma.py
+++ b/programs/programs/cross_white_label/lifeline/ma.py
@@ -1,0 +1,19 @@
+"""MA Lifeline."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+import programs.framework.pe_dependencies as dependency
+
+
+class MaLifeline(Lifeline):
+    """Massachusetts carries no PolicyEngine state supplement, so the value is federal-only.
+
+    ``MaStateCodeDependency`` is still load-bearing: ``pe_input()`` never sends
+    ``state_code`` on its own, and without it PE falls back to its own default state.
+    """
+
+    program_code = "ma_lifeline"
+
+    pe_inputs = [
+        *Lifeline.pe_inputs,
+        dependency.household.MaStateCodeDependency,
+    ]

--- a/programs/programs/cross_white_label/lifeline/nc.py
+++ b/programs/programs/cross_white_label/lifeline/nc.py
@@ -1,0 +1,19 @@
+"""NC Lifeline."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+import programs.framework.pe_dependencies as dependency
+
+
+class NcLifeline(Lifeline):
+    """North Carolina carries no PolicyEngine state supplement, so the value is federal-only.
+
+    ``NcStateCodeDependency`` is still load-bearing: ``pe_input()`` never sends
+    ``state_code`` on its own, and without it PE falls back to its own default state.
+    """
+
+    program_code = "nc_lifeline"
+
+    pe_inputs = [
+        *Lifeline.pe_inputs,
+        dependency.household.NcStateCodeDependency,
+    ]

--- a/programs/programs/cross_white_label/lifeline/tests/test_co.py
+++ b/programs/programs/cross_white_label/lifeline/tests/test_co.py
@@ -1,0 +1,44 @@
+"""CO tests."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+from programs.programs.cross_white_label.lifeline.co import CoLifeline
+from django.test import TestCase
+import programs.framework.pe_dependencies as dependency
+
+
+class TestCoLifelineWiring(TestCase):
+    """CoLifeline registration and CO-specific pe_inputs handling."""
+
+    def test_is_subclass_of_lifeline(self):
+        self.assertTrue(issubclass(CoLifeline, Lifeline))
+
+    def test_program_code_is_state_scoped(self):
+        """The bare ``lifeline`` code belongs to the base class, which must not back a row."""
+        self.assertEqual(CoLifeline.program_code, "co_lifeline")
+
+    def test_pe_name_is_lifeline(self):
+        """The federal SPM-level variable; CO adds no state variable of its own."""
+        self.assertEqual(CoLifeline.pe_name, "lifeline")
+
+    def test_pe_outputs_are_inherited_from_lifeline(self):
+        self.assertEqual(CoLifeline.pe_outputs, [dependency.spm.Lifeline])
+
+    # --- the CO-specific input ---
+
+    def test_pe_inputs_includes_co_state_code(self):
+        """``pe_input()`` never sends state_code on its own, and PE's Lifeline chain
+        branches on it for both the state supplement and the income limit."""
+        self.assertIn(dependency.household.CoStateCodeDependency, CoLifeline.pe_inputs)
+
+    def test_co_state_code_dependency_sends_co(self):
+        self.assertEqual(dependency.household.CoStateCodeDependency.state, "CO")
+
+    # --- federal inputs must survive the CO override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in Lifeline.pe_inputs:
+            self.assertIn(federal_input, CoLifeline.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_the_state_code(self):
+        added = [d for d in CoLifeline.pe_inputs if d not in Lifeline.pe_inputs]
+        self.assertEqual(added, [dependency.household.CoStateCodeDependency])

--- a/programs/programs/cross_white_label/lifeline/tests/test_il.py
+++ b/programs/programs/cross_white_label/lifeline/tests/test_il.py
@@ -1,0 +1,44 @@
+"""IL tests."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+from programs.programs.cross_white_label.lifeline.il import IlLifeline
+from django.test import TestCase
+import programs.framework.pe_dependencies as dependency
+
+
+class TestIlLifelineWiring(TestCase):
+    """IlLifeline registration and IL-specific pe_inputs handling."""
+
+    def test_is_subclass_of_lifeline(self):
+        self.assertTrue(issubclass(IlLifeline, Lifeline))
+
+    def test_program_code_is_state_scoped(self):
+        """The bare ``lifeline`` code belongs to the base class, which must not back a row."""
+        self.assertEqual(IlLifeline.program_code, "il_lifeline")
+
+    def test_pe_name_is_lifeline(self):
+        """The federal SPM-level variable; IL adds no state variable of its own."""
+        self.assertEqual(IlLifeline.pe_name, "lifeline")
+
+    def test_pe_outputs_are_inherited_from_lifeline(self):
+        self.assertEqual(IlLifeline.pe_outputs, [dependency.spm.Lifeline])
+
+    # --- the IL-specific input ---
+
+    def test_pe_inputs_includes_il_state_code(self):
+        """``pe_input()`` never sends state_code on its own, and PE's Lifeline chain
+        branches on it for both the state supplement and the income limit."""
+        self.assertIn(dependency.household.IlStateCodeDependency, IlLifeline.pe_inputs)
+
+    def test_il_state_code_dependency_sends_il(self):
+        self.assertEqual(dependency.household.IlStateCodeDependency.state, "IL")
+
+    # --- federal inputs must survive the IL override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in Lifeline.pe_inputs:
+            self.assertIn(federal_input, IlLifeline.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_the_state_code(self):
+        added = [d for d in IlLifeline.pe_inputs if d not in Lifeline.pe_inputs]
+        self.assertEqual(added, [dependency.household.IlStateCodeDependency])

--- a/programs/programs/cross_white_label/lifeline/tests/test_ma.py
+++ b/programs/programs/cross_white_label/lifeline/tests/test_ma.py
@@ -1,0 +1,44 @@
+"""MA tests."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+from programs.programs.cross_white_label.lifeline.ma import MaLifeline
+from django.test import TestCase
+import programs.framework.pe_dependencies as dependency
+
+
+class TestMaLifelineWiring(TestCase):
+    """MaLifeline registration and MA-specific pe_inputs handling."""
+
+    def test_is_subclass_of_lifeline(self):
+        self.assertTrue(issubclass(MaLifeline, Lifeline))
+
+    def test_program_code_is_state_scoped(self):
+        """The bare ``lifeline`` code belongs to the base class, which must not back a row."""
+        self.assertEqual(MaLifeline.program_code, "ma_lifeline")
+
+    def test_pe_name_is_lifeline(self):
+        """The federal SPM-level variable; MA adds no state variable of its own."""
+        self.assertEqual(MaLifeline.pe_name, "lifeline")
+
+    def test_pe_outputs_are_inherited_from_lifeline(self):
+        self.assertEqual(MaLifeline.pe_outputs, [dependency.spm.Lifeline])
+
+    # --- the MA-specific input ---
+
+    def test_pe_inputs_includes_ma_state_code(self):
+        """``pe_input()`` never sends state_code on its own, and PE's Lifeline chain
+        branches on it for both the state supplement and the income limit."""
+        self.assertIn(dependency.household.MaStateCodeDependency, MaLifeline.pe_inputs)
+
+    def test_ma_state_code_dependency_sends_ma(self):
+        self.assertEqual(dependency.household.MaStateCodeDependency.state, "MA")
+
+    # --- federal inputs must survive the MA override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in Lifeline.pe_inputs:
+            self.assertIn(federal_input, MaLifeline.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_the_state_code(self):
+        added = [d for d in MaLifeline.pe_inputs if d not in Lifeline.pe_inputs]
+        self.assertEqual(added, [dependency.household.MaStateCodeDependency])

--- a/programs/programs/cross_white_label/lifeline/tests/test_nc.py
+++ b/programs/programs/cross_white_label/lifeline/tests/test_nc.py
@@ -1,0 +1,44 @@
+"""NC tests."""
+
+from programs.programs.cross_white_label.lifeline.base import Lifeline
+from programs.programs.cross_white_label.lifeline.nc import NcLifeline
+from django.test import TestCase
+import programs.framework.pe_dependencies as dependency
+
+
+class TestNcLifelineWiring(TestCase):
+    """NcLifeline registration and NC-specific pe_inputs handling."""
+
+    def test_is_subclass_of_lifeline(self):
+        self.assertTrue(issubclass(NcLifeline, Lifeline))
+
+    def test_program_code_is_state_scoped(self):
+        """The bare ``lifeline`` code belongs to the base class, which must not back a row."""
+        self.assertEqual(NcLifeline.program_code, "nc_lifeline")
+
+    def test_pe_name_is_lifeline(self):
+        """The federal SPM-level variable; NC adds no state variable of its own."""
+        self.assertEqual(NcLifeline.pe_name, "lifeline")
+
+    def test_pe_outputs_are_inherited_from_lifeline(self):
+        self.assertEqual(NcLifeline.pe_outputs, [dependency.spm.Lifeline])
+
+    # --- the NC-specific input ---
+
+    def test_pe_inputs_includes_nc_state_code(self):
+        """``pe_input()`` never sends state_code on its own, and PE's Lifeline chain
+        branches on it for both the state supplement and the income limit."""
+        self.assertIn(dependency.household.NcStateCodeDependency, NcLifeline.pe_inputs)
+
+    def test_nc_state_code_dependency_sends_nc(self):
+        self.assertEqual(dependency.household.NcStateCodeDependency.state, "NC")
+
+    # --- federal inputs must survive the NC override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in Lifeline.pe_inputs:
+            self.assertIn(federal_input, NcLifeline.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_the_state_code(self):
+        added = [d for d in NcLifeline.pe_inputs if d not in Lifeline.pe_inputs]
+        self.assertEqual(added, [dependency.household.NcStateCodeDependency])


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-1682](https://linear.app/myfriendben/issue/MFB-1682/bug-bare-federal-lifeline-sends-no-state-code-dollar0-for-co-il-ma-nc)
- Related: [MFB-1755](https://linear.app/myfriendben/issue/MFB-1755/admin-lifeline-prwora-legal-statuses-immigration-warning-row-renames) (Lifeline admin follow-through — now closed; the row renames this change depends on were moved onto MFB-1682 as a comment), [MFB-1673](https://linear.app/myfriendben/issue/MFB-1673/programs-directory-redesign-cross-white-label-vs-white-label-self) (a base class should never back a `Program` row)

The bare federal `Lifeline` class supplies no `state_code`. That is correct for a base class — the state code is each subclass's contribution — but CO, IL, MA and NC all resolve their `Program` row directly to it, so those four had no state code of their own.

**This is latent fragility, not a live bug.** The ticket reported $0 in all four white labels. That does not reproduce: `pe_input()` builds one PolicyEngine request per screen and every household-level dependency writes into a single shared `raw_input["household"]`, so `state_code` only needs one supplier per request. CO/IL/MA/NC have 11/16/12/6 calculator modules supplying theirs, including each white label's Medicaid program, so Lifeline already computes correctly in practice. Full analysis is in a comment on MFB-1682.

What this fixes is the case where no sibling covers it — a thin white label, or a screen where `can_calc()` / `_drop_unreadable_programs` thins the request. The failure mode there is a plausible-but-wrong value rather than an error, so it would not be obvious.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Added `CoLifeline`, `IlLifeline`, `MaLifeline` and `NcLifeline` in `programs/programs/cross_white_label/lifeline/{co,il,ma,nc}.py`, each declaring `program_code = "{wl}_lifeline"` and appending only its `{St}StateCodeDependency` to the inherited `pe_inputs`. Follows the existing `tx.py` / `mo.py` pattern; all four dependency classes already existed in `pe_dependencies/household.py`.
- Added structural tests in `lifeline/tests/test_{co,il,ma,nc}.py` mirroring `test_mo.py`: subclass relationship, state-scoped `program_code`, inherited `pe_name` and `pe_outputs`, the state-code dependency and its value, and that the federal inputs survive the override and are the *only* thing added.
- No change to the base class, no change to any existing calculator.
- **Removed `non_citizen` and `gc_5less` from `legal_status_required` in all eight `*_lifeline_initial_config.json` files.** DOJ's Office of Legal Counsel concluded that PRWORA applies to Lifeline as both a federal public benefit and a federal means-tested public benefit, so undocumented applicants and LPRs inside the five-year bar are not eligible. The live rows were already narrowed by hand in staging and prod; the configs kept declaring the permissive list. `refugee` stays (exempt from the bar under 8 USC 1613(b)); `otherWithWorkPermission` stays and carries a scoped warning banner instead.
- **Pointed `name_abbreviated` at `{white_label}_lifeline` in the co/il/ma/nc configs.** This documents the intended end state. The live rows still read `lifeline` until the post-deploy admin rename — see Deployment.
- **Pinned all eight Lifeline programs in `test_five_year_bar_legal_statuses.py`** — both the exact-status set (`EDITED_PROGRAMS`) and the no-bare-`gc_5less` guard (`BAR_SUBJECT_PROGRAMS`), so a later config pass cannot quietly re-add either status. The distinct `name_abbreviated` values above are what make this possible: `find_program()` matches on that field against the config JSON on disk, so four configs sharing `"lifeline"` could only ever pin one of them. Verified the guard bites by re-adding `gc_5less` to one config — two assertions fail; restoring it returns to green.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: none to *run* this PR. Two things changed in the eight config JSONs — `legal_status_required` on all eight, and `name_abbreviated` on co/il/ma/nc — but neither is applied by this PR. These configs are seed data and are not re-run against existing programs.
- Environment variables/settings to add: none
- Manual testing steps:
  - `pytest programs/programs/cross_white_label/lifeline/tests/` — 51 passing.
  - `pytest programs/management/commands/tests/test_five_year_bar_legal_statuses.py` — 15 passing (the new Lifeline pins run inside existing `subTest` loops, so the count is unchanged).
  - `pytest programs/management/commands/tests/ programs/programs/cross_white_label/lifeline/tests/` — 137 passing together.
  - Confirm the new classes register:
    ```
    python manage.py shell -c "
    from integrations.clients.policyengine.registry import all_calculators
    for k in ['co_lifeline','il_lifeline','ma_lifeline','nc_lifeline']:
        c = all_calculators[k]
        print(k, c.__name__, [d.__name__ for d in c.pe_inputs if 'StateCode' in d.__name__])
    "
    ```
  - Behaviour is unchanged until the rows are renamed, so there is nothing user-visible to test in this PR on its own.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: none
- Production config updates: none. The config JSON changes in this PR are seed data — nothing needs importing, and the importer is not re-run against existing programs.
- **Admin updates needed: yes. This PR is inert without them.**

  The PolicyEngine registry is keyed on `Program.name_abbreviated` from the **database**, not on the config files. Those four rows still read `lifeline`, so they keep resolving to the bare `Lifeline` base class and the new subclasses match nothing. Renaming the rows is what activates this change.

  **Required in each environment, after that environment has the deploy** (`/admin/programs/program/` → *Name abbreviated*):

  | White label | Row ID | From | To |
  | -- | -- | -- | -- |
  | co | 3 | `lifeline` | `co_lifeline` |
  | il | 727 | `lifeline` | `il_lifeline` |
  | ma | 363 | `lifeline` | `ma_lifeline` |
  | nc | 228 | `lifeline` | `nc_lifeline` |

  Row IDs are staging's. Go straight to `/admin/programs/program/<id>/change/`, or use
  `/admin/programs/program/` and search `lifeline` — note the search box matches the *translated
  program name*, not `name_abbreviated` (`ProgramAdmin.search_fields` is
  `("name__translations__text",)`), so all eight Lifeline programs come back and the
  `Name abbreviated` column is what distinguishes them.

  Per row: confirm **White label** and that **Name abbreviated** reads `lifeline`, change it, Save.
  Change nothing else — in particular leave *Legal status required* alone, and leave
  **External name** alone (it is independent of the registry, globally unique, and co's is
  deliberately the bare `lifeline`).

  Case does not matter — `Program.save()` lowercases the field. No collision risk: the constraint is
  composite, `UNIQUE (white_label_id, name_abbreviated)`, and none of the four new names is taken in
  its white label.

  Before saving, it is worth confirming the program holds no cross-white-label references.
  `SecureAdmin._set_select_queryset` (`authentication/admin.py:81-85`) filters `documents`,
  `category`, `required_programs`, `excludes_programs` and the navigator inline to the program's own
  white label with no superuser exemption, so a Save would drop any reference outside it. Checked on
  staging for all four before the rename: zero cross-white-label documents, categories, required or
  excluded programs, or navigators. Re-check on prod before renaming there.

  - [x] **Staging — done 2026-09-04.** QA results in a comment on MFB-1682.
  - [ ] Prod — after the release deploy

  ⚠️ **Do not rename before that environment is deployed.** `screener/views.py:475-478` iterates the registry and does `program_by_abbr.get(calculator_name)`; a program whose `name_abbreviated` has no registered calculator is silently skipped — no error, no log. Renaming early makes Lifeline disappear from results in those four white labels with nothing to alert you.

  `Program.save()` lowercases the field, so case does not matter, and the composite `UNIQUE (white_label_id, name_abbreviated)` constraint leaves the new names free.

  **Verify per environment:**
  ```sql
  SELECT wl.code AS white_label, p.name_abbreviated, p.active
  FROM programs_program p
  JOIN screener_whitelabel wl ON wl.id = p.white_label_id
  WHERE p.name_abbreviated LIKE '%lifeline%'
  ORDER BY wl.code;
  ```
  Pass: no row holds the bare value `lifeline`. Then run a qualifying screen in each of CO/IL/MA/NC (single adult, ~$14,400/yr employment income, SNAP as a current benefit) and confirm the Lifeline card shows at **$111/yr**. **Absent** is the failure mode to watch for, not $0.

  Tracked as a comment on MFB-1682 (moved there when MFB-1755 closed).
- Notify team/users of: nothing. No user-visible change from this PR — CO/IL/MA/NC were already computing $111/yr via sibling-supplied state codes, and the values are the same after the rename. (The PRWORA eligibility narrowing is already live in both environments from the MFB-1755 admin work; this PR only brings the configs into line with it.)

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
  - **The new classes are inert until the rows are renamed.** The registry keys on `Program.name_abbreviated`, which is still `lifeline` on all four rows, so nothing resolves to `CoLifeline` et al. yet. That is deliberate — shipping the code first is what makes the rename safe.
  - **The configs now describe the end state, not the current DB.** `name_abbreviated` reads `{white_label}_lifeline` in the co/il/ma/nc configs while those rows still say `lifeline`. That divergence is safe because these configs are seed data and are not re-run against existing programs. If anyone did run one before the rename, the importer's existence check (`filter(name_abbreviated=..., white_label=...)`, `import_program_config.py:146`) would miss, it would create a row, and then collide on the globally-unique `external_name` — an IntegrityError inside the import transaction, rolled back. Loud, not silent, and on an operation nobody performs.
  - **`data-queries` undercounts program value, and it is much broader than Lifeline.** `data.sql` is 113 hand-written `SUM(CASE WHEN spes.name_abbreviated = '<literal>')` columns plus a hand-maintained grand-total sum; diffing those keys against active programs leaves **166 of 243 missing**, including every `ks_`/`mo_`/`tx_`/`wa_` program. `lifeline_annual` is one instance — it misses four white labels today and would match nothing after the rename. A combined bug ticket is planned; separate repo either way.
  - The rename leaves stale `program.lifeline_<id>-*` translation labels (`programs/models.py:494` embeds `name_abbreviated` in the label). Cosmetic for the app; note `data_programs.sql` keys off those labels, so reporting name resolution is worth a check.
- Future considerations:
  - A data migration doing the rename instead of the manual admin edits would run inside the deploy, in the right order, in both environments — removing the silent-ordering hazard and four manual edits. Deliberately not done here; raised on MFB-1682 and left as an owner decision.
  - Worth deciding whether to deregister the bare `lifeline` calculator once the rows are renamed, so a future config typo cannot silently resolve back to a stateless base class. That would enforce MFB-1673's rule structurally rather than by convention.
  - The same defect class exists for `nslp` — bare `SchoolLunch` backs rows in CO/NC/MA with no state code, and PE's fallback there behaves like universal-free-meals, so the wrong-value risk is larger than Lifeline's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lifeline program support for Colorado, Illinois, Massachusetts, and North Carolina.
  * State-specific program configurations now pass the appropriate state code for eligibility evaluation while retaining federal Lifeline inputs and outputs.

* **Tests**
  * Added coverage verifying program registration, inherited configuration, state-code handling, and preservation of federal inputs for all four states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

