### PR TITLE
Offer the UWGKC dropdown on the state-agnostic /select-state route

### DIFF
--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -242,21 +242,17 @@ class TestStateOptionsConfiguration(SimpleTestCase):
                     f'White label "{code}" is not a state screener but is offered as a state.',
                 )
 
-    def test_default_white_label_declares_state_options(self):
-        """
-        The "_default" config backs the state-agnostic /select-state route, so it stays the
-        generic every-public-state list. A partner narrowing the dropdown belongs in the config
-        for the state path it is handed out under, where the screener actually reads it.
-        """
+    def test_default_white_label_offers_every_launched_state_by_default(self):
+        """The "_default" config backs the state-agnostic /select-state route, so its unreferred dropdown stays generic."""
         state_options_config = white_label_config["_default"].referrer_data.get("stateOptions")
 
         self.assertIsNotNone(state_options_config, '"_default" must declare "stateOptions".')
         self.assertEqual(
-            state_options_config,
-            {"default": []},
-            '"_default" should offer every publicly launched state and nothing partner-specific. '
-            f"Found {state_options_config!r}; move any referrer entry to that referrer's state "
-            "config.",
+            state_options_config.get("default"),
+            [],
+            "Someone entering /select-state with no referrer must be offered every publicly "
+            f'launched state, but "_default" narrows it to {state_options_config.get("default")!r}. '
+            "A referrer key alongside it is fine; this is only about the unreferred default.",
         )
 
     def test_multi_state_referrers_are_configured_in_every_state_they_offer(self):

--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -52,9 +52,9 @@ class DefaultConfigurationData(ConfigurationData):
             ]
         },
         "uiOptions": {"default": []},
-        # Empty means every publicly launched state. Referrers that narrow the dropdown declare it
-        # in the config for the state path they are handed out under, not here.
-        "stateOptions": {"default": []},
+        # "default" stays empty so the public dropdown offers every launched state; a referrer key
+        # here narrows the state-agnostic /select-state route, which loads no state config.
+        "stateOptions": {"default": [], "uwgkc": ["ks", "mo"]},
         "noResultMessage": {
             "default": {
                 "_label": "noResultMessage",


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Follow-up to [MFB-1672](https://linear.app/myfriendben/issue/MFB-1672/handle-moks-kansas-city-overlap-in-landing-page), shipped in #1727 (api) and MyFriendBen/benefits-calculator#2187 (frontend)
- Related PR: #1727

`/select-state` and `/` load no state config, so they read `_default`. The `uwgkc` referrer is
declared only in `ks.py` and `mo.py`, so entering from either of those bare paths fell through to
the publicly launched states — Kansas and Missouri were absent from the very dropdown the referrer
exists to narrow. Verified on staging: `/ks/select-state?referrer=uwgkc` offers the two states,
`/select-state?referrer=uwgkc` offers the public six.

This declares the referrer in `_default` as well, so a single bi-state link works alongside the
per-state `/ks` and `/mo` entry points.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- `_default.py`: `"stateOptions": {"default": [], "uwgkc": ["ks", "mo"]}`. The `"default"` entry is
  untouched, so an unreferred visitor still gets every publicly launched state.
- `configuration/tests.py`: `test_default_white_label_declares_state_options` asserted `_default`'s
  `stateOptions` was *exactly* `{"default": []}`, which this change contradicts by design. Narrowed
  to `test_default_white_label_offers_every_launched_state_by_default`, which asserts only that the
  unreferred `"default"` is `[]` — see Notes for Reviewers, this is the substantive part of the PR.

No migrations, no derived-catalog change, no frontend change.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: `python manage.py add_config _default`
- Environment variables/settings to add: none
- Manual testing steps, with the frontend on `main`:
  1. `python manage.py add_config _default`
  2. `/select-state?referrer=uwgkc` → Kansas and Missouri only
  3. `/?referrer=uwgkc` → language step, then the same two-state dropdown
  4. `/select-state` with no referrer → the usual six states
  5. `/ks/select-state?referrer=uwgkc` → unchanged, still the two states
  6. `pytest configuration` (53 passing locally); full suite `pytest -m "not integration"` at 3975
     passing

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: `python manage.py add_config _default` on staging, then production.
  Nothing changes until it runs, and nothing breaks if it doesn't — the dropdown just keeps serving
  the public list to `uwgkc`.
- Production config updates: the same `add_config _default` run.
- Admin updates needed: none.
- Notify team/users of: whether UWGKC should be given a bare `screener.myfriendben.org/?referrer=uwgkc`
  link, which is what this enables, or kept on the per-state `/ks/step-1?referrer=uwgkc` link already
  in `ks.py`'s `shareLink`.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

**This reverses a deliberate decision, so it deserves a real look rather than a rubber stamp.** The
test I narrowed carried the message "move any referrer entry to that referrer's state config", and
the `_default.py` comment said the same. That was encoding a genuine invariant: across all ten
configs there are 28 referrer keys, and before this PR every one lived in the config of the state it
belongs to (`211co`/`cudenver`/`jeffcoHS` in `co`, `211nc`/`lanc`/`ccla` in `nc`, `uwgkc` in `ks` and
`mo`). `_default` had none. `uwgkc` here is the first exception.

What that costs and doesn't cost:

- No runtime side effect on anyone else. `getReferrer` resolves `referrerData[key][referrer ?? "default"]`,
  so the new sub-key is reachable only with `?referrer=uwgkc`; every other referrer resolves as before.
  I diffed the whole `referrer_data` payload against `main` and `stateOptions` is the only key that
  differs, in the only config that changed.
- It does cost co-location: partner config for a multi-state referrer now lives in two places.
- Drift between them is still caught. `test_multi_state_referrers_are_configured_in_every_state_they_offer`
  iterates `_default`'s entry too, so membership is cross-checked both ways. Adding a third state to
  `ks`'s list without updating `_default` fails with
  `"uwgkc" offers ['ks', 'mo'] in white label "_default" but ['ks', 'mo', 'wa'] in white label "ks"`.
  (Confirmed by temporarily making that edit, not by reading the test.)

- Known limitations:
  - `/?referrer=uwgkc` and `/select-state?referrer=uwgkc` render with default MyFriendBen branding,
    because `_default` has no `uwgkc` `theme`/`logoSource`/`logoClass`. The 211 lockup appears once
    the state pick lands on `/ks/...` or `/mo/...`. Duplicating the branding keys into `_default`
    would fix it at the cost of more duplication — say the word.
  - The narrowed test no longer blocks a *new* partner key being added to `_default` unthinkingly.
    If you'd rather keep that deliberate, I can pin an explicit allowlist (`{"default", "uwgkc"}`)
    so a second key fails CI until someone edits it on purpose.
- Future considerations: the alternative to this PR is routing white-label-scoped sessions to
  `/{whiteLabel}/select-state` in `SelectLanguage`, which keeps the config as merged and the partner's
  branding from first paint. That's a frontend change; happy to put it up instead of, or alongside, this.
