### PR TITLE
MFB-1315: Delete inaccurate categorical-eligibility notes from KS HS/EHS specs

### DIFF
--- a/programs/programs/cross_white_label/early_head_start/specs/ks.md
+++ b/programs/programs/cross_white_label/early_head_start/specs/ks.md
@@ -161,8 +161,6 @@ Early Head Start eligibility can be substantially evaluated with current screene
 
 **Why this matters**: Validates that SNAP categorical eligibility (45 CFR § 1302.12(a)(1)(ii)(B)) independently qualifies a family regardless of income. At ~136% FPL, this family is well above the 100% FPL income limit PolicyEngine enforces (`is_early_head_start_eligible` requires `AGI ≤ 100% FPG` or categorical eligibility), so income is not a valid pathway on its own. Eligibility flows solely from SNAP receipt. Tests a distinct code branch from Scenario 1. The same logic applies to TANF and SSI.
 
-**Known limitation** (same as shipped HS, PR #1622): PolicyEngine determines categorical eligibility from *calculated* SNAP/TANF/SSI, not reported receipt. A household that reports receiving SNAP but whose income is above PolicyEngine's calculated SNAP threshold is not caught by this path, so this scenario is not satisfied by the current PolicyEngine implementation unless the household's income also clears PE's own SNAP calculation.
-
 ---
 
 ### Scenario 5: Family Above 100% FPL, No Categorical Eligibility — Income Ineligible

--- a/programs/programs/cross_white_label/head_start/specs/ks.md
+++ b/programs/programs/cross_white_label/head_start/specs/ks.md
@@ -133,8 +133,6 @@ Head Start eligibility can be substantially evaluated with current screener fiel
 
 **Why this matters**: Validates that SNAP categorical eligibility (45 CFR § 1302.12(a)(1)(ii)(B)) independently qualifies a family regardless of income. The same logic applies to TANF and SSI.
 
-**Known limitation**: PolicyEngine determines categorical eligibility from *calculated* SNAP/TANF/SSI, not reported receipt. A household that reports receiving SNAP but whose income is above PolicyEngine's calculated SNAP threshold is not caught by this path, so this scenario is not satisfied by the current PolicyEngine implementation.
-
 ---
 
 ### Scenario 4: Family Above 135% FPL, No Categorical Eligibility — Income Ineligible


### PR DESCRIPTION
## Summary

Deletes two `Known limitation` notes from the KS Head Start and Early Head Start specs. Both asserted that PolicyEngine determines categorical eligibility from *calculated* SNAP/TANF/SSI rather than reported receipt, and concluded their own SNAP categorical scenario was unsatisfiable.

That is no longer true. The actual-receipt contract ([MFB-1312](https://linear.app/myfriendben/issue/MFB-1312), #1685) is merged, so a household reporting SNAP qualifies regardless of whether PE computes a SNAP allotment for them.

## Verified on staging

Run against `6e9204bd` (KS, HH of 3, one age-3 child):

| Case | Income | Reports SNAP | KS Head Start |
| -- | -- | -- | -- |
| A | $14,400 | No | $15,664 (income path) |
| B | $28,800 | No | $0 |
| C | $28,800 | Yes | $15,664 (receipt path) |

At $28,800 `ks_snap` itself computes **$0** while `ks_head_start` pays out — categorical eligibility fires on `receives_snap` with no computed allotment, which is exactly the case the deleted notes called impossible. EHS follows the same pattern at $13,323.

## Why delete rather than correct

These specs are read as input by the federal backfill tickets ([MFB-1616](https://linear.app/myfriendben/issue/MFB-1616), [MFB-1614](https://linear.app/myfriendben/issue/MFB-1614)), which decide what to trim from state specs and what to carry up to the federal spec. A false note either gets propagated upward or sends someone to "fix" working behavior.

The surviving `Why we care` lines in both scenarios already state the rule correctly, so no replacement text is needed — the scenarios now read as plain descriptions of current behavior.

## Tests

No tests here. The categorical behavior is federal — `is_head_start_categorically_eligible` has no state branching — so the test scenarios moved to the federal family tickets rather than being written as KS tests that M2 would then delete:

- [MFB-1616](https://linear.app/myfriendben/issue/MFB-1616) — HS categorical, both directions + reported-but-$0
- [MFB-1614](https://linear.app/myfriendben/issue/MFB-1614) — EHS, same
- [MFB-1768](https://linear.app/myfriendben/issue/MFB-1768) — SNAP simulated-suppression + reported-but-$0

Each carries the verified case table above.

Docs only — no code paths touched.

Closes [MFB-1315](https://linear.app/myfriendben/issue/MFB-1315)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Kansas Early Head Start eligibility specifications.
  - Removed outdated “Known limitation” notes from scenarios covering families above 100% of the federal poverty level and reported SNAP, TANF, or SSI receipt.
  - Existing eligibility criteria, scenario outcomes, and annual benefit values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->