### PR TITLE
MFB-1784: reconcile the WA/MA public charge URLs into the config

### DIFF
--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -376,3 +376,30 @@ class TestPublicChargeRuleConfiguration(SimpleTestCase):
                     "into a FormattedMessage; an empty _label renders as a FormattedMessage "
                     "with an empty id.",
                 )
+
+    # URLs known to 404. Reachability is not asserted -- that needs a live request, which
+    # would make this suite flaky and depend on the network. This list is the cheap half:
+    # a URL already found dead must not come back, which is exactly how WA and MA
+    # regressed. Both were fixed in the production database only, so `add_config` kept
+    # serving these from the Python config until they were reconciled here.
+    KNOWN_DEAD_LINKS = {
+        "https://www.dshs.wa.gov/esa/community-services-offices/public-charge",
+        "https://www.mass.gov/info-details/information-about-the-public-charge-rule-and-how-it-may-impact-you#information-about-the-public-charge-rule-",
+    }
+
+    def test_no_white_label_uses_a_known_dead_link(self):
+        """A public charge URL already confirmed dead must not reappear in the config."""
+        for code, white_label_data in white_label_config.items():
+            if white_label_data.is_default:
+                continue
+
+            link = white_label_data.public_charge_rule.get("link", "")
+
+            with self.subTest(white_label=code):
+                self.assertNotIn(
+                    link,
+                    self.KNOWN_DEAD_LINKS,
+                    f'White label "{code}" points its public charge link at {link!r}, which is '
+                    "known to return 404. Find the agency's current page rather than restoring "
+                    "this one.",
+                )

--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -376,30 +376,3 @@ class TestPublicChargeRuleConfiguration(SimpleTestCase):
                     "into a FormattedMessage; an empty _label renders as a FormattedMessage "
                     "with an empty id.",
                 )
-
-    # URLs known to 404. Reachability is not asserted -- that needs a live request, which
-    # would make this suite flaky and depend on the network. This list is the cheap half:
-    # a URL already found dead must not come back, which is exactly how WA and MA
-    # regressed. Both were fixed in the production database only, so `add_config` kept
-    # serving these from the Python config until they were reconciled here.
-    KNOWN_DEAD_LINKS = {
-        "https://www.dshs.wa.gov/esa/community-services-offices/public-charge",
-        "https://www.mass.gov/info-details/information-about-the-public-charge-rule-and-how-it-may-impact-you#information-about-the-public-charge-rule-",
-    }
-
-    def test_no_white_label_uses_a_known_dead_link(self):
-        """A public charge URL already confirmed dead must not reappear in the config."""
-        for code, white_label_data in white_label_config.items():
-            if white_label_data.is_default:
-                continue
-
-            link = white_label_data.public_charge_rule.get("link", "")
-
-            with self.subTest(white_label=code):
-                self.assertNotIn(
-                    link,
-                    self.KNOWN_DEAD_LINKS,
-                    f'White label "{code}" points its public charge link at {link!r}, which is '
-                    "known to return 404. Find the agency's current page rather than restoring "
-                    "this one.",
-                )

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -16,7 +16,7 @@ class MaConfigurationData(ConfigurationData):
         "link": "https://miracoalition.org/news/public-charge-rule-new-community-update-july-2026/",
         "text": {
             "_label": "landingPage.publicChargeLinkMA",
-            "_default_message": "Massachusetts Department of Health and Human Services",
+            "_default_message": "MIRA Coalition's public charge update",
         },
     }
 

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -13,7 +13,7 @@ class MaConfigurationData(ConfigurationData):
     state = {"name": "Massachusetts"}
 
     public_charge_rule = {
-        "link": "https://www.mass.gov/info-details/information-about-the-public-charge-rule-and-how-it-may-impact-you#information-about-the-public-charge-rule-",
+        "link": "https://miracoalition.org/news/public-charge-rule-new-community-update-july-2026/",
         "text": {
             "_label": "landingPage.publicChargeLinkMA",
             "_default_message": "Massachusetts Department of Health and Human Services",

--- a/configuration/white_labels/wa.py
+++ b/configuration/white_labels/wa.py
@@ -17,7 +17,7 @@ class WaConfigurationData(ConfigurationData):
     state = {"name": "Washington"}
 
     public_charge_rule = {
-        "link": "https://www.dshs.wa.gov/esa/community-services-offices/public-charge",
+        "link": "https://www.dshs.wa.gov/esa/csd-office-refugee-and-immigration-assistance/public-charge-information",
         "text": {
             "_label": "landingPage.publicChargeLinkWA",
             "_default_message": "Washington State Department of Social and Health Services",


### PR DESCRIPTION
## Problem

MFB-1707 fixed the dead WA and MA public charge links by editing the **production database** directly. Those corrections were never written back to `configuration/white_labels/wa.py` / `ma.py`, so `main` still carried the old URLs.

`add_config` rewrites config rows from these files, so the next `add_config --all` on production would have **reverted both links to 404s** and re-broken MFB-1707.

David [confirmed on MFB-1707](https://linear.app/myfriendben/issue/MFB-1707/public-charge-link-broken-in-wa-and-ma-screeners) that folding these into a PR was the right move.

## The URLs

Both taken verbatim from David's comments on MFB-1707, and matching what production serves today:

| WL | URL | HTTP |
| -- | -- | -- |
| wa | `.../esa/csd-office-refugee-and-immigration-assistance/public-charge-information` | **200** |
| ma | `miracoalition.org/news/public-charge-rule-new-community-update-july-2026/` | **200** |

Replacing, in `main`:

| WL | URL | HTTP |
| -- | -- | -- |
| wa | `.../esa/community-services-offices/public-charge` | **404** |
| ma | `mass.gov/info-details/information-about-the-public-charge-rule-and-how-it-may-impact-you#...` | **404** |

## MA label

MA's label read "Massachusetts Department of Health and Human Services" while the URL points at MIRA Coalition, a nonprofit. Per MFB-1707 the nonprofit destination is **deliberate** — David asked "Do we have alternative links to use here? I am not finding a good alternative on my end," and MIRA was chosen after no suitable government page was found. So the label was the thing out of step.

Now reads **"MIRA Coalition's public charge update"**, which follows the existing convention — NC and TX already name nonprofits (`North Carolina Justice Center's fact sheet about public charge`, `Protecting Immigrant Families website`).

Non-English translations for `landingPage.publicChargeLinkMA` will fall back to English until re-translated, since this edits an existing label rather than adding a new one.

## Checks

* `configuration/` suite: **53 passed**
* `black --check`: clean across 1028 files
* Diff: 3 files, +3/-3

The shape guard from MFB-1754 (`test_public_charge_rule_has_link_and_text`) still passes. An earlier revision of this PR added a hardcoded dead-URL denylist; that has been dropped — it needed manual curation to stay useful and could not catch the *next* dead link, which is the real gap.

## After merge

Run `add_config wa ma` per environment so staging picks up the working URLs — staging currently holds the 404s, matching what `main` had.

This also unblocks MFB-1754's release step: `add_config --all` on production becomes safe again rather than needing to be scoped to `ks mo`.

Found during MFB-1754 staging QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated Massachusetts public-charge information with a link to MIRA Coalition’s July 2026 community update.
  - Updated the Massachusetts link label to clearly identify the MIRA Coalition resource.
  - Updated Washington public-charge information with the latest Washington State DSHS link.
  - These changes help ensure users are directed to current, relevant state-specific resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->