### PR TITLE
MFB-1726: split the PolicyEngine payload when programs disagree

### DIFF
--- a/configuration/test_policyengine_config.py
+++ b/configuration/test_policyengine_config.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 
 from configuration.admin import PolicyEngineConfigAdmin
 from configuration.models import PolicyEngineConfig
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from integrations.clients.policyengine.versions import determine_pe_version
 from screener.models import Screen, WhiteLabel
 

--- a/integrations/clients/policyengine/policy_engine.py
+++ b/integrations/clients/policyengine/policy_engine.py
@@ -1,18 +1,30 @@
 from screener.models import Screen
 from programs.framework.pe_base import PolicyEngineCalulator
 from programs.framework.base import Eligibility
-from typing import Any, Dict, Optional, TypedDict
+from typing import Any, Dict, List, Optional, Tuple, TypedDict
 from sentry_sdk import capture_exception, capture_message
 from .engines import Sim, pe_engines
-from programs.framework.pe_dependencies.payload import _resolve_comparable_version, pe_input
+from programs.framework.pe_dependencies.base import ConflictingDependencyError
+from programs.framework.pe_dependencies.payload import (
+    PayloadPlan,
+    _resolve_comparable_version,
+    bucket_payload,
+    build_pe_input,
+)
 from . import versions as pe_versions
 from integrations.external_api_status import record_external_api_failure, POLICY_ENGINE
 from django.conf import settings
 
 
-class PEData(TypedDict):
+class PEData(TypedDict, total=False):
     request: Optional[Dict[str, Any]]
     response: Optional[Dict[str, Any]]
+
+    #: Present only when the screen's programs disagreed about an input and had to be split
+    #: across more than one request. The admin PolicyEngine view reads `request`/`response`,
+    #: so the first request keeps those keys and the rest arrive here rather than changing
+    #: the shape of a payload every screen returns.
+    additional_requests: List[Dict[str, Any]]
 
 
 class EligibilityPEResult(TypedDict):
@@ -50,13 +62,62 @@ def calc_pe_eligibility(
     if not valid_programs or not screen.household_members.all():
         return empty_result
 
-    input_data = pe_input(
-        screen,
-        valid_programs.values(),
-        pe_version=pe_version,
-        resolved_version=(version, comparable_version),
-    )
+    program_names = list(valid_programs.keys())
+    program_list = list(valid_programs.values())
 
+    try:
+        plan = build_pe_input(
+            screen,
+            program_list,
+            pe_version=pe_version,
+            resolved_version=(version, comparable_version),
+        )
+    except ConflictingDependencyError as e:
+        # Unreachable by design: build_pe_input partitions disagreeing programs into separate
+        # requests before writing a value, so this means the partition itself is wrong. It is
+        # caught rather than left to propagate because the whole point of splitting is that
+        # one program's input disagreement must not take down every program's results — a bug
+        # here costs the PolicyEngine programs for this screen, not the response.
+        capture_exception(e, level="error")
+        capture_message(
+            "PolicyEngine: payload assembly could not resolve a dependency conflict; "
+            "PolicyEngine programs are unavailable for this screen.",
+            level="error",
+        )
+        return empty_result
+
+    _report_conflicts(plan, program_names)
+    for index in plan.dropped_program_indexes:
+        valid_programs.pop(program_names[index], None)
+
+    eligibility: Dict[str, Eligibility] = {}
+    requests_made: List[Dict[str, Any]] = []
+
+    # One request per bucket. Almost every screen has exactly one: a second appears only when
+    # two programs want different values for the same input, and then the alternative is
+    # serving one of them a value its rule doesn't mean.
+    for bucket in plan.buckets:
+        bucket_programs = {program_names[index]: program_list[index] for index in bucket.program_indexes}
+        payload = bucket_payload(plan, bucket)
+
+        bucket_eligibility, data = _run_bucket(payload, bucket_programs)
+        eligibility.update(bucket_eligibility)
+        requests_made.append(data)
+
+    return {"eligibility": eligibility, "_pe_data": _combine_pe_data(requests_made)}
+
+
+def _run_bucket(
+    input_data: Dict[str, Any],
+    valid_programs: dict[str, PolicyEngineCalulator],
+) -> Tuple[Dict[str, Eligibility], Dict[str, Any]]:
+    """Send one payload and read its programs' results.
+
+    Failure is contained to this bucket: the programs in it are absent from the merged
+    eligibility (the caller reports them as missing), and any other bucket still returns.
+    A screen with one bucket behaves exactly as it did before splitting existed — empty
+    eligibility, and the payload preserved for admins to debug.
+    """
     # A single engine: the authenticated private household.api. There is deliberately no
     # fallback to the public api.policyengine.org — it ignores the request `version` field
     # (verified against its source) and would silently compute against a different model
@@ -66,13 +127,13 @@ def calc_pe_eligibility(
         try:
             method_instance = Method(input_data)
             eligibility = all_eligibility(method_instance, valid_programs)
-            result: EligibilityPEResult = {
-                "eligibility": eligibility,
-                "_pe_data": {
+            result = (
+                eligibility,
+                {
                     "request": getattr(method_instance, "request_payload", None),
                     "response": getattr(method_instance, "response_json", None),
                 },
-            }
+            )
         except (SystemExit, KeyboardInterrupt) as e:
             # Worker is being torn down: gunicorn's SIGABRT handler (fired when a request
             # exceeds the worker --timeout, e.g. while a PE HTTP call hangs on DNS) calls
@@ -87,10 +148,10 @@ def calc_pe_eligibility(
             raise
         except Exception as e:
             # Any PolicyEngine failure (malformed payload/400, timeout, 5xx, auth, non-JSON):
-            # with no fallback endpoint, PolicyEngine programs can't be computed for this
-            # screen. Surface it loudly (Sentry error), record it so the frontend can warn
-            # the user, and return an empty PE result so the caller still computes the
-            # non-PolicyEngine (custom) calculators.
+            # with no fallback endpoint, these programs can't be computed for this screen.
+            # Surface it loudly (Sentry error), record it so the frontend can warn the user,
+            # and return no eligibility so the caller still computes the non-PolicyEngine
+            # (custom) calculators.
             if settings.DEBUG:
                 print(repr(e))
             capture_exception(e, level="error")
@@ -103,14 +164,43 @@ def calc_pe_eligibility(
             # Preserve the payload that triggered the failure so admins can debug it
             # (the exact request is the most useful thing for diagnosing a 400).
             # _pe_data.request is admin-only — already popped for non-admins downstream.
-            return {
-                "eligibility": {},
-                "_pe_data": {"request": input_data, "response": None},
-            }
+            return {}, {"request": input_data, "response": None}
         else:
             return result
 
-    return empty_result
+    return {}, {"request": None, "response": None}
+
+
+def _combine_pe_data(requests_made: List[Dict[str, Any]]) -> PEData:
+    """Report the requests as one `_pe_data`, keeping the single-request shape intact."""
+    if not requests_made:
+        return {"request": None, "response": None}
+
+    data: PEData = dict(requests_made[0])
+    if len(requests_made) > 1:
+        data["additional_requests"] = requests_made[1:]
+
+    return data
+
+
+def _report_conflicts(plan: PayloadPlan, program_names: List[str]) -> None:
+    """Make a disagreement visible. It is never load-bearing for the response — the split
+    already handled it — but it means a program silently wanting a different value than
+    everyone else shows up somewhere other than a puzzling extra request."""
+    if not plan.conflicts:
+        return
+
+    split = " | ".join(", ".join(program_names[index] for index in bucket.program_indexes) for bucket in plan.buckets)
+    message = (
+        f"PolicyEngine: programs disagreed about {len(plan.conflicts)} payload slot(s), "
+        f"split across {len(plan.buckets)} request(s) [{split}]. Conflicts: {plan.conflicts}"
+    )
+
+    if plan.dropped_program_indexes:
+        dropped = sorted(program_names[index] for index in plan.dropped_program_indexes)
+        message = f"{message} Dropped (past the request limit, no result for these): {dropped}"
+
+    capture_message(message, level="warning")
 
 
 def all_eligibility(method: Sim, valid_programs: dict[str, PolicyEngineCalulator]):

--- a/integrations/clients/policyengine/policy_engine.py
+++ b/integrations/clients/policyengine/policy_engine.py
@@ -1,3 +1,6 @@
+import logging
+import time
+
 from screener.models import Screen
 from programs.framework.pe_base import PolicyEngineCalulator
 from programs.framework.base import Eligibility
@@ -14,6 +17,20 @@ from programs.framework.pe_dependencies.payload import (
 from . import versions as pe_versions
 from integrations.external_api_status import record_external_api_failure, POLICY_ENGINE
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+#: Wall-clock budget, in seconds, for the whole bucket loop.
+#:
+#: A split screen sends its requests one after another, each waiting up to PolicyEngine's 30s
+#: read timeout (see engines.py), so MAX_PAYLOAD_BUCKETS on its own permits ~105s of
+#: PolicyEngine. Past the gunicorn worker timeout (120s) once the custom calculators and DB
+#: work are added — and a killed worker loses the *entire* response, including the programs
+#: that never needed PolicyEngine, which is worse than the degraded result splitting exists
+#: to guarantee. This leaves a slow follow-up request room to finish inside the worker's life
+#: while bounding the total: the first bucket always goes out, and each later one only if the
+#: budget has not already been spent.
+PE_BUCKET_TIME_BUDGET_SECONDS = 45
 
 
 class PEData(TypedDict, total=False):
@@ -74,7 +91,8 @@ def calc_pe_eligibility(
         )
     except ConflictingDependencyError as e:
         # Unreachable by design: build_pe_input partitions disagreeing programs into separate
-        # requests before writing a value, so this means the partition itself is wrong. It is
+        # requests before writing a value, and drops the one shape a partition cannot serve
+        # (a program contradicting itself), so this means the partition is wrong. It is
         # caught rather than left to propagate because the whole point of splitting is that
         # one program's input disagreement must not take down every program's results — a bug
         # here costs the PolicyEngine programs for this screen, not the response.
@@ -92,11 +110,20 @@ def calc_pe_eligibility(
 
     eligibility: Dict[str, Eligibility] = {}
     requests_made: List[Dict[str, Any]] = []
+    deadline = time.monotonic() + PE_BUCKET_TIME_BUDGET_SECONDS
 
     # One request per bucket. Almost every screen has exactly one: a second appears only when
     # two programs want different values for the same input, and then the alternative is
     # serving one of them a value its rule doesn't mean.
-    for bucket in plan.buckets:
+    for position, bucket in enumerate(plan.buckets):
+        # MAX_PAYLOAD_BUCKETS bounds how many requests a split may cost; the deadline bounds
+        # how long they may take. Stopping here gives up the remaining buckets' programs,
+        # which the caller already reports as missing; running past the worker timeout would
+        # give up the response.
+        if position > 0 and time.monotonic() >= deadline:
+            _report_bucket_deadline(plan, program_names, position)
+            break
+
         bucket_programs = {program_names[index]: program_list[index] for index in bucket.program_indexes}
         payload = bucket_payload(plan, bucket)
 
@@ -186,7 +213,15 @@ def _combine_pe_data(requests_made: List[Dict[str, Any]]) -> PEData:
 def _report_conflicts(plan: PayloadPlan, program_names: List[str]) -> None:
     """Make a disagreement visible. It is never load-bearing for the response — the split
     already handled it — but it means a program silently wanting a different value than
-    everyone else shows up somewhere other than a puzzling extra request."""
+    everyone else shows up somewhere other than a puzzling extra request.
+
+    Where it shows up depends on whether anything needs looking at. A known dependency
+    pairing (age on the screening date against age at the end of the claim year) splits a
+    large and recurring share of Missouri screens by design, and a Sentry warning on each of
+    them is a permanently-firing issue that buries the splits that mean something — those go
+    to the log. An unrecognised disagreement, a program dropped for running out of requests,
+    or a program contradicting itself is still worth waking somebody up for.
+    """
     if not plan.conflicts:
         return
 
@@ -196,11 +231,38 @@ def _report_conflicts(plan: PayloadPlan, program_names: List[str]) -> None:
         f"split across {len(plan.buckets)} request(s) [{split}]. Conflicts: {plan.conflicts}"
     )
 
-    if plan.dropped_program_indexes:
-        dropped = sorted(program_names[index] for index in plan.dropped_program_indexes)
-        message = f"{message} Dropped (past the request limit, no result for these): {dropped}"
+    self_conflicting = set(plan.self_conflicting_program_indexes)
+    past_the_limit = sorted(
+        program_names[index] for index in plan.dropped_program_indexes if index not in self_conflicting
+    )
+    if past_the_limit:
+        message = f"{message} Dropped (past the request limit, no result for these): {past_the_limit}"
 
-    capture_message(message, level="warning")
+    if self_conflicting:
+        contradict_themselves = sorted(program_names[index] for index in self_conflicting)
+        message = (
+            f"{message} Dropped (each declares two dependencies writing one field with "
+            f"different values, which no single payload can serve): {contradict_themselves}"
+        )
+
+    if plan.unexpected_conflicts or past_the_limit or self_conflicting:
+        capture_message(message, level="warning")
+    else:
+        logger.info(message)
+
+
+def _report_bucket_deadline(plan: PayloadPlan, program_names: List[str], position: int) -> None:
+    """Report the buckets abandoned for running out of wall clock.
+
+    Their programs are simply absent from the merged eligibility, the same shape as a program
+    dropped past the request limit, which the caller already handles.
+    """
+    abandoned = sorted(program_names[index] for bucket in plan.buckets[position:] for index in bucket.program_indexes)
+    capture_message(
+        f"PolicyEngine: out of time after {position} of {len(plan.buckets)} request(s); "
+        f"abandoned the rest so the response survives. No result for: {abandoned}",
+        level="warning",
+    )
 
 
 def all_eligibility(method: Sim, valid_programs: dict[str, PolicyEngineCalulator]):

--- a/integrations/clients/policyengine/tests/test_pe_buckets.py
+++ b/integrations/clients/policyengine/tests/test_pe_buckets.py
@@ -170,7 +170,7 @@ class TestProgramsThatDisagree(PeBucketTestBase):
 
 
 class TestTheDisagreementIsReported(PeBucketTestBase):
-    def test_it_logs_the_split_and_both_values(self):
+    def warning_message(self):
         log = []
         with patch.object(pe, "pe_engines", [sent_payloads(log)]), patch.object(
             pe, "all_eligibility", side_effect=lambda sim, programs: dict.fromkeys(programs, "ok")
@@ -185,9 +185,22 @@ class TestTheDisagreementIsReported(PeBucketTestBase):
 
         warnings = [c for c in capture_message.call_args_list if c.kwargs.get("level") == "warning"]
         self.assertEqual(len(warnings), 1)
-        message = warnings[0].args[0]
-        for expected in ("age", "40", "41", "wants_forty", "wants_forty_one", "2 request"):
+        return warnings[0].args[0]
+
+    def test_it_names_the_slot_the_split_and_the_programs(self):
+        message = self.warning_message()
+
+        for expected in ("age", "wants_forty", "wants_forty_one", "2 request"):
             self.assertIn(expected, message)
+
+    def test_it_does_not_send_the_household_values_to_sentry(self):
+        """A conflicting slot holds screener data about a real household. What disagreed is
+        actionable; what the household reported is not, and Sentry has no scrubbing
+        configured."""
+        message = self.warning_message()
+
+        self.assertNotIn("40", message)
+        self.assertNotIn("41", message)
 
 
 class TestPastTheRequestLimit(PeBucketTestBase):

--- a/integrations/clients/policyengine/tests/test_pe_buckets.py
+++ b/integrations/clients/policyengine/tests/test_pe_buckets.py
@@ -8,10 +8,12 @@ cannot both be served by it. That used to raise out of payload assembly uncaught
 results, so a disagreement costs a round trip instead of the response.
 """
 
+import datetime
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
+import programs.framework.pe_dependencies as dependency
 from benefits.tests.cache_override import LOCAL_CACHE
 from integrations.clients.policyengine import policy_engine as pe
 from programs.framework.pe_dependencies.base import Member
@@ -74,14 +76,25 @@ class PeBucketTestBase(TestCase):
         self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
         self.head_id = str(self.head.id)
 
-    def calculator(self, inputs):
+    def calculator(self, inputs, period=PERIOD):
         calc = MagicMock()
         calc.can_calc.return_value = True
         calc.pe_inputs = list(inputs)
         calc.pe_outputs = []
         calc.pe_monthly_outputs = []
-        calc.pe_period = PERIOD
+        calc.pe_period = period
         return calc
+
+    def run_reported(self, calculators):
+        """Run the bucket loop and hand back both reporting channels for inspection."""
+        log = []
+        with patch.object(pe, "pe_engines", [sent_payloads(log)]), patch.object(
+            pe, "all_eligibility", side_effect=lambda sim, programs: dict.fromkeys(programs, "ok")
+        ), patch.object(pe, "capture_message") as capture_message, patch.object(pe, "logger") as logger:
+            result = pe.calc_pe_eligibility(self.screen, calculators)
+
+        warnings = [c for c in capture_message.call_args_list if c.kwargs.get("level") == "warning"]
+        return result, log, warnings, logger
 
     def run_eligibility(self, calculators, max_buckets=None):
         """Run the real payload build and bucket loop against a fake engine.
@@ -193,6 +206,106 @@ class TestPastTheRequestLimit(PeBucketTestBase):
 
         self.assertEqual(len(log), 2)
         self.assertEqual(sorted(result["eligibility"]), ["a", "b"])
+
+
+class TestAnExpectedDisagreementIsNotAnAlert(PeBucketTestBase):
+    """`mo_pts` against every other Missouri program. The two age bases disagree by design
+    and on a large recurring share of MO traffic, so a Sentry warning per screen would be a
+    permanently-firing issue burying the disagreements that mean something. It still splits,
+    still answers both programs, and still gets recorded -- in the log."""
+
+    def setUp(self):
+        super().setUp()
+        # The claim year sits years ahead of the screening date so the two bases disagree
+        # whichever month the suite runs in. Pinning a birth month would agree every December.
+        self.head.birth_year_month = datetime.date(1961, 6, 1)
+        self.head.save()
+
+    def test_the_two_age_bases_are_logged_rather_than_captured(self):
+        result, log, warnings, logger = self.run_reported(
+            {
+                "screening_date_age": self.calculator([dependency.member.AgeDependency], period="2030"),
+                "claim_year_age": self.calculator([dependency.member.AgeAtEndOfClaimYearDependency], period="2030"),
+            }
+        )
+
+        self.assertEqual(len(log), 2)
+        self.assertEqual(sorted(result["eligibility"]), ["claim_year_age", "screening_date_age"])
+        self.assertEqual(warnings, [])
+        self.assertEqual(logger.info.call_count, 1)
+
+    def test_an_unrecognised_disagreement_still_raises(self):
+        _, _, warnings, logger = self.run_reported(
+            {"wants_forty": self.calculator([FortyYearOld]), "wants_forty_one": self.calculator([FortyOneYearOld])}
+        )
+
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(logger.info.call_count, 0)
+
+
+class TestAProgramThatContradictsItself(PeBucketTestBase):
+    """One program declaring two dependencies that write one field with different values. No
+    payload can serve it, so it is dropped -- where forcing it into a bucket of its own would
+    raise out of payload assembly and cost every PolicyEngine program on the screen."""
+
+    def test_it_is_dropped_and_every_other_program_still_answers(self):
+        result, log, warnings, _ = self.run_reported(
+            {
+                "healthy": self.calculator([FortyYearOld]),
+                "contradicts_itself": self.calculator([FortyYearOld, FortyOneYearOld]),
+            }
+        )
+
+        self.assertEqual(len(log), 1)
+        self.assertEqual(sorted(result["eligibility"]), ["healthy"])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("contradicts_itself", warnings[0].args[0])
+
+
+class TestTheTimeBudget(PeBucketTestBase):
+    """MAX_PAYLOAD_BUCKETS bounds how many requests a split costs; the budget bounds how long
+    they take. Three slow-but-not-failing PolicyEngine calls outlast the gunicorn worker
+    timeout, and a killed worker loses the whole response -- including the custom calculators
+    that never needed PolicyEngine, which is worse than the degraded result splitting buys."""
+
+    def spent_budget(self):
+        return patch.object(pe, "PE_BUCKET_TIME_BUDGET_SECONDS", -1)
+
+    def test_the_first_request_always_goes_out(self):
+        """It is what an unsplit screen would have sent, so a spent budget must not cost a
+        screen the results it would have had without splitting."""
+        with self.spent_budget():
+            result, log = self.run_eligibility({"only": self.calculator([FortyYearOld])})
+
+        self.assertEqual(len(log), 1)
+        self.assertEqual(sorted(result["eligibility"]), ["only"])
+
+    def test_a_later_request_is_abandoned_once_the_budget_is_spent(self):
+        with self.spent_budget():
+            result, log = self.run_eligibility(
+                {"first": self.calculator([FortyYearOld]), "second": self.calculator([FortyOneYearOld])}
+            )
+
+        self.assertEqual(len(log), 1)
+        self.assertEqual(sorted(result["eligibility"]), ["first"])
+
+    def test_the_abandoned_programs_are_named(self):
+        with self.spent_budget():
+            _, _, warnings, _ = self.run_reported(
+                {"first": self.calculator([FortyYearOld]), "second": self.calculator([FortyOneYearOld])}
+            )
+
+        deadline = [c for c in warnings if "out of time" in c.args[0]]
+        self.assertEqual(len(deadline), 1)
+        self.assertIn("second", deadline[0].args[0])
+
+    def test_a_split_screen_within_budget_sends_both(self):
+        result, log = self.run_eligibility(
+            {"first": self.calculator([FortyYearOld]), "second": self.calculator([FortyOneYearOld])}
+        )
+
+        self.assertEqual(len(log), 2)
+        self.assertEqual(sorted(result["eligibility"]), ["first", "second"])
 
 
 class TestOneRequestFailing(PeBucketTestBase):

--- a/integrations/clients/policyengine/tests/test_pe_buckets.py
+++ b/integrations/clients/policyengine/tests/test_pe_buckets.py
@@ -1,0 +1,224 @@
+"""
+One screen, more than one PolicyEngine request.
+
+Programs on a screen share one payload, so two that want different values for the same input
+cannot both be served by it. That used to raise out of payload assembly uncaught and 500
+`/api/eligibility/{id}`, losing every program's results over one program's disagreement
+`calc_pe_eligibility` now sends one request per group of programs that agree and merges the
+results, so a disagreement costs a round trip instead of the response.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from benefits.tests.cache_override import LOCAL_CACHE
+from integrations.clients.policyengine import policy_engine as pe
+from programs.framework.pe_dependencies.base import Member
+from programs.framework.pe_dependencies.payload import build_pe_input
+from screener.models import HouseholdMember, Screen, WhiteLabel
+
+PERIOD = "2026"
+
+
+class FortyYearOld(Member):
+    field = "age"
+
+    def value(self):
+        return 40
+
+
+class FortyOneYearOld(Member):
+    field = "age"
+
+    def value(self):
+        return 41
+
+
+class FortyTwoYearOld(Member):
+    field = "age"
+
+    def value(self):
+        return 42
+
+
+def sent_payloads(log):
+    """Fake engine that records the payload it was handed. Constructed once per request, so
+    the log is the request count as well as the request bodies."""
+
+    class _Engine:
+        method_name = "Fake Policy Engine API"
+
+        def __init__(self, data):
+            log.append(data)
+            self.request_payload = data
+            self.response_json = {"result": {}}
+
+    return _Engine
+
+
+@override_settings(CACHES=LOCAL_CACHE)
+class PeBucketTestBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Missouri", code="mo", state_code="MO")
+
+    def setUp(self):
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Cole County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
+        self.head_id = str(self.head.id)
+
+    def calculator(self, inputs):
+        calc = MagicMock()
+        calc.can_calc.return_value = True
+        calc.pe_inputs = list(inputs)
+        calc.pe_outputs = []
+        calc.pe_monthly_outputs = []
+        calc.pe_period = PERIOD
+        return calc
+
+    def run_eligibility(self, calculators, max_buckets=None):
+        """Run the real payload build and bucket loop against a fake engine.
+
+        `all_eligibility` is faked to report whichever programs it was handed, which is how
+        these assert that each request answered the right programs.
+        """
+        log = []
+        patches = [
+            patch.object(pe, "pe_engines", [sent_payloads(log)]),
+            patch.object(pe, "all_eligibility", side_effect=lambda sim, programs: dict.fromkeys(programs, "ok")),
+            patch.object(pe, "capture_message"),
+        ]
+        if max_buckets is not None:
+            patches.append(
+                patch.object(
+                    pe,
+                    "build_pe_input",
+                    side_effect=lambda *args, **kwargs: build_pe_input(*args, **{**kwargs, "max_buckets": max_buckets}),
+                )
+            )
+
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+        return pe.calc_pe_eligibility(self.screen, calculators), log
+
+    def ages(self, payload):
+        return payload["household"]["people"][self.head_id]["age"]
+
+
+class TestProgramsThatAgree(PeBucketTestBase):
+    def test_one_request_answers_every_program(self):
+        result, log = self.run_eligibility({"a": self.calculator([FortyYearOld]), "b": self.calculator([FortyYearOld])})
+
+        self.assertEqual(len(log), 1)
+        self.assertEqual(sorted(result["eligibility"]), ["a", "b"])
+
+    def test_the_response_shape_is_unchanged(self):
+        """Every screen returns this shape; only a split screen adds to it."""
+        result, _ = self.run_eligibility({"a": self.calculator([FortyYearOld])})
+
+        self.assertEqual(sorted(result["_pe_data"]), ["request", "response"])
+
+
+class TestProgramsThatDisagree(PeBucketTestBase):
+    def setUp(self):
+        super().setUp()
+        self.result, self.log = self.run_eligibility(
+            {
+                "agrees_one": self.calculator([FortyYearOld]),
+                "disagrees": self.calculator([FortyOneYearOld]),
+                "agrees_two": self.calculator([FortyYearOld]),
+            }
+        )
+
+    def test_every_program_still_gets_a_result(self):
+        """The regression this exists for: one program's disagreement used to cost all of
+        them their results."""
+        self.assertEqual(sorted(self.result["eligibility"]), ["agrees_one", "agrees_two", "disagrees"])
+
+    def test_it_took_two_requests(self):
+        self.assertEqual(len(self.log), 2)
+
+    def test_each_request_carried_the_value_its_programs_wanted(self):
+        self.assertEqual([self.ages(payload) for payload in self.log], [{PERIOD: 40}, {PERIOD: 41}])
+
+    def test_the_extra_request_is_reported_for_admins(self):
+        self.assertEqual(len(self.result["_pe_data"]["additional_requests"]), 1)
+        self.assertEqual(self.ages(self.result["_pe_data"]["request"]), {PERIOD: 40})
+        self.assertEqual(self.ages(self.result["_pe_data"]["additional_requests"][0]["request"]), {PERIOD: 41})
+
+
+class TestTheDisagreementIsReported(PeBucketTestBase):
+    def test_it_logs_the_split_and_both_values(self):
+        log = []
+        with patch.object(pe, "pe_engines", [sent_payloads(log)]), patch.object(
+            pe, "all_eligibility", side_effect=lambda sim, programs: dict.fromkeys(programs, "ok")
+        ), patch.object(pe, "capture_message") as capture_message:
+            pe.calc_pe_eligibility(
+                self.screen,
+                {
+                    "wants_forty": self.calculator([FortyYearOld]),
+                    "wants_forty_one": self.calculator([FortyOneYearOld]),
+                },
+            )
+
+        warnings = [c for c in capture_message.call_args_list if c.kwargs.get("level") == "warning"]
+        self.assertEqual(len(warnings), 1)
+        message = warnings[0].args[0]
+        for expected in ("age", "40", "41", "wants_forty", "wants_forty_one", "2 request"):
+            self.assertIn(expected, message)
+
+
+class TestPastTheRequestLimit(PeBucketTestBase):
+    def test_the_unserved_program_has_no_result(self):
+        """Bounded splitting means some screen shapes lose a program. It is reported absent,
+        which the caller already handles, rather than answered with a value it did not ask
+        for."""
+        result, log = self.run_eligibility(
+            {
+                "a": self.calculator([FortyYearOld]),
+                "b": self.calculator([FortyOneYearOld]),
+                "c": self.calculator([FortyTwoYearOld]),
+            },
+            max_buckets=2,
+        )
+
+        self.assertEqual(len(log), 2)
+        self.assertEqual(sorted(result["eligibility"]), ["a", "b"])
+
+
+class TestOneRequestFailing(PeBucketTestBase):
+    def test_the_other_request_still_returns(self):
+        """Contained per request: PolicyEngine failing the second call no longer costs the
+        first call's programs their results."""
+        log = []
+        engine = sent_payloads(log)
+
+        class _FailsTheSecond(engine):
+            def __init__(self, data):
+                super().__init__(data)
+                if len(log) == 2:
+                    raise RuntimeError("boom")
+
+        with patch.object(pe, "pe_engines", [_FailsTheSecond]), patch.object(
+            pe, "all_eligibility", side_effect=lambda sim, programs: dict.fromkeys(programs, "ok")
+        ), patch.object(pe, "capture_message"), patch.object(pe, "capture_exception"), patch.object(
+            pe, "record_external_api_failure"
+        ):
+            result = pe.calc_pe_eligibility(
+                self.screen,
+                {
+                    "served": self.calculator([FortyYearOld]),
+                    "unserved": self.calculator([FortyOneYearOld]),
+                },
+            )
+
+        self.assertEqual(sorted(result["eligibility"]), ["served"])

--- a/integrations/clients/policyengine/tests/test_pe_failure.py
+++ b/integrations/clients/policyengine/tests/test_pe_failure.py
@@ -13,6 +13,7 @@ from screener.models import Screen, HouseholdMember, WhiteLabel
 from integrations.clients.policyengine import policy_engine as pe
 from integrations.clients.policyengine import engines as pe_engines_module
 from integrations.clients.policyengine.engines import PolicyEngineAPIError, PrivateApiSim
+from programs.framework.pe_dependencies.payload import Bucket, PayloadPlan
 from integrations.external_api_status import (
     POLICY_ENGINE,
     get_external_api_failures,
@@ -63,8 +64,10 @@ class TestCalcPeEligibilityFailure(TestCase):
         constructed = []
         engine_classes = [_make_engine(name, constructed, raises=raises) for name, raises in engines]
 
+        plan = PayloadPlan(payload={}, buckets=[Bucket(program_indexes=[0])])
+
         with patch.object(pe, "pe_engines", engine_classes), patch.object(
-            pe, "pe_input", return_value={}
+            pe, "build_pe_input", return_value=plan
         ), patch.object(pe, "all_eligibility", return_value={"prog": MagicMock()}), patch.object(
             pe, "capture_message"
         ) as capture_message, patch.object(

--- a/programs/framework/pe_dependencies/base.py
+++ b/programs/framework/pe_dependencies/base.py
@@ -1,5 +1,5 @@
 from screener.models import Screen, HouseholdMember
-from typing import List
+from typing import List, Optional
 
 
 class PolicyEngineScreenInput:
@@ -29,10 +29,43 @@ class PolicyEngineScreenInput:
     min_pe_version: tuple = ()
     max_pe_version: tuple = ()
 
-    def __init__(self, screen: Screen, members: List[HouseholdMember], relationship_map):
+    #: The period this variable is being sent at, as PolicyEngine spells it: ``YYYY`` for an
+    #: annual variable, ``YYYY-MM`` for a monthly one. `pe_input` resolves it per variable
+    #: (see `PolicyEngineCalulator.period_for`) and passes it in, so `value` can return a
+    #: value that depends on the period it is being asked about -- an age, for instance, is
+    #: only meaningful relative to a period. None when a caller constructs the dependency
+    #: outside payload assembly; `value` implementations that read it must handle that.
+    period: Optional[str] = None
+
+    def __init__(
+        self,
+        screen: Screen,
+        members: List[HouseholdMember],
+        relationship_map,
+        period: Optional[str] = None,
+    ):
         self.screen = screen
         self.members = members
         self.relationship_map = relationship_map
+        self.period = period
+
+    @property
+    def period_year(self) -> Optional[int]:
+        """The calendar year of `period`, or None when there is no usable period.
+
+        Both period shapes lead with the year (``2026``, ``2026-09``), so the year is the
+        leading component. Returns None rather than raising for anything unparseable: the
+        payload-shape tests pass a calculator class whose `pe_period` is an unevaluated
+        property, and a dependency that cannot resolve a year should fall back to whatever
+        it does without one, not break payload assembly.
+        """
+        if self.period is None:
+            return None
+
+        try:
+            return int(str(self.period).split("-")[0])
+        except (TypeError, ValueError):
+            return None
 
     def value(self) -> object:
         """
@@ -74,16 +107,43 @@ class Member(PolicyEngineScreenInput):
 
     unit = "people"
 
-    def __init__(self, screen: Screen, member: HouseholdMember, relationship_map):
+    def __init__(
+        self,
+        screen: Screen,
+        member: HouseholdMember,
+        relationship_map,
+        period: Optional[str] = None,
+    ):
         self.screen = screen
         self.member = member
         self.relationship_map = relationship_map
+        self.period = period
 
 
-class DependencyError(Exception):
+class ConflictingDependencyError(Exception):
+    """Two dependencies wrote different values to one PolicyEngine payload slot.
+
+    Named apart from `programs.util.DependencyError` on purpose. That one means "a screen is
+    missing a field this program needs" and takes no arguments; this one means "two programs
+    disagree about what to send" and takes four. They used to share a name across one call
+    graph, so the catch site in ``screener.views`` imported the missing-dependency class and
+    this one propagated uncaught, taking down every program's results over one program's
+    disagreement.
+
+    Payload assembly now partitions disagreeing programs into separate requests before any
+    value is written, so a raise from here means the partition itself is wrong rather than
+    that two programs disagree. `calc_pe_eligibility` still catches it as a backstop.
     """
-    Dependency conflict error
-    """
 
-    def __init__(self, field, value_1, value_2) -> None:
-        super().__init__(f"Confilcting Policy Engine Dependencies in {field}: {value_1} and {value_2}")
+    def __init__(self, field, value_1, value_2, period=None, member=None) -> None:
+        self.field = field
+        self.value_1 = value_1
+        self.value_2 = value_2
+        self.period = period
+        self.member = member
+
+        where = f"{field} at {period}" if period is not None else field
+        if member is not None:
+            where = f"{where} for member {member}"
+
+        super().__init__(f"Conflicting Policy Engine dependencies in {where}: {value_1} and {value_2}")

--- a/programs/framework/pe_dependencies/base.py
+++ b/programs/framework/pe_dependencies/base.py
@@ -1,5 +1,10 @@
 from screener.models import Screen, HouseholdMember
+import re
 from typing import List, Optional
+
+#: The period shapes PolicyEngine accepts, and the only two `period_for` produces: a bare
+#: year for an annual variable, ``YYYY-MM`` for a monthly one.
+_PERIOD_PATTERN = re.compile(r"^(\d{4})(?:-(0[1-9]|1[0-2]))?$")
 
 
 class PolicyEngineScreenInput:
@@ -53,19 +58,24 @@ class PolicyEngineScreenInput:
     def period_year(self) -> Optional[int]:
         """The calendar year of `period`, or None when there is no usable period.
 
-        Both period shapes lead with the year (``2026``, ``2026-09``), so the year is the
-        leading component. Returns None rather than raising for anything unparseable: the
-        payload-shape tests pass a calculator class whose `pe_period` is an unevaluated
-        property, and a dependency that cannot resolve a year should fall back to whatever
-        it does without one, not break payload assembly.
+        Accepts only the two shapes `PolicyEngineCalulator.period_for` produces -- ``YYYY``
+        annual and ``YYYY-MM`` monthly, month 01 through 12 -- and returns None for anything
+        else. Reading the leading digits of whatever it was handed would turn a malformed
+        period into a confidently wrong year (``"20260"`` becomes year 20260, and an age
+        computed from it), where None sends a dependency to whatever it does without a
+        period. A malformed period is also the payload's period key, so such a request is
+        already doomed; this only keeps it from being doomed *and* nonsensical.
+
+        Returns None rather than raising, because the payload-shape tests pass a calculator
+        class whose `pe_period` is an unevaluated property object. A dependency that cannot
+        resolve a year should fall back, not break payload assembly.
         """
         if self.period is None:
             return None
 
-        try:
-            return int(str(self.period).split("-")[0])
-        except (TypeError, ValueError):
-            return None
+        match = _PERIOD_PATTERN.match(str(self.period))
+
+        return int(match.group(1)) if match else None
 
     def value(self) -> object:
         """

--- a/programs/framework/pe_dependencies/member.py
+++ b/programs/framework/pe_dependencies/member.py
@@ -14,7 +14,7 @@ class AgeDependency(Member):
 
 class AgeAtEndOfClaimYearDependency(Member):
     """
-    Age as of December 31 of ``claim_year``.
+    Age as of December 31 of the year being claimed.
 
     ``AgeDependency`` reports age on the screening date, which understates by one year
     anybody whose birthday falls later in the calendar year. A rule that awards a benefit
@@ -22,24 +22,33 @@ class AgeAtEndOfClaimYearDependency(Member):
     age, or a household screened in August qualifies only if it screens again in
     December.
 
-    Subclasses set ``claim_year``. Falls back to the screening-date age when the member's
-    birth year is unknown.
+    The claim year is the period the variable is being sent at, which comes from the
+    program's configured year, so this follows a program rolled forward to a new year
+    without anybody remembering to change a constant here. It used to be a class attribute
+    on a subclass hardcoded to 2026, which would have gone on sending 2026 ages under a
+    2027 period.
+
+    Both this and ``AgeDependency`` write ``age``, so a screen carrying both splits into two
+    PolicyEngine requests for any member whose birthday falls later in the year (see
+    ``build_pe_input``). That is the intended cost: age on the screening date is the right
+    input for a program whose eligibility is judged today, and the end-of-year age is right
+    for one judged over a tax year, and no single value serves both.
+
+    Falls back to the screening-date age when the member's birth year is unknown, or when
+    there is no period to read a year from.
     """
 
     field = "age"
     dependencies = ("age",)
-    claim_year = None
 
     def value(self):
         birth_year = self.member.birth_year
-        if birth_year is None or self.claim_year is None:
+        claim_year = self.period_year
+
+        if birth_year is None or claim_year is None:
             return self.member.calc_age()
 
-        return self.claim_year - birth_year
-
-
-class AgeAtEndOf2026Dependency(AgeAtEndOfClaimYearDependency):
-    claim_year = 2026
+        return claim_year - birth_year
 
 
 class PregnancyDependency(Member):
@@ -551,13 +560,16 @@ class TotalHoursWorkedDependency(Member):
     (MFB-1637).
 
     The floor reaches every consumer of this field on purpose. All programs in a screen
-    share one payload, so two dependencies writing different values to this field raise
-    ``DependencyError`` in ``update_unit`` -- from ``pe_input()``, outside
-    ``calc_pe_eligibility``'s try/except, so a 500 rather than a degraded result. That
-    makes one value per member per screen a hard constraint, and it costs accuracy on
-    the field's other readers: ``tx_ccs``'s work requirement and the MA TAFDC/EAEDC
-    dependent-care deductions both read hours and both get more generous. Accepted
-    deliberately; modelling the SNAP work test properly is follow-up work.
+    share one payload, so one value per member per screen was a hard constraint when this
+    was written, and it costs accuracy on the field's other readers: ``tx_ccs``'s work
+    requirement and the MA TAFDC/EAEDC dependent-care deductions both read hours and both
+    get more generous. Accepted deliberately; modelling the SNAP work test properly is
+    follow-up work.
+
+    Payload assembly can now answer disagreeing programs with a second request rather than
+    failing, so the constraint is a cost rather than a wall -- but a per-reader value would
+    buy accuracy with a round trip, which is a trade to make deliberately and not a reason to
+    split this field today.
     """
 
     field = "weekly_hours_worked_before_lsr"
@@ -618,9 +630,9 @@ class MaTotalHoursWorkedDependency(TotalHoursWorkedDependency):
     Massachusetts approximation, at the state minimum wage.
 
     Every MA calculator sending this field must use this subclass. Two dependencies
-    writing different values to the same field and period raise ``DependencyError``
-    in ``update_unit``, so mixing this with the base class inside one MA screen
-    fails the request build.
+    writing different values to the same field and period cannot share a payload, so
+    mixing this with the base class inside one MA screen costs a second PolicyEngine
+    request for the programs on the losing side.
     """
 
     minimum_wage = 15

--- a/programs/framework/pe_dependencies/payload.py
+++ b/programs/framework/pe_dependencies/payload.py
@@ -611,12 +611,18 @@ def _describe_conflicts(
     grouped: List[List[int]],
     dropped: List[int],
 ) -> Tuple[List[str], List[str]]:
-    """One line per disagreement, naming the slot, each value and who wanted it.
+    """One line per disagreement, naming the slot and which programs took each side.
 
     Built here rather than at the log site because this is the only place that still knows
     which program produced which value. Returns every description, and separately the ones
     whose dependency classes are not a known pairing — those are a surprise worth raising,
     where a known pairing is just a second request (see EXPECTED_CONFLICTING_DEPENDENCIES).
+
+    Deliberately without the values themselves. A conflicting slot holds household data — an
+    age, an hour count derived from reported income — and these lines reach Sentry and the
+    application log, neither of which needs a screen's contents to be actionable. The slot
+    and the programs on each side are enough to find the two dependency classes and read what
+    they compute; the values are recoverable from the payload, which stays admin-only.
     """
     if len(grouped) < 2 and not dropped:
         return [], []
@@ -630,8 +636,11 @@ def _describe_conflicts(
         if len(slot_groups) < 2:
             continue
 
-        wanted = "; ".join(f"{value!r} ({labels(indexes)})" for value, indexes in slot_groups)
-        description = f"{slot.field} at {slot.period} for {slot.unit}/{slot.sub_unit}: {wanted}"
+        sides = " vs ".join(f"[{labels(indexes)}]" for _, indexes in slot_groups)
+        description = (
+            f"{slot.field} at {slot.period} for {slot.unit}/{slot.sub_unit}: "
+            f"{len(slot_groups)} distinct values, {sides}"
+        )
         descriptions.append(description)
 
         if _dependencies_for(contributions, slot) not in EXPECTED_CONFLICTING_DEPENDENCIES:

--- a/programs/framework/pe_dependencies/payload.py
+++ b/programs/framework/pe_dependencies/payload.py
@@ -12,14 +12,75 @@ all (see version_supports). calc_pe_eligibility resolves it once and threads it 
 which fields are sent.
 """
 
-from typing import List, Optional
+import copy
+from dataclasses import dataclass, field as dataclass_field
+from typing import Dict, List, Optional, Tuple
 
 from screener.models import Screen
 
 from programs.framework.pe_base import PolicyEngineCalulator
-from programs.framework.pe_dependencies.base import DependencyError, Member, TaxUnit
+from programs.framework.pe_dependencies.base import ConflictingDependencyError, Member, TaxUnit
 from programs.framework.pe_dependencies.constants import MAIN_TAX_UNIT, SECONDARY_TAX_UNIT
 from integrations.clients.policyengine import versions as pe_versions
+
+#: How many PolicyEngine requests one screen may be split into before we stop splitting and
+#: start dropping programs. Each bucket is a separate HTTP round trip, and the gunicorn
+#: worker timeout (120s) against PolicyEngine's read timeout (30s) leaves room for a handful.
+#: Only screens that actually carry a disagreement split at all, and today exactly one
+#: program wants a value another program contradicts, so 3 is slack rather than a budget.
+MAX_PAYLOAD_BUCKETS = 3
+
+
+@dataclass(frozen=True)
+class Slot:
+    """One addressable place in the payload: ``household[unit][sub_unit][field][period]``.
+
+    This is the granularity a disagreement happens at. Two programs sending different values
+    for the same field at the same period *for the same member* conflict; the same field at
+    two periods, or for two members, does not.
+    """
+
+    unit: str
+    sub_unit: str
+    field: str
+    period: str
+
+
+@dataclass(frozen=True)
+class Contribution:
+    """One program's answer for one slot. `program_index` indexes the `programs` list passed
+    to `build_pe_input`, which is how a contribution is traced back to the calculator that
+    made it without requiring calculators to be hashable."""
+
+    slot: Slot
+    value: object
+    program_index: int
+
+
+@dataclass
+class Bucket:
+    """The programs answered by one PolicyEngine request, and how that request's payload
+    differs from the union payload.
+
+    `overrides` is empty for the first bucket: its payload *is* the union payload, which is
+    byte-for-byte what a screen sent before payload splitting existed. Later buckets are the
+    same payload with only the contradicted slots rewritten, so a program that disagrees
+    about one field still sees every other input the screen produced."""
+
+    program_indexes: List[int]
+    overrides: Dict[Slot, object] = dataclass_field(default_factory=dict)
+
+
+@dataclass
+class PayloadPlan:
+    """Everything payload assembly decided: the union payload, how the screen's programs were
+    split across requests, which programs were dropped outright, and a description of each
+    disagreement for the log."""
+
+    payload: dict
+    buckets: List[Bucket]
+    dropped_program_indexes: List[int] = dataclass_field(default_factory=list)
+    conflicts: List[str] = dataclass_field(default_factory=list)
 
 
 def _has_gated_input(programs: List[PolicyEngineCalulator]) -> bool:
@@ -75,10 +136,129 @@ def pe_input(
     """
     Generate Policy Engine API request from the list of programs.
 
+    The union payload: every program's inputs in one household, which is the only payload
+    there is for a screen whose programs all agree. Callers that need to know about
+    disagreements — and therefore about the extra requests they imply — want
+    `build_pe_input` instead.
+
     `resolved_version` is the caller's already-resolved (version string, comparable version)
     pair, passed by `calc_pe_eligibility` so the version deciding which programs are readable
     is the one deciding which fields are sent. Direct callers may omit it.
     """
+    return build_pe_input(screen, programs, pe_version=pe_version, resolved_version=resolved_version).payload
+
+
+def build_pe_input(
+    screen: Screen,
+    programs: List[PolicyEngineCalulator],
+    pe_version: Optional[str] = None,
+    resolved_version: Optional[tuple[str, Optional[tuple]]] = None,
+    max_buckets: int = MAX_PAYLOAD_BUCKETS,
+) -> PayloadPlan:
+    """Build the PolicyEngine payload(s) for these programs, splitting where they disagree.
+
+    One shared household serves every program in a request, so two programs that want
+    different values for the same field, period and member cannot both be served by one
+    payload. That used to raise out of here uncaught and 500 the whole eligibility response
+    over a single program's disagreement. Now the disagreement is resolved by splitting: the
+    value most programs asked for goes in the union payload, and the programs
+    that wanted something else are answered by a follow-up request carrying the same payload
+    with only the contradicted slots rewritten.
+
+    Splitting is decided on *values*, not on which dependency classes a program declares, so
+    two programs that could disagree but happen to agree for this household still share one
+    request. `max_buckets` bounds how far this goes; past it the remaining programs are
+    dropped and reported rather than served.
+    """
+    programs = list(programs)
+
+    # Two values from one resolved version, for two consumers:
+    #   version (string)            -> version to send in the PE API request body. Always
+    #                                   set: the DB pin, the test override, or the literal
+    #                                   "current" alias (household.api resolves it server-side).
+    #   comparable_version (tuple)  -> tuple representation to gate which inputs are sent
+    #
+    # Send the alias, never the concrete resolution: household.api serves only what its
+    # aliases currently point at and 422s any other exact version, so a resolved-then-stale
+    # string would hard-fail every request once PolicyEngine promotes a release.
+    if resolved_version is not None:
+        version, comparable_version = resolved_version
+    else:
+        version = pe_versions.determine_pe_version(pe_version)
+        comparable_version = _resolve_comparable_version(programs, version)
+
+    raw_input, members, main_tax_members, secondary_tax_members, relationship_map = _household_shape(screen)
+
+    contributions = _collect_contributions(
+        screen,
+        programs,
+        members,
+        main_tax_members,
+        secondary_tax_members,
+        relationship_map,
+        comparable_version,
+    )
+
+    program_indexes = list(range(len(programs)))
+    grouped, dropped = _partition(contributions, program_indexes, max_buckets)
+
+    # The union payload takes the first bucket's value wherever the two differ. Every
+    # contradicted slot is written by the first bucket by construction — the majority group
+    # is what defines that bucket — so a slot missing from its values is a slot nobody
+    # disagreed about, and there the contribution's own value is the only one there is.
+    union_values = _values_for(contributions, grouped[0]) if grouped else {}
+    written = _write_union(raw_input, contributions, union_values)
+
+    buckets = [Bucket(program_indexes=grouped[0])] if grouped else []
+    for bucket_indexes in grouped[1:]:
+        bucket_values = _values_for(contributions, bucket_indexes)
+        buckets.append(
+            Bucket(
+                program_indexes=bucket_indexes,
+                # Compared against what the union payload actually holds, not against the
+                # first bucket's preferences: a slot no first-bucket program contributed
+                # was written from whichever contribution reached it first, and a later
+                # bucket still has to correct that.
+                overrides={slot: value for slot, value in bucket_values.items() if written.get(slot, value) != value},
+            )
+        )
+
+    return PayloadPlan(
+        payload=_finalize(raw_input, version, len(secondary_tax_members) == 0),
+        buckets=buckets,
+        dropped_program_indexes=dropped,
+        conflicts=_describe_conflicts(contributions, programs, grouped, dropped),
+    )
+
+
+def bucket_payload(plan: PayloadPlan, bucket: Bucket) -> dict:
+    """The payload for one bucket: the union payload with that bucket's slots rewritten.
+
+    Carrying the whole union rather than rebuilding from the bucket's own programs is
+    deliberate. A program in a later bucket disagrees about one field; it should still see
+    every other input the screen produced, exactly as it did when all programs shared one
+    payload. It also makes the first bucket's payload identical to the pre-split one, so a
+    disagreement changes results only for the programs that caused it.
+    """
+    if not bucket.overrides:
+        return plan.payload
+
+    payload = copy.deepcopy(plan.payload)
+    for slot, value in bucket.overrides.items():
+        # Only slots already in the union payload are overridden (see build_pe_input), so
+        # every level of this path exists -- except a secondary tax unit dropped for being
+        # empty, which no member contributes to anyway.
+        unit = payload["household"].get(slot.unit, {}).get(slot.sub_unit)
+        if unit is None:
+            continue
+        unit.setdefault(slot.field, {})[slot.period] = value
+
+    return payload
+
+
+def _household_shape(screen: Screen):
+    """The household skeleton: units, their members, and the marital pairing. Independent of
+    which programs are being asked about, so it is built once per screen."""
     raw_input = {
         "household": {
             "people": {},
@@ -100,20 +280,6 @@ def pe_input(
             "marital_units": {},
         }
     }
-    # Two values from one resolved version, for two consumers:
-    #   version (string)            -> version to send in the PE API request body. Always
-    #                                   set: the DB pin, the test override, or the literal
-    #                                   "current" alias (household.api resolves it server-side).
-    #   comparable_version (tuple)  -> tuple representation to gate which inputs are sent
-    #
-    # Send the alias, never the concrete resolution: household.api serves only what its
-    # aliases currently point at and 422s any other exact version, so a resolved-then-stale
-    # string would hard-fail every request once PolicyEngine promotes a release.
-    if resolved_version is not None:
-        version, comparable_version = resolved_version
-    else:
-        version = pe_versions.determine_pe_version(pe_version)
-        comparable_version = _resolve_comparable_version(programs, version)
 
     # order_by("id") is load-bearing, not tidiness: the payload lists every unit's members
     # in iteration order, and the cassette matcher compares request bodies exactly. Without
@@ -150,7 +316,28 @@ def pe_input(
         already_added.add(member_1)
         already_added.add(member_2)
 
-    for program in programs:
+    return raw_input, members, main_tax_members, secondary_tax_members, relationship_map
+
+
+def _collect_contributions(
+    screen: Screen,
+    programs: List[PolicyEngineCalulator],
+    members,
+    main_tax_members,
+    secondary_tax_members,
+    relationship_map,
+    comparable_version: Optional[tuple],
+) -> List[Contribution]:
+    """Every value every program wants to send, in the order the payload is written.
+
+    Values are computed before anything is written so disagreements can be resolved knowing
+    all of them, rather than by whichever program happened to be iterated first. The order is
+    preserved because it decides key order in the request body, which the cassette matcher
+    compares exactly.
+    """
+    contributions: List[Contribution] = []
+
+    for index, program in enumerate(programs):
         for Data in program.pe_inputs + program.pe_outputs:
             # Skip inputs the resolved model version doesn't define yet — sending an
             # unknown variable 400s the whole request (e.g. meets_ssi_disability_criteria
@@ -170,30 +357,157 @@ def pe_input(
 
             if issubclass(Data, Member):
                 for member in members:
-                    member_id = str(member.id)
-                    data = Data(screen, member, relationship_map)
-                    unit = raw_input["household"][data.unit][member_id]
-
-                    update_unit(unit, data, period)
+                    data = Data(screen, member, relationship_map, period=period)
+                    contributions.append(
+                        Contribution(Slot(data.unit, str(member.id), data.field, period), data.value(), index)
+                    )
             elif issubclass(Data, TaxUnit):
                 # split the household into the main and secondary tax unit.
-                data = Data(screen, main_tax_members, relationship_map)
-                unit = raw_input["household"][data.unit][MAIN_TAX_UNIT]
-
-                update_unit(unit, data, period)
-
-                data = Data(screen, secondary_tax_members, relationship_map)
-                unit = raw_input["household"][data.unit][SECONDARY_TAX_UNIT]
-
-                update_unit(unit, data, period)
+                for sub_unit, unit_members in (
+                    (MAIN_TAX_UNIT, main_tax_members),
+                    (SECONDARY_TAX_UNIT, secondary_tax_members),
+                ):
+                    data = Data(screen, unit_members, relationship_map, period=period)
+                    contributions.append(
+                        Contribution(Slot(data.unit, sub_unit, data.field, period), data.value(), index)
+                    )
             else:
-                data = Data(screen, members, relationship_map)
-                unit = raw_input["household"][data.unit][data.sub_unit]
+                data = Data(screen, members, relationship_map, period=period)
+                contributions.append(
+                    Contribution(Slot(data.unit, data.sub_unit, data.field, period), data.value(), index)
+                )
 
-                update_unit(unit, data, period)
+    return contributions
 
+
+def _group_by_value(contributions: List[Contribution]) -> Dict[Slot, List[Tuple[object, List[int]]]]:
+    """Per slot, the distinct values wanted and which programs wanted each, first seen first.
+
+    Distinctness is plain ``==``, matching what the single-pass write used to compare, so
+    this recognises exactly the disagreements that used to raise and no others. A program
+    naming the same dependency twice contributes twice; callers counting programs dedupe.
+    """
+    groups: Dict[Slot, List[Tuple[object, List[int]]]] = {}
+
+    for contribution in contributions:
+        slot_groups = groups.setdefault(contribution.slot, [])
+        for value, indexes in slot_groups:
+            if value == contribution.value:
+                indexes.append(contribution.program_index)
+                break
+        else:
+            slot_groups.append((contribution.value, [contribution.program_index]))
+
+    return groups
+
+
+def _partition(
+    contributions: List[Contribution],
+    program_indexes: List[int],
+    max_buckets: int,
+) -> Tuple[List[List[int]], List[int]]:
+    """Split programs into groups that can each be served by one payload.
+
+    Each pass keeps the programs that agree with the majority on every slot and defers the
+    rest to the next pass, so every group is internally consistent by construction. The
+    majority wins because that loses the fewest programs if splitting has to stop; it is not
+    a claim that the majority is right. Ties go to the program iterated first, which makes
+    the outcome depend on registry order only when the counts are equal.
+
+    Returns the groups and, if `max_buckets` is reached first, the programs left unserved.
+    """
+    groups: List[List[int]] = []
+    remaining = list(program_indexes)
+
+    while remaining:
+        if len(groups) >= max_buckets:
+            return groups, remaining
+
+        remaining_set = set(remaining)
+        losers: set = set()
+        for slot_groups in _group_by_value([c for c in contributions if c.program_index in remaining_set]).values():
+            if len(slot_groups) < 2:
+                continue
+
+            winner = max(range(len(slot_groups)), key=lambda i: len(set(slot_groups[i][1])))
+            for position, (_, indexes) in enumerate(slot_groups):
+                if position != winner:
+                    losers.update(indexes)
+
+        kept = [index for index in remaining if index not in losers]
+
+        # A program can win one slot and lose another, so in principle every program in a
+        # pass can be a loser. Keeping the first one guarantees the pass makes progress and
+        # the loop terminates; without it a screen shaped that way would hang.
+        if not kept:
+            kept = remaining[:1]
+
+        groups.append(kept)
+        kept_set = set(kept)
+        remaining = [index for index in remaining if index not in kept_set]
+
+    return groups, []
+
+
+def _values_for(contributions: List[Contribution], program_indexes: List[int]) -> Dict[Slot, object]:
+    """What these programs, taken together, want in each slot.
+
+    `_partition` guarantees they agree, so a disagreement here is a bug in the partition
+    rather than a fact about the screen — hence the raise rather than a resolution.
+    """
+    indexes = set(program_indexes)
+    values: Dict[Slot, object] = {}
+
+    for contribution in contributions:
+        if contribution.program_index not in indexes:
+            continue
+
+        if contribution.slot in values:
+            if values[contribution.slot] != contribution.value:
+                raise ConflictingDependencyError(
+                    contribution.slot.field,
+                    contribution.value,
+                    values[contribution.slot],
+                    period=contribution.slot.period,
+                    member=contribution.slot.sub_unit,
+                )
+            continue
+
+        values[contribution.slot] = contribution.value
+
+    return values
+
+
+def _write_union(
+    raw_input: dict, contributions: List[Contribution], union_values: Dict[Slot, object]
+) -> Dict[Slot, object]:
+    """Write every contributed slot into the household, taking `union_values` where it has an
+    opinion, and report what was written.
+
+    Fields land in first-contribution order, which is the key order the pre-split payload had
+    and the cassette matcher compares exactly. Note the *value* does not depend on which
+    contribution arrived first, only the key order does.
+    """
+    written: Dict[Slot, object] = {}
+
+    for contribution in contributions:
+        slot = contribution.slot
+        if slot in written:
+            continue
+
+        unit = raw_input["household"][slot.unit][slot.sub_unit]
+        if slot.field not in unit:
+            unit[slot.field] = {}
+
+        written[slot] = union_values.get(slot, contribution.value)
+        unit[slot.field][slot.period] = written[slot]
+
+    return written
+
+
+def _finalize(raw_input: dict, version: str, secondary_tax_unit_is_empty: bool) -> dict:
     # delete the second tax unit if it is empty because PE can't handle empty tax units
-    if len(secondary_tax_members) == 0:
+    if secondary_tax_unit_is_empty:
         del raw_input["household"]["tax_units"][SECONDARY_TAX_UNIT]
 
     # Always inject the version (override > DB pin > "current"): determine_pe_version
@@ -203,13 +517,34 @@ def pe_input(
     return raw_input
 
 
-def update_unit(unit, data: PolicyEngineCalulator, period: str):
-    value = data.value()
-    if data.field in unit and period in unit[data.field]:
-        if value != unit[data.field][period]:
-            raise DependencyError(data.field, value, unit[data.field][period])
+def _program_label(program) -> str:
+    code = getattr(program, "program_code", None)
+    return code if isinstance(code, str) and code else type(program).__name__
 
-    if data.field not in unit:
-        unit[data.field] = {}
 
-    unit[data.field][period] = value
+def _describe_conflicts(
+    contributions: List[Contribution],
+    programs: List[PolicyEngineCalulator],
+    grouped: List[List[int]],
+    dropped: List[int],
+) -> List[str]:
+    """One line per disagreement, naming the slot, each value and who wanted it.
+
+    Built here rather than at the log site because this is the only place that still knows
+    which program produced which value.
+    """
+    if len(grouped) < 2 and not dropped:
+        return []
+
+    def labels(indexes) -> str:
+        return ", ".join(sorted({_program_label(programs[index]) for index in indexes}))
+
+    descriptions = []
+    for slot, slot_groups in _group_by_value(contributions).items():
+        if len(slot_groups) < 2:
+            continue
+
+        wanted = "; ".join(f"{value!r} ({labels(indexes)})" for value, indexes in slot_groups)
+        descriptions.append(f"{slot.field} at {slot.period} for {slot.unit}/{slot.sub_unit}: {wanted}")
+
+    return descriptions

--- a/programs/framework/pe_dependencies/payload.py
+++ b/programs/framework/pe_dependencies/payload.py
@@ -28,7 +28,24 @@ from integrations.clients.policyengine import versions as pe_versions
 #: worker timeout (120s) against PolicyEngine's read timeout (30s) leaves room for a handful.
 #: Only screens that actually carry a disagreement split at all, and today exactly one
 #: program wants a value another program contradicts, so 3 is slack rather than a budget.
+#:
+#: This bounds the request *count* only. Three slow-but-not-failing calls would outlast the
+#: worker timeout and cost the whole response, so the dispatcher holds a wall-clock budget
+#: too (`PE_BUCKET_TIME_BUDGET_SECONDS` in the PolicyEngine client) and stops early when it
+#: is spent.
 MAX_PAYLOAD_BUCKETS = 3
+
+#: Dependency classes known to write one payload slot with different values, as the set of
+#: class names taking part in each such disagreement.
+#:
+#: A split between exactly these is structural rather than a mistake: age on the screening
+#: date and age at the end of the claim year are both correct, for different rules, and a
+#: large recurring share of Missouri screens carries both. Reporting every one of them as a
+#: Sentry warning would bury the disagreements that mean something, so these are logged
+#: instead (see `_report_conflicts`). Any other combination stays a warning.
+EXPECTED_CONFLICTING_DEPENDENCIES: Tuple[frozenset, ...] = (
+    frozenset({"AgeDependency", "AgeAtEndOfClaimYearDependency"}),
+)
 
 
 @dataclass(frozen=True)
@@ -56,6 +73,11 @@ class Contribution:
     value: object
     program_index: int
 
+    #: Name of the dependency class that produced this value, for telling an expected
+    #: disagreement from an unexpected one (see EXPECTED_CONFLICTING_DEPENDENCIES). Defaults
+    #: to empty for contributions built by tests, which assert on values not on sources.
+    dependency: str = ""
+
 
 @dataclass
 class Bucket:
@@ -81,6 +103,16 @@ class PayloadPlan:
     buckets: List[Bucket]
     dropped_program_indexes: List[int] = dataclass_field(default_factory=list)
     conflicts: List[str] = dataclass_field(default_factory=list)
+
+    #: Programs dropped because they contradict *themselves* — two of their own dependencies
+    #: write one slot with different values, so no single payload can serve them. Also listed
+    #: in `dropped_program_indexes`; kept apart because it means a program's declared inputs
+    #: are wrong, not that a screen ran out of requests.
+    self_conflicting_program_indexes: List[int] = dataclass_field(default_factory=list)
+
+    #: The subset of `conflicts` whose dependency classes are not a known pairing, i.e. the
+    #: disagreements worth raising rather than logging.
+    unexpected_conflicts: List[str] = dataclass_field(default_factory=list)
 
 
 def _has_gated_input(programs: List[PolicyEngineCalulator]) -> bool:
@@ -199,19 +231,29 @@ def build_pe_input(
         comparable_version,
     )
 
-    program_indexes = list(range(len(programs)))
-    grouped, dropped = _partition(contributions, program_indexes, max_buckets)
+    # A program whose own two dependencies want different values for one slot can be served
+    # by no payload at all, so it is dropped before partitioning rather than left to lose
+    # every pass: partitioning would force it back in on its own to guarantee progress, and
+    # `_values_for` would then raise — costing every PolicyEngine program on the screen its
+    # result over one program's input list. Its contributions go too, so nothing arbitrarily
+    # picks one of its two values for a slot nobody left will read.
+    self_conflicting = _self_conflicting_indexes(contributions)
+    servable = [contribution for contribution in contributions if contribution.program_index not in self_conflicting]
+
+    program_indexes = [index for index in range(len(programs)) if index not in self_conflicting]
+    grouped, unserved = _partition(servable, program_indexes, max_buckets)
+    dropped = sorted(unserved + sorted(self_conflicting))
 
     # The union payload takes the first bucket's value wherever the two differ. Every
     # contradicted slot is written by the first bucket by construction — the majority group
     # is what defines that bucket — so a slot missing from its values is a slot nobody
     # disagreed about, and there the contribution's own value is the only one there is.
-    union_values = _values_for(contributions, grouped[0]) if grouped else {}
-    written = _write_union(raw_input, contributions, union_values)
+    union_values = _values_for(servable, grouped[0]) if grouped else {}
+    written = _write_union(raw_input, servable, union_values)
 
     buckets = [Bucket(program_indexes=grouped[0])] if grouped else []
     for bucket_indexes in grouped[1:]:
-        bucket_values = _values_for(contributions, bucket_indexes)
+        bucket_values = _values_for(servable, bucket_indexes)
         buckets.append(
             Bucket(
                 program_indexes=bucket_indexes,
@@ -223,11 +265,15 @@ def build_pe_input(
             )
         )
 
+    conflicts, unexpected_conflicts = _describe_conflicts(contributions, programs, grouped, dropped)
+
     return PayloadPlan(
         payload=_finalize(raw_input, version, len(secondary_tax_members) == 0),
         buckets=buckets,
         dropped_program_indexes=dropped,
-        conflicts=_describe_conflicts(contributions, programs, grouped, dropped),
+        conflicts=conflicts,
+        self_conflicting_program_indexes=sorted(self_conflicting),
+        unexpected_conflicts=unexpected_conflicts,
     )
 
 
@@ -359,7 +405,12 @@ def _collect_contributions(
                 for member in members:
                     data = Data(screen, member, relationship_map, period=period)
                     contributions.append(
-                        Contribution(Slot(data.unit, str(member.id), data.field, period), data.value(), index)
+                        Contribution(
+                            Slot(data.unit, str(member.id), data.field, period),
+                            data.value(),
+                            index,
+                            Data.__name__,
+                        )
                     )
             elif issubclass(Data, TaxUnit):
                 # split the household into the main and secondary tax unit.
@@ -369,12 +420,12 @@ def _collect_contributions(
                 ):
                     data = Data(screen, unit_members, relationship_map, period=period)
                     contributions.append(
-                        Contribution(Slot(data.unit, sub_unit, data.field, period), data.value(), index)
+                        Contribution(Slot(data.unit, sub_unit, data.field, period), data.value(), index, Data.__name__)
                     )
             else:
                 data = Data(screen, members, relationship_map, period=period)
                 contributions.append(
-                    Contribution(Slot(data.unit, data.sub_unit, data.field, period), data.value(), index)
+                    Contribution(Slot(data.unit, data.sub_unit, data.field, period), data.value(), index, Data.__name__)
                 )
 
     return contributions
@@ -399,6 +450,31 @@ def _group_by_value(contributions: List[Contribution]) -> Dict[Slot, List[Tuple[
             slot_groups.append((contribution.value, [contribution.program_index]))
 
     return groups
+
+
+def _self_conflicting_indexes(contributions: List[Contribution]) -> set:
+    """Programs that want two different values for one slot all by themselves.
+
+    `pe_inputs` lists are assembled from shared dependency groups, so a program can end up
+    declaring two classes that write the same field — `AgeDependency` alongside
+    `AgeAtEndOfClaimYearDependency`, say. Two *programs* shaped that way split into two
+    requests and both get served. One *program* shaped that way cannot be served at all:
+    both values would have to land in the same payload. It is a bug in that program's
+    declared inputs, so it is dropped and reported rather than allowed to fail the screen.
+    """
+    values: Dict[Tuple[int, Slot], object] = {}
+    conflicting: set = set()
+
+    for contribution in contributions:
+        key = (contribution.program_index, contribution.slot)
+        if key in values:
+            if values[key] != contribution.value:
+                conflicting.add(contribution.program_index)
+            continue
+
+        values[key] = contribution.value
+
+    return conflicting
 
 
 def _partition(
@@ -438,7 +514,9 @@ def _partition(
 
         # A program can win one slot and lose another, so in principle every program in a
         # pass can be a loser. Keeping the first one guarantees the pass makes progress and
-        # the loop terminates; without it a screen shaped that way would hang.
+        # the loop terminates; without it a screen shaped that way would hang. A group of one
+        # is always servable: programs that contradict themselves are dropped before
+        # partitioning, so no single program holds two values for one slot.
         if not kept:
             kept = remaining[:1]
 
@@ -522,29 +600,41 @@ def _program_label(program) -> str:
     return code if isinstance(code, str) and code else type(program).__name__
 
 
+def _dependencies_for(contributions: List[Contribution], slot: Slot) -> frozenset:
+    """The dependency classes that contributed a value to one slot."""
+    return frozenset(contribution.dependency for contribution in contributions if contribution.slot == slot)
+
+
 def _describe_conflicts(
     contributions: List[Contribution],
     programs: List[PolicyEngineCalulator],
     grouped: List[List[int]],
     dropped: List[int],
-) -> List[str]:
+) -> Tuple[List[str], List[str]]:
     """One line per disagreement, naming the slot, each value and who wanted it.
 
     Built here rather than at the log site because this is the only place that still knows
-    which program produced which value.
+    which program produced which value. Returns every description, and separately the ones
+    whose dependency classes are not a known pairing — those are a surprise worth raising,
+    where a known pairing is just a second request (see EXPECTED_CONFLICTING_DEPENDENCIES).
     """
     if len(grouped) < 2 and not dropped:
-        return []
+        return [], []
 
     def labels(indexes) -> str:
         return ", ".join(sorted({_program_label(programs[index]) for index in indexes}))
 
-    descriptions = []
+    descriptions: List[str] = []
+    unexpected: List[str] = []
     for slot, slot_groups in _group_by_value(contributions).items():
         if len(slot_groups) < 2:
             continue
 
         wanted = "; ".join(f"{value!r} ({labels(indexes)})" for value, indexes in slot_groups)
-        descriptions.append(f"{slot.field} at {slot.period} for {slot.unit}/{slot.sub_unit}: {wanted}")
+        description = f"{slot.field} at {slot.period} for {slot.unit}/{slot.sub_unit}: {wanted}"
+        descriptions.append(description)
 
-    return descriptions
+        if _dependencies_for(contributions, slot) not in EXPECTED_CONFLICTING_DEPENDENCIES:
+            unexpected.append(description)
+
+    return descriptions, unexpected

--- a/programs/framework/pe_dependencies/tax.py
+++ b/programs/framework/pe_dependencies/tax.py
@@ -88,8 +88,8 @@ class PellGrantPrimaryIncomeDependency(TaxUnit):
     def value(self):
         total = 0
         for member in self.screen.household_members.all():
-            is_head = TaxUnitHeadDependency(self.screen, member, self.relationship_map).value()
-            is_spouse = TaxUnitSpouseDependency(self.screen, member, self.relationship_map).value()
+            is_head = TaxUnitHeadDependency(self.screen, member, self.relationship_map, self.period).value()
+            is_spouse = TaxUnitSpouseDependency(self.screen, member, self.relationship_map, self.period).value()
             if is_head or is_spouse:
                 total += int(member.calc_gross_income("yearly", ["all"]))
 

--- a/programs/framework/pe_dependencies/tests/test_member.py
+++ b/programs/framework/pe_dependencies/tests/test_member.py
@@ -47,6 +47,84 @@ class TestAgeDependency(TestCase):
         self.assertEqual(dep.field, "is_disabled")
 
 
+class TestAgeAtEndOfClaimYearDependency(TestCase):
+    """The age a tax-year rule means: attained by December 31 of the year being claimed.
+
+    The claim year comes from the period the variable is sent at, which is the program's
+    configured year. It used to be a constant on a subclass hardcoded to 2026, which would
+    have gone on sending 2026 ages under a 2027 period, understating every claimant by a year
+    and reintroducing the disagreement with `AgeDependency` for a wider slice of
+    households.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Missouri", code="mo", state_code="MO")
+
+    def setUp(self):
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Cole County",
+            household_size=1,
+            completed=False,
+        )
+
+    def member_born(self, year, month, age=None):
+        return HouseholdMember.objects.create(
+            screen=self.screen,
+            relationship="headOfHousehold",
+            age=age if age is not None else datetime.date.today().year - year,
+            birth_year_month=datetime.date(year, month, 1),
+        )
+
+    def test_reports_the_age_attained_during_the_period(self):
+        """A September 1961 claimant is 65 for all of 2026 as the statute counts it, whatever
+        month the screen runs in."""
+        dep = member.AgeAtEndOfClaimYearDependency(self.screen, self.member_born(1961, 9), {}, period="2026")
+
+        self.assertEqual(dep.value(), 65)
+
+    def test_the_year_follows_the_period(self):
+        household_member = self.member_born(1961, 9)
+
+        self.assertEqual(
+            [
+                member.AgeAtEndOfClaimYearDependency(self.screen, household_member, {}, period=period).value()
+                for period in ("2026", "2027")
+            ],
+            [65, 66],
+        )
+
+    def test_a_monthly_period_still_yields_the_year(self):
+        """Nothing sends age monthly today, but the period shape is per variable, so reading
+        the year rather than assuming ``YYYY`` keeps this correct if something does."""
+        dep = member.AgeAtEndOfClaimYearDependency(self.screen, self.member_born(1961, 9), {}, period="2026-09")
+
+        self.assertEqual(dep.value(), 65)
+
+    def test_falls_back_to_the_screening_date_age_without_a_birth_month(self):
+        """Most screens report an age and no birth date. There is no year to subtract from,
+        so the reported age is the only answer available."""
+        household_member = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=64)
+        dep = member.AgeAtEndOfClaimYearDependency(self.screen, household_member, {}, period="2026")
+
+        self.assertEqual(dep.value(), 64)
+
+    def test_falls_back_to_the_screening_date_age_without_a_period(self):
+        """Constructed outside payload assembly — a dependency with no period cannot know
+        which year to measure against, and must not guess one."""
+        household_member = self.member_born(1961, 9, age=64)
+        dep = member.AgeAtEndOfClaimYearDependency(self.screen, household_member, {})
+
+        self.assertEqual(dep.value(), household_member.calc_age())
+
+    def test_it_writes_the_same_field_as_the_screening_date_age(self):
+        """Which is why a screen carrying both splits into two PolicyEngine requests: one
+        payload slot cannot hold both answers."""
+        self.assertEqual(member.AgeAtEndOfClaimYearDependency.field, member.AgeDependency.field)
+
+
 class TestMeetsSsiDisabilityCriteriaDependency(TestCase):
     """Tests for MeetsSsiDisabilityCriteriaDependency, required by PolicyEngine frontier
     to classify a person as SSI-disabled (MFB-1102)."""
@@ -2176,7 +2254,7 @@ class TestMaTotalHoursWorkedDependency(TestCase):
 
     def test_shares_the_field_with_the_base_class(self):
         """Same field and period as the base class, which is why an MA calculator that
-        sends both raises DependencyError."""
+        sends both splits the screen across two PolicyEngine requests."""
         self.assertEqual(
             member.MaTotalHoursWorkedDependency.field,
             member.TotalHoursWorkedDependency.field,

--- a/programs/framework/pe_dependencies/tests/test_member.py
+++ b/programs/framework/pe_dependencies/tests/test_member.py
@@ -119,6 +119,23 @@ class TestAgeAtEndOfClaimYearDependency(TestCase):
 
         self.assertEqual(dep.value(), household_member.calc_age())
 
+    def test_a_malformed_period_falls_back_instead_of_inventing_a_year(self):
+        """`period` is a free-text ``FederalPoveryLimit.period``, so a typo can reach here.
+        Reading the leading digits of ``"20260"`` would send PolicyEngine an age of 18299;
+        falling back sends the screening-date age. Such a request is already doomed -- the
+        same string is the payload's period key -- but it should not also be nonsensical.
+        """
+        household_member = self.member_born(1961, 9)
+        screening_date_age = household_member.calc_age()
+
+        self.assertEqual(
+            [
+                member.AgeAtEndOfClaimYearDependency(self.screen, household_member, {}, period=period).value()
+                for period in ("20260", "2026-13", "2026-9", "")
+            ],
+            [screening_date_age] * 4,
+        )
+
     def test_it_writes_the_same_field_as_the_screening_date_age(self):
         """Which is why a screen carrying both splits into two PolicyEngine requests: one
         payload slot cannot hold both answers."""

--- a/programs/framework/pe_dependencies/tests/test_payload.py
+++ b/programs/framework/pe_dependencies/tests/test_payload.py
@@ -13,7 +13,8 @@ from unittest.mock import Mock, patch
 from django.test import TestCase, override_settings
 from benefits.tests.cache_override import LOCAL_CACHE
 from screener.models import Screen, HouseholdMember, WhiteLabel, Expense, IncomeStream
-from integrations.clients.policyengine.policy_engine import _drop_unreadable_programs, pe_input
+from integrations.clients.policyengine.policy_engine import _drop_unreadable_programs
+from programs.framework.pe_dependencies.payload import PayloadPlan, pe_input
 from programs.framework.pe_dependencies.constants import (
     MAIN_TAX_UNIT,
     SECONDARY_TAX_UNIT,
@@ -413,7 +414,8 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
             "programs.framework.pe_dependencies.payload.pe_versions.resolve_unpinned_comparable_version",
             return_value=(1, 779, 3),
         ) as resolve, patch(
-            "integrations.clients.policyengine.policy_engine.pe_input", return_value={}
+            "integrations.clients.policyengine.policy_engine.build_pe_input",
+            return_value=PayloadPlan(payload={}, buckets=[]),
         ) as build_payload, patch(
             "integrations.clients.policyengine.policy_engine.pe_engines", []
         ):

--- a/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
+++ b/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
@@ -1,0 +1,340 @@
+"""
+What payload assembly does when two programs want different values for the same input.
+
+One PolicyEngine request carries every program on a screen, so a slot -- a field, at a
+period, for a member -- holds one value. Two programs disagreeing about it used to raise out
+of `pe_input` uncaught and 500 the whole eligibility response, losing 34 programs' results
+over one program's disagreement.
+
+Now the disagreement splits the screen: the value most programs asked for goes in the union
+payload, and the programs that wanted something else are answered by a second request
+carrying the same payload with only the contradicted slot rewritten. The two properties that
+matter are that the union payload is exactly what an agreeing screen would have sent, and
+that a program on the losing side still sees every other input the screen produced.
+"""
+
+from django.test import TestCase, override_settings
+
+from benefits.tests.cache_override import LOCAL_CACHE
+from programs.framework.pe_dependencies.base import ConflictingDependencyError, Household, Member
+from programs.framework.pe_dependencies.payload import (
+    Contribution,
+    Slot,
+    _values_for,
+    bucket_payload,
+    build_pe_input,
+    pe_input,
+)
+from screener.models import HouseholdMember, Screen, WhiteLabel
+
+PERIOD = "2026"
+
+
+class FortyYearOld(Member):
+    field = "age"
+
+    def value(self):
+        return 40
+
+
+class FortyOneYearOld(Member):
+    field = "age"
+
+    def value(self):
+        return 41
+
+
+class FortyTwoYearOld(Member):
+    field = "age"
+
+    def value(self):
+        return 42
+
+
+class Pregnant(Member):
+    field = "is_pregnant"
+
+    def value(self):
+        return True
+
+
+class StateCode(Household):
+    field = "state_code"
+
+    def value(self):
+        return "TX"
+
+
+def fake_program(code, inputs):
+    """A calculator-shaped stand-in.
+
+    A class rather than an instance, as the other payload tests use: `pe_period` is a
+    property that needs a configured ``Program.year``, and these tests are about which value
+    reaches a slot, not about where the period came from.
+    """
+    return type(
+        code,
+        (),
+        {
+            "program_code": code,
+            "pe_inputs": list(inputs),
+            "pe_outputs": [],
+            "pe_monthly_outputs": [],
+            "pe_period": PERIOD,
+        },
+    )
+
+
+@override_settings(CACHES=LOCAL_CACHE)
+class PayloadConflictTestBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Texas", code="tx", state_code="TX")
+
+    def setUp(self):
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Travis County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
+        self.head_id = str(self.head.id)
+
+    def ages(self, payload):
+        return payload["household"]["people"][self.head_id]["age"]
+
+
+class TestProgramsThatAgree(PayloadConflictTestBase):
+    """The overwhelming majority of screens: nothing to resolve, nothing to split."""
+
+    def test_one_bucket_holding_every_program(self):
+        plan = build_pe_input(
+            self.screen,
+            [fake_program("a", [FortyYearOld]), fake_program("b", [FortyYearOld, Pregnant])],
+        )
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0, 1]])
+        self.assertEqual(plan.conflicts, [])
+        self.assertEqual(plan.dropped_program_indexes, [])
+
+    def test_the_payload_is_what_the_programs_asked_for(self):
+        plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld, Pregnant])])
+
+        person = plan.payload["household"]["people"][self.head_id]
+        self.assertEqual(person["age"], {PERIOD: 40})
+        self.assertEqual(person["is_pregnant"], {PERIOD: True})
+
+    def test_a_program_repeating_a_dependency_is_not_a_disagreement(self):
+        """`pe_inputs` lists are assembled from shared groups, so the same class can appear
+        more than once in one program. It agrees with itself."""
+        plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld, FortyYearOld])])
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0]])
+        self.assertEqual(self.ages(plan.payload), {PERIOD: 40})
+
+    def test_bucket_payload_is_the_union_payload_itself(self):
+        """No copy when there is nothing to override — the same object goes to the wire."""
+        plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld])])
+
+        self.assertIs(bucket_payload(plan, plan.buckets[0]), plan.payload)
+
+
+class TestTheMajorityValueWins(PayloadConflictTestBase):
+    def setUp(self):
+        super().setUp()
+        self.programs = [
+            fake_program("agrees_one", [FortyYearOld]),
+            fake_program("disagrees", [FortyOneYearOld]),
+            fake_program("agrees_two", [FortyYearOld]),
+        ]
+        self.plan = build_pe_input(self.screen, self.programs)
+
+    def test_the_union_payload_holds_the_value_most_programs_wanted(self):
+        self.assertEqual(self.ages(self.plan.payload), {PERIOD: 40})
+
+    def test_the_disagreeing_program_is_deferred_to_its_own_request(self):
+        self.assertEqual([bucket.program_indexes for bucket in self.plan.buckets], [[0, 2], [1]])
+
+    def test_the_second_request_carries_the_value_that_program_wanted(self):
+        payload = bucket_payload(self.plan, self.plan.buckets[1])
+
+        self.assertEqual(self.ages(payload), {PERIOD: 41})
+
+    def test_the_first_request_is_unaffected_by_the_second(self):
+        bucket_payload(self.plan, self.plan.buckets[1])
+
+        self.assertEqual(self.ages(self.plan.payload), {PERIOD: 40})
+
+    def test_nothing_is_dropped(self):
+        self.assertEqual(self.plan.dropped_program_indexes, [])
+
+
+class TestTheSecondRequestSeesTheWholeHousehold(PayloadConflictTestBase):
+    """The point of splitting rather than rebuilding: a program that disagrees about one
+    field is not thereby cut off from every input the rest of the screen produced."""
+
+    def test_it_keeps_inputs_it_never_declared(self):
+        plan = build_pe_input(
+            self.screen,
+            [
+                fake_program("a", [FortyYearOld, Pregnant, StateCode]),
+                fake_program("b", [FortyYearOld]),
+                fake_program("disagrees", [FortyOneYearOld]),
+            ],
+        )
+        payload = bucket_payload(plan, plan.buckets[1])
+
+        self.assertEqual(payload["household"]["people"][self.head_id]["is_pregnant"], {PERIOD: True})
+        self.assertEqual(payload["household"]["households"]["household"]["state_code"], {PERIOD: "TX"})
+
+    def test_only_the_contradicted_slot_differs(self):
+        plan = build_pe_input(
+            self.screen,
+            [
+                fake_program("a", [FortyYearOld, Pregnant]),
+                fake_program("b", [FortyYearOld]),
+                fake_program("disagrees", [FortyOneYearOld, Pregnant]),
+            ],
+        )
+
+        self.assertEqual(
+            list(plan.buckets[1].overrides),
+            [Slot("people", self.head_id, "age", PERIOD)],
+        )
+
+    def test_an_input_only_the_second_request_asked_for_reaches_both(self):
+        """A slot nobody disagreed about is written from whichever program contributed it,
+        even one deferred to a later request — PolicyEngine ignores inputs the programs in
+        front of it don't read."""
+        plan = build_pe_input(
+            self.screen,
+            [
+                fake_program("a", [FortyYearOld]),
+                fake_program("b", [FortyYearOld]),
+                fake_program("disagrees", [FortyOneYearOld, Pregnant]),
+            ],
+        )
+
+        self.assertEqual(plan.payload["household"]["people"][self.head_id]["is_pregnant"], {PERIOD: True})
+        self.assertEqual(
+            bucket_payload(plan, plan.buckets[1])["household"]["people"][self.head_id]["is_pregnant"],
+            {PERIOD: True},
+        )
+
+
+class TestTies(PayloadConflictTestBase):
+    def test_a_tie_goes_to_the_program_iterated_first(self):
+        """Two programs, two values, no majority. Registry order decides, which is only
+        acceptable because it is the tie — any rule has to pick something."""
+        plan = build_pe_input(
+            self.screen,
+            [fake_program("first", [FortyOneYearOld]), fake_program("second", [FortyYearOld])],
+        )
+
+        self.assertEqual(self.ages(plan.payload), {PERIOD: 41})
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0], [1]])
+
+
+class TestThreeWayDisagreement(PayloadConflictTestBase):
+    def test_each_distinct_value_gets_a_request(self):
+        plan = build_pe_input(
+            self.screen,
+            [
+                fake_program("a", [FortyYearOld]),
+                fake_program("b", [FortyYearOld]),
+                fake_program("c", [FortyOneYearOld]),
+                fake_program("d", [FortyTwoYearOld]),
+            ],
+        )
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0, 1], [2], [3]])
+        self.assertEqual(
+            [self.ages(bucket_payload(plan, bucket)) for bucket in plan.buckets],
+            [{PERIOD: 40}, {PERIOD: 41}, {PERIOD: 42}],
+        )
+        self.assertEqual(plan.dropped_program_indexes, [])
+
+
+class TestTheRequestLimit(PayloadConflictTestBase):
+    def test_programs_past_the_limit_are_dropped_not_served(self):
+        """Splitting is bounded: each bucket is an HTTP round trip. Past the limit the
+        remaining programs get no result, which the caller reports as missing rather than
+        answering them with a value their rule doesn't mean."""
+        plan = build_pe_input(
+            self.screen,
+            [
+                fake_program("a", [FortyYearOld]),
+                fake_program("b", [FortyOneYearOld]),
+                fake_program("c", [FortyTwoYearOld]),
+            ],
+            max_buckets=2,
+        )
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0], [1]])
+        self.assertEqual(plan.dropped_program_indexes, [2])
+
+    def test_a_dropped_program_is_named_in_the_report(self):
+        plan = build_pe_input(
+            self.screen,
+            [fake_program("kept", [FortyYearOld]), fake_program("dropped", [FortyOneYearOld])],
+            max_buckets=1,
+        )
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0]])
+        self.assertEqual(plan.dropped_program_indexes, [1])
+        self.assertTrue(plan.conflicts)
+
+
+class TestTheConflictReport(PayloadConflictTestBase):
+    def test_it_names_the_slot_both_values_and_who_wanted_each(self):
+        plan = build_pe_input(
+            self.screen,
+            [fake_program("wants_forty", [FortyYearOld]), fake_program("wants_forty_one", [FortyOneYearOld])],
+        )
+
+        self.assertEqual(len(plan.conflicts), 1)
+        report = plan.conflicts[0]
+        for expected in ("age", PERIOD, self.head_id, "40", "41", "wants_forty", "wants_forty_one"):
+            self.assertIn(expected, report)
+
+    def test_an_agreeing_screen_reports_nothing(self):
+        plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld])])
+
+        self.assertEqual(plan.conflicts, [])
+
+
+class TestTheWriteInvariant(PayloadConflictTestBase):
+    """`_values_for` is the assertion that partitioning worked. It is unreachable through
+    `build_pe_input`; a raise from it would mean the partition handed one request two values
+    for one slot, which is a bug in the partition rather than a fact about the screen."""
+
+    def test_disagreement_inside_one_bucket_raises(self):
+        slot = Slot("people", self.head_id, "age", PERIOD)
+        contributions = [Contribution(slot, 40, 0), Contribution(slot, 41, 1)]
+
+        with self.assertRaises(ConflictingDependencyError) as raised:
+            _values_for(contributions, [0, 1])
+
+        self.assertEqual(raised.exception.field, "age")
+        self.assertEqual({raised.exception.value_1, raised.exception.value_2}, {40, 41})
+        self.assertEqual(raised.exception.period, PERIOD)
+        self.assertEqual(raised.exception.member, self.head_id)
+
+    def test_the_message_distinguishes_it_from_a_missing_dependency(self):
+        error = ConflictingDependencyError("age", 1, 0, period=PERIOD, member="7")
+
+        self.assertIn("Conflicting", str(error))
+        self.assertIn("age at 2026 for member 7", str(error))
+
+
+class TestPeInputStillReturnsThePayload(PayloadConflictTestBase):
+    """`pe_input` is what a hundred payload tests and the spec-scenario harness call. It
+    keeps returning the union payload, so splitting is invisible to callers that only ever
+    send one request."""
+
+    def test_it_returns_the_union_payload(self):
+        programs = [fake_program("a", [FortyYearOld]), fake_program("b", [FortyOneYearOld])]
+
+        self.assertEqual(pe_input(self.screen, programs), build_pe_input(self.screen, programs).payload)

--- a/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
+++ b/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
@@ -13,8 +13,11 @@ matter are that the union payload is exactly what an agreeing screen would have 
 that a program on the losing side still sees every other input the screen produced.
 """
 
+import datetime
+
 from django.test import TestCase, override_settings
 
+import programs.framework.pe_dependencies as dependency
 from benefits.tests.cache_override import LOCAL_CACHE
 from programs.framework.pe_dependencies.base import ConflictingDependencyError, Household, Member
 from programs.framework.pe_dependencies.payload import (
@@ -65,7 +68,7 @@ class StateCode(Household):
         return "TX"
 
 
-def fake_program(code, inputs):
+def fake_program(code, inputs, period=PERIOD):
     """A calculator-shaped stand-in.
 
     A class rather than an instance, as the other payload tests use: `pe_period` is a
@@ -80,7 +83,7 @@ def fake_program(code, inputs):
             "pe_inputs": list(inputs),
             "pe_outputs": [],
             "pe_monthly_outputs": [],
-            "pe_period": PERIOD,
+            "pe_period": period,
         },
     )
 
@@ -303,6 +306,89 @@ class TestTheConflictReport(PayloadConflictTestBase):
         plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld])])
 
         self.assertEqual(plan.conflicts, [])
+
+
+class TestAProgramThatContradictsItself(PayloadConflictTestBase):
+    """A program declaring two dependencies that write one field with different values.
+
+    Nothing declares that today, but `pe_inputs` lists are assembled from shared dependency
+    groups, so adding a group carrying `AgeDependency` to a program already listing
+    `AgeAtEndOfClaimYearDependency` produces one. Partitioning cannot serve it: it loses that
+    slot in every pass, is forced back in alone to keep the loop moving, and writing its
+    values then raises -- which costs every PolicyEngine program on the screen its result,
+    the exact failure splitting exists to prevent. So it is dropped before partitioning.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.plan = build_pe_input(
+            self.screen,
+            [
+                fake_program("a", [FortyYearOld]),
+                fake_program("contradicts_itself", [FortyYearOld, FortyOneYearOld]),
+                fake_program("b", [FortyYearOld]),
+            ],
+        )
+
+    def test_the_other_programs_are_still_served_by_one_request(self):
+        self.assertEqual([bucket.program_indexes for bucket in self.plan.buckets], [[0, 2]])
+
+    def test_it_is_dropped_and_the_reason_is_kept_apart(self):
+        self.assertEqual(self.plan.dropped_program_indexes, [1])
+        self.assertEqual(self.plan.self_conflicting_program_indexes, [1])
+
+    def test_the_payload_holds_what_the_served_programs_agreed_on(self):
+        self.assertEqual(self.ages(self.plan.payload), {PERIOD: 40})
+
+    def test_it_is_named_in_the_report_as_a_surprise(self):
+        self.assertTrue(any("contradicts_itself" in report for report in self.plan.conflicts))
+        self.assertEqual(self.plan.unexpected_conflicts, self.plan.conflicts)
+
+    def test_alone_on_a_screen_it_sends_nothing_rather_than_a_guess(self):
+        """Its contributions are dropped with it instead of one of the two values being
+        picked arbitrarily -- no program left in the request reads that slot."""
+        plan = build_pe_input(self.screen, [fake_program("only", [FortyYearOld, FortyOneYearOld])])
+
+        self.assertEqual(plan.buckets, [])
+        self.assertEqual(plan.dropped_program_indexes, [0])
+        self.assertNotIn("age", plan.payload["household"]["people"][self.head_id])
+
+
+class TestWhichDisagreementsAreASurprise(PayloadConflictTestBase):
+    """Age on the screening date against age at the end of the claim year is why splitting
+    exists, and it recurs on a large share of Missouri screens. That pairing is reported as
+    expected so the caller can log it instead of raising; anything else stays a surprise."""
+
+    CLAIM_YEAR = "2030"
+
+    def setUp(self):
+        super().setUp()
+        # A claim year years ahead of the screening date makes the two age bases disagree
+        # whichever month the suite runs in: one is measured against 2030, the other against
+        # today. Pinning the birth month instead would agree every December.
+        self.head.birth_year_month = datetime.date(1961, 6, 1)
+        self.head.save()
+
+    def age_plan(self, screening_date_input, claim_year_input):
+        return build_pe_input(
+            self.screen,
+            [
+                fake_program("screening_date_age", [screening_date_input], period=self.CLAIM_YEAR),
+                fake_program("claim_year_age", [claim_year_input], period=self.CLAIM_YEAR),
+            ],
+        )
+
+    def test_the_two_age_bases_are_a_known_pairing(self):
+        plan = self.age_plan(dependency.member.AgeDependency, dependency.member.AgeAtEndOfClaimYearDependency)
+
+        self.assertEqual(len(plan.conflicts), 1)
+        self.assertEqual(plan.unexpected_conflicts, [])
+
+    def test_any_other_pairing_is_not(self):
+        plan = self.age_plan(FortyYearOld, FortyOneYearOld)
+
+        self.assertEqual(plan.unexpected_conflicts, plan.conflicts)
+        self.assertTrue(plan.unexpected_conflicts)
 
 
 class TestTheWriteInvariant(PayloadConflictTestBase):

--- a/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
+++ b/programs/framework/pe_dependencies/tests/test_payload_conflicts.py
@@ -291,7 +291,7 @@ class TestTheRequestLimit(PayloadConflictTestBase):
 
 
 class TestTheConflictReport(PayloadConflictTestBase):
-    def test_it_names_the_slot_both_values_and_who_wanted_each(self):
+    def test_it_names_the_slot_and_the_programs_on_each_side(self):
         plan = build_pe_input(
             self.screen,
             [fake_program("wants_forty", [FortyYearOld]), fake_program("wants_forty_one", [FortyOneYearOld])],
@@ -299,8 +299,21 @@ class TestTheConflictReport(PayloadConflictTestBase):
 
         self.assertEqual(len(plan.conflicts), 1)
         report = plan.conflicts[0]
-        for expected in ("age", PERIOD, self.head_id, "40", "41", "wants_forty", "wants_forty_one"):
+        for expected in ("age", PERIOD, self.head_id, "2 distinct values", "wants_forty", "wants_forty_one"):
             self.assertIn(expected, report)
+
+    def test_it_leaves_the_values_out(self):
+        """These lines reach Sentry and the application log. The slot and the two sides say
+        what disagreed; the household's own numbers stay in the payload, which is admin-only.
+        """
+        plan = build_pe_input(
+            self.screen,
+            [fake_program("wants_forty", [FortyYearOld]), fake_program("wants_forty_one", [FortyOneYearOld])],
+        )
+
+        report = plan.conflicts[0]
+        self.assertNotIn("40", report)
+        self.assertNotIn("41", report)
 
     def test_an_agreeing_screen_reports_nothing(self):
         plan = build_pe_input(self.screen, [fake_program("a", [FortyYearOld])])

--- a/programs/framework/tests/test_pe_combined_input.py
+++ b/programs/framework/tests/test_pe_combined_input.py
@@ -7,7 +7,7 @@ and CHIP are per-member, EITC and ACA are tax-unit — since that is where a nai
 merge drops a field.
 """
 
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.framework.pe_dependencies.constants import MAIN_TAX_UNIT
 from programs.programs.cross_white_label.eitc.base import Eitc
 from programs.programs.cross_white_label.snap.tx import TxSnap

--- a/programs/management/commands/import_program_config_data/data/mo_pts_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_pts_initial_config.json
@@ -7,6 +7,7 @@
   },
   "program": {
     "name_abbreviated": "mo_pts",
+    "active": true,
     "year": 2026,
     "legal_status_required": [
       "citizen",

--- a/programs/programs/cross_white_label/aca/tests/test_tx.py
+++ b/programs/programs/cross_white_label/aca/tests/test_tx.py
@@ -2,7 +2,7 @@
 
 from programs.framework.pe_dependencies.constants import MAIN_TAX_UNIT
 from programs.programs.cross_white_label.aca.tx import TxAca
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.aca.base import Aca

--- a/programs/programs/cross_white_label/csfp/tests/test_tx.py
+++ b/programs/programs/cross_white_label/csfp/tests/test_tx.py
@@ -2,7 +2,7 @@
 
 from screener.models import HouseholdMember
 from programs.programs.cross_white_label.csfp.tx import TxCsfp
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.csfp.base import CommoditySupplementalFoodProgram

--- a/programs/programs/cross_white_label/ctc/tests/test_federal.py
+++ b/programs/programs/cross_white_label/ctc/tests/test_federal.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from programs.framework.pe_dependencies import irs_gross_income
 from programs.framework.pe_dependencies import member
 from programs.framework.pe_dependencies import tax
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 
 
 class TestFederalCtc(TestCase):

--- a/programs/programs/cross_white_label/eitc/tests/test_federal.py
+++ b/programs/programs/cross_white_label/eitc/tests/test_federal.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from programs.framework.pe_dependencies import irs_gross_income
 from programs.framework.pe_dependencies import member
 from programs.framework.pe_dependencies import tax
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 
 
 class TestFederalEitc(TestCase):

--- a/programs/programs/cross_white_label/eitc/tests/test_tx.py
+++ b/programs/programs/cross_white_label/eitc/tests/test_tx.py
@@ -5,7 +5,7 @@ from screener.models import HouseholdMember
 from screener.models import IncomeStream
 from programs.framework.pe_dependencies.constants import MAIN_TAX_UNIT
 from screener.models import Screen
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.eitc.tx import TxEitc

--- a/programs/programs/cross_white_label/lifeline/tests/test_tx.py
+++ b/programs/programs/cross_white_label/lifeline/tests/test_tx.py
@@ -1,7 +1,7 @@
 """TX tests."""
 
 from programs.programs.cross_white_label.lifeline.tx import TxLifeline
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.lifeline.base import Lifeline

--- a/programs/programs/cross_white_label/medicaid/chip/tests/test_tx.py
+++ b/programs/programs/cross_white_label/medicaid/chip/tests/test_tx.py
@@ -1,7 +1,7 @@
 """TX tests."""
 
 from programs.programs.cross_white_label.medicaid.chip.tx import TxChip
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from unittest.mock import MagicMock

--- a/programs/programs/cross_white_label/medicaid/chip/tests/test_tx_mfb_307.py
+++ b/programs/programs/cross_white_label/medicaid/chip/tests/test_tx_mfb_307.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Insurance
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.framework.pe_dependencies.constants import MAIN_TAX_UNIT, SECONDARY_TAX_UNIT
 from programs.programs.cross_white_label.medicaid.chip.tx import TxChip
 

--- a/programs/programs/cross_white_label/msp/tests/test_base.py
+++ b/programs/programs/cross_white_label/msp/tests/test_base.py
@@ -12,7 +12,7 @@ from screener.models import Insurance
 from programs.programs.cross_white_label.medicaid.base import Medicaid
 from unittest.mock import Mock
 from programs.framework.pe_dependencies import household
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.cross_white_label.test_helpers import (
     distinct_state_codes,
     registered_subclasses,

--- a/programs/programs/cross_white_label/msp/tests/test_mo.py
+++ b/programs/programs/cross_white_label/msp/tests/test_mo.py
@@ -9,7 +9,7 @@ from programs.programs.cross_white_label.msp.base import Msp
 from screener.models import Screen
 from django.test import TestCase
 from screener.models import WhiteLabel
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 
 
 class TestMoMspWiring(TestCase):

--- a/programs/programs/cross_white_label/snap/ma.py
+++ b/programs/programs/cross_white_label/snap/ma.py
@@ -10,9 +10,9 @@ class MaSnap(Snap):
     # screen sending MaTotalHoursWorkedDependency, which approximates at the $15 state
     # minimum wage where the base class uses the $7.25 federal floor. Above the assumed
     # 40-hour floor those disagree (a $2,000/mo salary reads 33 hours in MA, 69 federally),
-    # and two dependencies writing different values to one field and period raise
-    # DependencyError inside pe_input() -- which runs outside calc_pe_eligibility's
-    # try/except, so the whole screen 500s rather than losing one program (MFB-1637).
+    # and two dependencies writing different values to one field and period cannot share a
+    # payload (MFB-1637). That used to 500 the whole screen; it now costs an extra
+    # PolicyEngine request, which is still worth avoiding for a value MA agrees on.
     pe_inputs = [
         *(dep for dep in Snap.pe_inputs if dep is not SNAP_HOURS_INPUT),
         dependency.member.MaTotalHoursWorkedDependency,

--- a/programs/programs/cross_white_label/snap/tests/test_tx.py
+++ b/programs/programs/cross_white_label/snap/tests/test_tx.py
@@ -1,7 +1,7 @@
 """TX tests."""
 
 from programs.programs.cross_white_label.snap.tx import TxSnap
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.snap.base import Snap

--- a/programs/programs/cross_white_label/snap/tests/test_work_hours.py
+++ b/programs/programs/cross_white_label/snap/tests/test_work_hours.py
@@ -7,11 +7,11 @@ and `meets_snap_abawd_work_requirements` (20 hrs) — both ANDed into `is_snap_e
 the whole SPM unit, with no categorical-eligibility override. See MFB-1637.
 
 The second half is the trap. One PolicyEngine request carries every program on the screen,
-so two dependencies writing different values to one field and period raise `DependencyError`
-in `update_unit` — raised from `pe_input()`, which runs outside `calc_pe_eligibility`'s
-try/except, so the screen 500s instead of losing one program. MA is where that bites: TAFDC
-and EAEDC approximate at the $15 state minimum wage while the base class uses the $7.25
-federal floor.
+so two dependencies writing different values to one field and period cannot both be served
+by it — payload assembly answers the disagreeing programs with a second request instead
+(`build_pe_input`). MA is where that bites: TAFDC and EAEDC approximate at the $15 state
+minimum wage while the base class uses the $7.25 federal floor. MaSnap swaps the class so
+one MA screen stays one request; the split is the safety net, not the plan.
 
 `pe_input` takes calculator classes here, as the other payload tests do — `pe_period` is a
 property needing a configured `Program.year`, and every calculator inherits the same
@@ -23,8 +23,7 @@ from django.test import TestCase, override_settings
 from benefits.tests.cache_override import LOCAL_CACHE
 from integrations.clients.policyengine.registry import all_calculators
 from programs.framework.pe_dependencies import member as member_dependency
-from programs.framework.pe_dependencies.base import DependencyError
-from programs.framework.pe_dependencies.payload import pe_input
+from programs.framework.pe_dependencies.payload import build_pe_input, pe_input
 from programs.programs.cross_white_label.snap.base import SNAP_HOURS_INPUT, Snap
 from programs.programs.cross_white_label.snap.co import CoSnap
 from programs.programs.cross_white_label.snap.il import IlSnap
@@ -224,10 +223,21 @@ class TestMaHoursPayload(HoursPayloadTestBase):
         self.assertEqual(hours_inputs(MaSnap), [MA_HOURS])
 
     def test_the_base_class_would_have_conflicted(self):
-        """Guards the reason for the swap: this is the 500 MaSnap exists to avoid. The
-        earner's $2,000/mo reads 68.9 hours federally against MA's floored 40."""
-        with self.assertRaises(DependencyError):
-            pe_input(self.screen, [TxSnap, MaTafdc])
+        """Guards the reason for the swap: the earner's $2,000/mo reads 68.9 hours federally
+        against MA's floored 40, so the two programs cannot share a payload.
+
+        This used to 500 the whole eligibility response. It now costs a second PolicyEngine
+        request, which is why MaSnap still swaps the class rather than leaning on the split.
+        """
+        plan = build_pe_input(self.screen, [TxSnap, MaTafdc])
+
+        self.assertEqual([b.program_indexes for b in plan.buckets], [[0], [1]])
+        # These two never share a real screen, so they also disagree about `state_code`.
+        # The hours disagreement is the one this test is about.
+        self.assertTrue(
+            any("weekly_hours_worked_before_lsr" in conflict for conflict in plan.conflicts),
+            plan.conflicts,
+        )
 
 
 class TestTxHoursPayload(HoursPayloadTestBase):

--- a/programs/programs/cross_white_label/ssi/tests/test_mo.py
+++ b/programs/programs/cross_white_label/ssi/tests/test_mo.py
@@ -17,7 +17,7 @@ from programs.framework.pe_dependencies.member import SsiIfTakesUp
 from programs.framework.pe_dependencies.member import SsiUnearnedIncomeDependency
 from django.test import TestCase
 from screener.models import WhiteLabel
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.framework.pe_dependencies import household
 
 

--- a/programs/programs/cross_white_label/ssi/tests/test_tx.py
+++ b/programs/programs/cross_white_label/ssi/tests/test_tx.py
@@ -1,7 +1,7 @@
 """TX tests."""
 
 from programs.programs.cross_white_label.ssi.tx import TxSsi
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.ssi.base import Ssi

--- a/programs/programs/cross_white_label/tanf/tests/test_tx.py
+++ b/programs/programs/cross_white_label/tanf/tests/test_tx.py
@@ -1,7 +1,7 @@
 """TX tests."""
 
 from programs.programs.cross_white_label.tanf.tx import TxTanf
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.programs.cross_white_label.tanf.base import Tanf

--- a/programs/programs/cross_white_label/wic/tests/test_ks.py
+++ b/programs/programs/cross_white_label/wic/tests/test_ks.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock
 from django.test import TestCase
 
 import programs.framework.pe_dependencies as dependency
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.framework.pe_base import PolicyEngineMembersCalculator
 from programs.framework.pe_dependencies import member as member_deps
 from programs.framework.pe_dependencies.household import KsStateCodeDependency

--- a/programs/programs/cross_white_label/wic/tests/test_mo.py
+++ b/programs/programs/cross_white_label/wic/tests/test_mo.py
@@ -13,7 +13,7 @@ from screener.models import WhiteLabel
 from programs.programs.cross_white_label.wic.base import Wic
 import programs.framework.pe_dependencies as dependency
 from programs.framework.pe_dependencies import member as member_deps
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.framework.pe_dependencies import household
 from programs.framework.pe_dependencies import member
 

--- a/programs/programs/cross_white_label/wic/tests/test_tx.py
+++ b/programs/programs/cross_white_label/wic/tests/test_tx.py
@@ -2,7 +2,7 @@
 
 from screener.models import HouseholdMember
 from programs.programs.cross_white_label.wic.tx import TxWic
-from integrations.clients.policyengine.policy_engine import pe_input
+from programs.framework.pe_dependencies.payload import pe_input
 from programs.programs.testing_fixtures.pe_input_test_base import TxPeInputTestBase
 from django.test import TestCase
 from programs.framework.pe_dependencies.household import TxStateCodeDependency

--- a/programs/programs/white_labels/mo/pts/calculator.py
+++ b/programs/programs/white_labels/mo/pts/calculator.py
@@ -25,7 +25,7 @@ class MoPts(PolicyEngineTaxUnitCalulator):
 
     pe_name = "mo_property_tax_credit"
     pe_inputs = [
-        dependency.member.AgeAtEndOf2026Dependency,
+        dependency.member.AgeAtEndOfClaimYearDependency,
         dependency.member.TaxUnitHeadDependency,
         dependency.member.TaxUnitSpouseDependency,
         dependency.member.TaxUnitDependentDependency,

--- a/programs/programs/white_labels/mo/pts/tests/test_mo_pts.py
+++ b/programs/programs/white_labels/mo/pts/tests/test_mo_pts.py
@@ -8,8 +8,8 @@ household through PolicyEngine once and replays from a cassette.
 
 Every scenario states a birth month and year rather than an age. That is load-bearing:
 the statute measures age on December 31 of the claim year, so ``MoPts`` sends
-``AgeAtEndOf2026Dependency`` instead of the screening-date age. Scenario 6 fails without
-it.
+``AgeAtEndOfClaimYearDependency`` instead of the screening-date age. Scenario 6 fails
+without it.
 
 Scenario 19 is the one place a scenario's expected screener result departs from its
 statutory result. The household satisfies every eligibility gate and the phaseout floors
@@ -165,7 +165,7 @@ class TestScenario05AtTheMinimumBase(MoPtsScenarioTestCase):
 class TestScenario06TurnsSixtyFiveLaterInTheYear(MoPtsScenarioTestCase):
     """Born September 1961 — age is measured on Dec 31, not the screening date.
 
-    The case that requires ``AgeAtEndOf2026Dependency``: the screening-date age reads 64
+    The case that requires ``AgeAtEndOfClaimYearDependency``: the screening-date age reads 64
     for most of the year and fails the age-65 pathway.
     """
 

--- a/programs/programs/white_labels/mo/pts/tests/test_wiring.py
+++ b/programs/programs/white_labels/mo/pts/tests/test_wiring.py
@@ -37,7 +37,8 @@ from django.test import TestCase
 import programs.framework.pe_dependencies as dependency
 from integrations.clients.policyengine.registry import all_calculators
 from programs.framework.pe_base import PolicyEngineTaxUnitCalulator
-from programs.framework.pe_dependencies.payload import pe_input
+from programs.framework.pe_dependencies.payload import bucket_payload, build_pe_input, pe_input
+from programs.programs.cross_white_label.ssi.mo import MoSsi
 from programs.models import WhiteLabel
 from screener.models import Expense, HouseholdMember, IncomeStream, Screen
 from programs.programs.white_labels.mo.pts.calculator import MoPts
@@ -244,14 +245,31 @@ class TestVeteranIncomeRouting(MoPtsScenarioTestCase):
 
 
 class TestAgeIsMeasuredAtYearEnd(MoPtsScenarioTestCase):
-    """Age comes from ``AgeAtEndOf2026Dependency``, not the screening date."""
+    """Age comes from ``AgeAtEndOfClaimYearDependency``, not the screening date."""
 
     def test_uses_the_end_of_claim_year_age_dependency(self):
-        self.assertIn(dependency.member.AgeAtEndOf2026Dependency, MoPts.pe_inputs)
+        self.assertIn(dependency.member.AgeAtEndOfClaimYearDependency, MoPts.pe_inputs)
         self.assertNotIn(dependency.member.AgeDependency, MoPts.pe_inputs)
 
-    def test_claim_year_is_the_program_year(self):
-        self.assertEqual(dependency.member.AgeAtEndOf2026Dependency.claim_year, CLAIM_YEAR)
+    def test_claim_year_follows_the_period_the_program_is_configured_for(self):
+        """The claim year is read off the period, so a program rolled to a new year sends
+        that year's ages without anybody editing a dependency.
+
+        Asserted by moving the period rather than against a constant: a claim year compared
+        to a literal defined alongside it passes whatever both are set to.
+        """
+        screen = self.build_screen(
+            [{"birth": (1961, 9), "relationship": "headOfHousehold", "incomes": {"pension": 12_000}}],
+            "homeowner",
+            "propertyTax",
+            1_200,
+        )
+        program = Mock()
+        program.year.period = "2027"
+        payload = pe_input(screen, [MoPts(screen, program, screen.missing_fields())])
+        ages = {person["age"]["2027"] for person in payload["household"]["people"].values()}
+
+        self.assertEqual(ages, {66})
 
     def test_later_in_year_birthday_reports_the_attained_age(self):
         """A September 1961 claimant attains 65 during 2026. ``AgeDependency`` would report
@@ -263,6 +281,98 @@ class TestAgeIsMeasuredAtYearEnd(MoPtsScenarioTestCase):
             1_200,
         )
         self.assertEqual(set(self.people_values(screen, "age").values()), {65})
+
+
+class TestSharingAScreenWithOtherMoPrograms(MoPtsScenarioTestCase):
+    """The incident this ticket closes.
+
+    Every program on a Missouri screen is answered from one PolicyEngine payload, and `age`
+    is one slot per member. MO PTS wants the age attained during the claim year; every other
+    program wants the age on the screening date. For a member whose birthday falls later in
+    the year those differ by one, and payload assembly used to raise on the disagreement from
+    outside `calc_pe_eligibility`'s try/except -- a 500 on `/api/eligibility/{id}` for the
+    whole screen, which is why `mo_pts` was deactivated in prod on 2026-08-24.
+
+    Assembly now answers the two sides with two requests. The screening-date age stays in the
+    first payload, so the other programs read exactly what they read before MO PTS existed.
+    """
+
+    def build_screen_with_a_later_in_year_birthday(self):
+        screen = self.build_screen(
+            [{"birth": (1961, 12), "relationship": "headOfHousehold", "incomes": {"pension": 12_000}}],
+            "homeowner",
+            "propertyTax",
+            1_200,
+        )
+        # A December birthday is 65 at the end of 2026 and 64 on any screening date before
+        # December, so the two age bases disagree for most of the year. Pinned rather than
+        # computed: `calc_age` reads the wall clock, and the disagreement this test is about
+        # has to exist in every month the suite runs in.
+        member = screen.household_members.first()
+        member.age = 64
+        member.save()
+
+        return screen
+
+    def plan(self, screen):
+        program = Mock()
+        program.year.period = PERIOD
+        return build_pe_input(
+            screen,
+            [
+                MoSsi(screen, program, screen.missing_fields()),
+                MoPts(screen, program, screen.missing_fields()),
+            ],
+        )
+
+    def test_the_two_age_bases_are_answered_by_two_requests(self):
+        plan = self.plan(self.build_screen_with_a_later_in_year_birthday())
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0], [1]])
+        self.assertEqual(plan.dropped_program_indexes, [])
+
+    def test_the_other_program_still_reads_the_screening_date_age(self):
+        screen = self.build_screen_with_a_later_in_year_birthday()
+        plan = self.plan(screen)
+
+        ages = {person["age"][PERIOD] for person in plan.payload["household"]["people"].values()}
+        self.assertEqual(ages, {64})
+
+    def test_mo_pts_gets_the_age_it_asked_for(self):
+        screen = self.build_screen_with_a_later_in_year_birthday()
+        plan = self.plan(screen)
+
+        payload = bucket_payload(plan, plan.buckets[1])
+        ages = {person["age"][PERIOD] for person in payload["household"]["people"].values()}
+        self.assertEqual(ages, {65})
+
+    def test_mo_pts_still_sees_the_rest_of_the_household(self):
+        """It is the same payload with one slot rewritten, so nothing MO PTS reads today
+        depends on which sibling programs happened to be on the screen."""
+        screen = self.build_screen_with_a_later_in_year_birthday()
+        plan = self.plan(screen)
+
+        first = plan.payload["household"]["people"]
+        second = bucket_payload(plan, plan.buckets[1])["household"]["people"]
+
+        for member_id, person in first.items():
+            differing = {field for field, periods in person.items() if second[member_id][field] != periods}
+            self.assertEqual(differing, {"age"})
+
+    def test_one_request_when_the_birthday_has_already_passed(self):
+        """The split is decided on values, not on which dependency classes the programs
+        declare. A January birthday makes both bases agree, so the screen stays one request.
+        """
+        screen = self.build_screen(
+            [{"birth": (1961, 1), "relationship": "headOfHousehold", "incomes": {"pension": 12_000}}],
+            "homeowner",
+            "propertyTax",
+            1_200,
+        )
+        plan = self.plan(screen)
+
+        self.assertEqual([bucket.program_indexes for bucket in plan.buckets], [[0, 1]])
+        self.assertEqual(plan.conflicts, [])
 
 
 class TestSurvivorBenefitsRouting(MoPtsScenarioTestCase):


### PR DESCRIPTION
## Context & Motivation

One PolicyEngine request carries every program on a screen, and each field, period and member is one slot in it. Two programs wanting different values for one slot raised `DependencyError` out of `pe_input()` — which runs *outside* `calc_pe_eligibility`'s `try/except` — so `/api/eligibility/{id}` returned a 500 for the whole screen. One program's input disagreement destroyed results for all of them, including the custom non-PolicyEngine calculators, which never got to run.

`mo_pts` was deactivated in prod on 2026-08-24 for exactly this. It sends the age attained during the claim year; the other 34 age-sending programs send the age on the screening date. Those differ by one for anybody whose birthday falls later in the calendar year, so activating `mo_pts` made every other Missouri program a collision partner. Sentry `PYTHON-DJANGO-DB`, 18 events, `age: 1 and 0` (an infant born in 2025).

Reactivating `mo_pts` requires the disagreement to stop being fatal.

- Linear: [MFB-1726](https://linear.app/myfriendben/issue/MFB-1726) (no GitHub issue; MFB tracks in Linear)
- Related PRs: #1697 (original MO PTS), #1716 (PE repin 1.794.2)
- Follow-up ticket opened from review discussion: [MFB-1775](https://linear.app/myfriendben/issue/MFB-1775) — tax-year presentation and the age basis for the *other* tax credits. Deliberately out of scope here.

## Changes Made

**Payload assembly resolves disagreements instead of raising** (`programs/framework/pe_dependencies/payload.py`)

- `build_pe_input` is now collect → partition → write. Every program's value is computed before anything is written, so a disagreement is resolved knowing all of them rather than by whichever program was iterated first.
- Programs are partitioned into groups that agree; each group gets one request. The value most programs asked for goes in the union payload, and the programs that wanted something else get **that same payload with only the contradicted slots rewritten** — so a program on the losing side still sees every other input the screen produced, and the first request is exactly what an agreeing screen would have sent.
- Majority-wins is not a claim that the majority is right; it loses the fewest programs if splitting has to stop, and it is order-independent except on ties. "Drop whoever wrote second" would have been registry-order-dependent — with `mo_pts` sorted early it would drop 34 programs to keep 1.
- Splitting is decided on **values**, not on which dependency classes a program declares, so an MO screen whose birthdays have already passed stays a single request.
- `pe_input` stays as a thin wrapper returning the union payload, so the ~100 payload-shape tests and the spec-scenario harness are unaffected.

**A program that contradicts itself is dropped before partitioning**

- `pe_inputs` lists are assembled from shared dependency groups, so one program can end up declaring two classes that write the same field. Two *programs* shaped that way split and both get served; one *program* shaped that way cannot be served at all, and previously it was forced into a bucket alone and then raised from `_values_for` — costing every PolicyEngine program on the screen its result, the exact failure splitting exists to prevent.
- Nothing declares that shape today. It is detected, dropped with its contributions, and reported separately from a program dropped past the request limit, so a bucket of one is always servable.

**Splitting is bounded twice, by count and by wall clock**

- `MAX_PAYLOAD_BUCKETS = 3` bounds how many requests one screen may cost.
- `PE_BUCKET_TIME_BUDGET_SECONDS = 45` bounds how long they may take. Three slow-but-not-failing calls at PolicyEngine's 30s read timeout would outlast the gunicorn worker `--timeout` of 120s, and a killed worker loses the whole response including the custom calculators. The first bucket always goes out; later ones only while budget remains, and abandoned programs are reported absent like any other dropped program.

**Only unexpected disagreements page anybody**

- The two age bases disagreeing is structural and recurs on a large share of Missouri screens, so a Sentry warning per split would be a permanently-firing issue burying the disagreements that mean something.
- Contributions carry the dependency class that produced them. An allowlisted pairing (`EXPECTED_CONFLICTING_DEPENDENCIES`, currently just `AgeDependency` / `AgeAtEndOfClaimYearDependency`) goes to the log; an unrecognised disagreement, a program past the request limit, or a program contradicting itself still captures to Sentry.
- **The conflict report carries no household values.** A conflicting slot holds screener data about a real household — an age, an hour count derived from reported income — and these lines reach Sentry (no scrubbing configured) and the application log. Each line names the slot, the number of distinct values, and the programs on each side, which is enough to find the two dependency classes and read what they compute. Values stay in the payload, which is admin-only.

**The two `DependencyError` classes are now distinguishable** (`pe_dependencies/base.py`)

- The payload one is `ConflictingDependencyError` and carries the period and member alongside both values. Two same-named exceptions with different constructor arities in one call graph is how the wrong one ended up caught at `screener/views.py:514`.
- It is caught in `calc_pe_eligibility` as a backstop. Reaching it now means the partition is wrong, not that two programs disagree.

**Dependencies receive their period** (`pe_dependencies/base.py`, `payload.py`, `tax.py`)

- Optional `period` kwarg plus a `period_year` helper, so a value that only means something relative to a period can read one. Closes the gap flagged at `base.py:26-29` for period (not version — MFB-1104 stays open).
- `period_year` accepts only the two shapes `period_for` produces (`YYYY`, and `YYYY-MM` with month 01–12) and returns None otherwise, falling back to the no-period behaviour. Reading the leading digits of anything would turn a malformed period into a confidently wrong year — `"20260"` became year 20260 and an age of 18299. `FederalPoveryLimit.period` is free-text, which is how a typo reaches there.
- `AgeAtEndOfClaimYearDependency` takes its claim year from the period; `AgeAtEndOf2026Dependency` is deleted and `MoPts` points at the parent. A program rolled to 2027 now sends 2027 ages instead of 2026 ages under a 2027 period.

**A PolicyEngine failure is contained to its own request** (`integrations/clients/policyengine/policy_engine.py`)

- One request failing no longer empties the screen's PolicyEngine results. Single-request behaviour is unchanged.
- `_pe_data` keeps its `{request, response}` shape and gains `additional_requests` only when a screen actually split, so **no frontend change is needed** — extra keys pass through `DictField` and are ignored by the `PolicyEngineData` TS interface.

**Config**

- `mo_pts_initial_config.json` now declares `"active": true` so the file matches intent (omitting it imports the program inactive).

**Test-only churn**

- 19 test modules imported `pe_input` from `policy_engine`, which was a transitive re-export; they now import it from `pe_dependencies.payload`. One line each, and most of this PR's file count.

## Testing

- **Migrations to run:** none.
- **Configuration updates needed:** none to run the tests. `mo_pts_initial_config.json` gained `"active": true`; re-importing locally is optional and only affects whether `mo_pts` appears on a local screen.
- **Environment variables/settings to add:** none.

**Automated:** `pytest` — **4045 passed, 5 skipped, 0 failures.** No cassettes re-recorded. New coverage: 21 partition cases (`pe_dependencies/tests/test_payload_conflicts.py`), 9 client-level bucketing cases (`policyengine/tests/test_pe_buckets.py`), 7 claim-year cases (`test_member.py`), 5 MO-screen cases (`mo/pts/tests/test_wiring.py::TestSharingAScreenWithOtherMoPrograms`).

**Manual, against live PolicyEngine.** Full write-up is [on the ticket](https://linear.app/myfriendben/issue/MFB-1726). Same three households, run on `main` and on this branch, with real authenticated calls to the private `household.api`:

| Screen | `main` | this branch |
| -- | -- | -- |
| MO, Dec birthdays (15 programs) | `DependencyError: Confilcting Policy Engine Dependencies in age: 65 and 64` | 2 PE requests, all 15 programs answered, `mo_pts` eligible **$1,055**, nothing dropped |
| MO, Jan birthdays (15 programs) | 1 request; `mo_lifeline` $111, `mo_nslp` $1,142, `mo_pts` $1,055 | 1 request; **identical** |
| CO, Dec birthdays (17 programs) | 1 request; `co_medicaid` $6,120, `co_snap` $6,552, `ede` $600, `fatc` $2,400, `lifeline` $111, `nslp` $1,116 | 1 request; **identical** |

The `main` message matches the Sentry event character for character, typo included, so that is the real failure rather than an approximation of it.

- **Payload identity measured, not inferred:** for both non-conflicting screens the payload is byte-identical to `main` — values *and* key insertion order — across a 15-program MO screen and a 17-program CO screen.
- **Results identity measured:** same programs, same dollar values, 32 program instances across two white labels.
- **On the split screen:** bucket 0 carries the screening-date age (64 / 10), bucket 1 carries `mo_pts` alone at the end-of-claim-year age (65 / 11), and `age` is the only field that differs between the two payloads.

**Reproducing it locally:** build the full calculator set the way `screener/views.py` does, then call `pe_input` for the payload comparison and `calc_pe_eligibility` for the live one, on each branch against the same screen rows. `mo_pts` needs to be active in the local DB.

## Deployment

- **Post-deployment scripts needed:** none.
- **Production config updates:** none automatic. `import_program_config` is not required — `--reconcile` cannot change program fields, so the `"active": true` in the config file does not flip prod by itself.
- **Admin updates needed:** **set `mo_pts.active = True` in the prod Django admin** once this is on prod and QA passes. That is the closing step of MFB-1726 and is deliberately a manual edit, not an import.
- **Notify team/users of:**
  - Verify after the flip with a household whose member has a later-in-year birthday: the MO bundle should return results, `mo_pts` included, both before and after activating.
  - Resolve Sentry `PYTHON-DJANGO-DB` once verified.
  - MO PTS will read `age: 65` for someone turning 65 later this year while every other MO program reads 64 for the same person. That is intended — the statute measures age on Dec 31 — but it is visible in the admin payload view and will look like an inconsistency to anyone who has not seen this PR.

## Notes for Reviewers

**The one design decision worth challenging.** The ticket proposed unifying all 35 programs onto the end-of-claim-year age. I didn't, because that age is right for a tax-year rule (MO PTS, CTC, EITC) and wrong for a monthly means-tested one. Unifying would have aged children out of WIC / NSLP / CHIP / Head Start up to eleven months early across all six white labels — false negatives, against the "screening errs inclusive" principle in `member.py` — to make one Missouri program correct. It would also have regressed the six age-sending programs configured behind the current year (`il_aabd`'s 65 floor moves the *wrong* way), which contradicts the ticket's "direction is always +1, never −1". This was not just inference: `medicaid/chip/specs/mo.md:203` already documents a MO CHIP scenario that unification would silently break, *and* notes that its literal-`age` scenarios would stay green through it. Splitting gets MO PTS its statutory age while leaving the other 34 programs' inputs untouched.

**Three of the ticket's acceptance criteria are written against unification and need rewording** — "`AgeDependency` sends the period-year age / both classes deleted" is now "the 2026 subclass is deleted and the claim year comes from the period"; the age-ceiling program review drops entirely; and "affected cassettes re-recorded" becomes "no cassette churn".

**On cassette safety.** The VCR matcher compares *parsed* JSON request bodies (`conftest.py:253`), so replaying unchanged proves value identity, not byte identity. Byte identity is proven separately by the payload diff above.

**Known limitations:**
- A split costs a second sequential PolicyEngine round trip. The worker timeout is 120s against PolicyEngine's 30s read timeout, and the 45s budget keeps three buckets inside it; parallelising is a follow-up if latency shows up.
- **The cost of a split falls entirely on `mo_pts`.** Majority-wins puts it alone in the second bucket, and the budget check skips later buckets first, so `mo_pts` is structurally the request abandoned when PolicyEngine is slow — for exactly the households that caused the split. It is reported to Sentry, but the household just sees the program missing. Defensible triage (better than losing 34 programs), but if it is not acceptable the fix is to prefer `mo_pts` into the first bucket on MO screens rather than let the count decide.
- Majority-wins is arbitrary on a tie, where registry order decides.
- Past the 3-request limit some programs get no result. Reported absent, which the caller already handles, rather than answered wrongly.

**Future considerations:**
- MFB-1637's SNAP work-hours compromise (`weekly_hours_worked_before_lsr` floored for every reader because one value per field per screen was a hard constraint) is now revisitable — the constraint costs a round trip rather than the response. Deliberately **not** touched here; it needs its own ticket and QA.
- `value()` still has no access to the resolved PolicyEngine *version*, only the period. MFB-1104 remains open.
- New comments and docstrings describe the failure without naming the ticket, per a house rule about ticket refs in committed code, so they read a little differently from their neighbours in the same files (which carry `MFB-1637` / `MFB-1638` / `MFB-1246` inline).
