### PR TITLE
MFB-1051: point KS WIC and KS federal EITC at the shared categories

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_eitc_federal_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_eitc_federal_initial_config.json
@@ -3,7 +3,7 @@
     "code": "ks"
   },
   "program_category": {
-    "external_name": "ks_tax"
+    "external_name": "tax_credit"
   },
   "program": {
     "name_abbreviated": "ks_eitc_federal",

--- a/programs/management/commands/import_program_config_data/data/ks_wic_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_wic_initial_config.json
@@ -3,9 +3,7 @@
     "code": "ks"
   },
   "program_category": {
-    "external_name": "ks_food",
-    "name": "Food and Nutrition",
-    "icon": "food"
+    "external_name": "food"
   },
   "program": {
     "name_abbreviated": "ks_wic",


### PR DESCRIPTION
Follow-up to [MFB-1601](https://linear.app/myfriendben/issue/MFB-1601) / #1741. Relates to [MFB-1051](https://linear.app/myfriendben/issue/MFB-1051/program-ks-women-infants-and-children-wic).

## Problem

#1741 rewrote every program config from a white-label-prefixed category `external_name` to a shared one, and migration `0172` consolidates the prefixed rows into the shared rows and then **deletes** them.

Two programs merged into `main` while that PR was open, so the sweep never saw them:

| Program | PR | Merged | Declared | Should be |
|---|---|---|---|---|
| `ks_wic` | #1744 | Sep 2, 18:08 UTC | `ks_food` | `food` |
| `ks_eitc_federal` | #1740 | Sep 1, 22:26 UTC | `ks_tax` | `tax_credit` |

#1741 merged at Sep 2, 18:21 UTC — after both.

## The database is already correct

`0172` lists `("ks", "ks_food", "food")` and `("ks", "ks_tax", "tax_credit")`, so both programs moved to the shared rows along with the rest of KS. Nothing is orphaned and nothing is user-visible today.

**This is a latent regression.** The configs still name rows that no longer exist. The next `import_program_config` run on either file — a fresh environment, a prod import, a re-import to pick up copy edits — recreates the deleted white-label-scoped row and quietly pulls the program back out of the shared category, re-introducing exactly the drift #1741 removed.

Worth noting `--reconcile` skips category, so an existing program will not self-correct from a re-import; the config has to be right.

## Changes

Two files. `ks_eitc_federal` is a one-line rename. `ks_wic` also dropped `name` and `icon`, since a shared row owns both and repeating them invites the drift back — this matches how `ks_nslp` and the other KS configs read after #1741.

## Verification

- Imported both configs against a local database carrying `0172`: neither `ks_food` nor `ks_tax` is recreated, and both programs resolve to the shared row (`white_label = NULL`).
- Swept all 200+ configs against the full set of names `0172` deletes — no other config references a consolidated row. The only remaining prefixed names are the intentional keepers (`cesn_efficiency_upgrades`, `tax_credit_calculator`).
- `programs/` + `screener/`: **3663 passed, 5 skipped, 0 failed.**

## Note for reviewers

`audit_program_categories.py` from #1741 is a before/after DB snapshotter, so it could not have caught this — the gap is between a config file and the migration, not within the database. A config linter that fails on an `external_name` no table row can satisfy would close it; I have left that out of this PR to keep it to the fix, but it is the thing that prevents the next in-flight branch from repeating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)