### PR TITLE
MFB-1683: Fix: NC school meals shown to over-income households

### DIFF
--- a/programs/migrations/0173_rename_nc_nslp.py
+++ b/programs/migrations/0173_rename_nc_nslp.py
@@ -1,0 +1,48 @@
+# Renames North Carolina's National School Lunch Program row's name_abbreviated
+# from the bare federal key "nslp" to "nc_nslp" so it dispatches to the new
+# NcNslp calculator (programs/programs/cross_white_label/nslp/nc.py) instead of
+# the bare federal SchoolLunch calculator.
+#
+# Root cause (MFB-1683): SchoolLunch sends no state code, so PolicyEngine defaults
+# to universal-free-meals behavior and every NC household over the reduced-price
+# cutoff is shown as FREE. NcNslp adds NcStateCodeDependency, matching the
+# il_nslp / ks_nslp / mo_nslp / tx_nslp / wa_nslp precedent.
+#
+# Match strategy: filter by (white_label=nc, name_abbreviated="nslp"). Unlike the
+# coeitc rename (0154), NC has only one nslp-family row per white label, so no
+# additional external_name disambiguation is needed.
+
+from django.db import migrations
+
+
+def forward(apps, schema_editor):
+    from programs.models import Program, WhiteLabel
+
+    try:
+        nc = WhiteLabel.objects.get(code="nc")
+    except WhiteLabel.DoesNotExist:
+        return
+
+    Program.objects.filter(white_label=nc, name_abbreviated="nslp").update(name_abbreviated="nc_nslp")
+
+
+def reverse(apps, schema_editor):
+    from programs.models import Program, WhiteLabel
+
+    try:
+        nc = WhiteLabel.objects.get(code="nc")
+    except WhiteLabel.DoesNotExist:
+        return
+
+    Program.objects.filter(white_label=nc, name_abbreviated="nc_nslp").update(name_abbreviated="nslp")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0172_consolidate_shared_program_categories"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/programs/migrations/0175_rename_nc_nslp.py
+++ b/programs/migrations/0175_rename_nc_nslp.py
@@ -40,7 +40,7 @@ def reverse(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("programs", "0172_consolidate_shared_program_categories"),
+        ("programs", "0174_consolidate_missed_program_categories"),
     ]
 
     operations = [

--- a/programs/programs/cross_white_label/nslp/nc.py
+++ b/programs/programs/cross_white_label/nslp/nc.py
@@ -1,0 +1,23 @@
+"""NC National School Lunch Program."""
+
+from programs.programs.cross_white_label.nslp.base import SchoolLunch
+import programs.framework.pe_dependencies as dependency
+
+
+class NcNslp(SchoolLunch):
+    """
+    North Carolina National School Lunch Program (NSLP) calculator.
+
+    Inherits the federal SchoolLunch eligibility/value logic and adds the NC
+    state code so PolicyEngine resolves state_has_universal_free_school_meals
+    correctly. Without a state code, PE defaults to universal-free behavior,
+    which is wrong for NC (see MFB-1683) but coincidentally correct for the
+    bare-key CO/MA rows, which are genuinely universal-free.
+    """
+
+    program_code = "nc_nslp"
+
+    pe_inputs = [
+        *SchoolLunch.pe_inputs,
+        dependency.household.NcStateCodeDependency,
+    ]

--- a/programs/programs/cross_white_label/nslp/tests/test_nc.py
+++ b/programs/programs/cross_white_label/nslp/tests/test_nc.py
@@ -1,0 +1,46 @@
+"""NC tests."""
+
+from programs.programs.cross_white_label.nslp.nc import NcNslp
+from programs.programs.cross_white_label.nslp.base import SchoolLunch
+from django.test import TestCase
+import programs.framework.pe_dependencies as dependency
+
+
+class TestNcNslpWiring(TestCase):
+    """NcNslp registration and NC-specific pe_inputs handling."""
+
+    def test_is_subclass_of_school_lunch(self):
+        self.assertTrue(issubclass(NcNslp, SchoolLunch))
+
+    def test_pe_name_is_school_meal_net_subsidy(self):
+        """The annual net subsidy, not the per-day ``school_meal_daily_subsidy``."""
+        self.assertEqual(NcNslp.pe_name, "school_meal_net_subsidy")
+
+    def test_pe_outputs_are_inherited_from_school_lunch(self):
+        self.assertEqual(
+            NcNslp.pe_outputs,
+            [dependency.spm.SchoolMealNetSubsidy, dependency.spm.SchoolMealTier],
+        )
+
+    # --- the load-bearing input (over-eligibility regression guard) ---
+
+    def test_pe_inputs_includes_nc_state_code(self):
+        """Dropping this scores every NC household FREE tier at any income (MFB-1683)."""
+        self.assertIn(dependency.household.NcStateCodeDependency, NcNslp.pe_inputs)
+
+    # --- federal inputs must survive the NC override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in SchoolLunch.pe_inputs:
+            self.assertIn(federal_input, NcNslp.pe_inputs)
+
+    def test_pe_inputs_includes_school_meal_countable_income(self):
+        self.assertIn(dependency.spm.SchoolMealCountableIncomeDependency, NcNslp.pe_inputs)
+
+    def test_pe_inputs_includes_age(self):
+        """PE derives ``is_in_k12_school`` from age; without it there are no K-12 children
+        to value and the subsidy collapses to $0."""
+        self.assertIn(dependency.member.AgeDependency, NcNslp.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_one_input_over_federal(self):
+        self.assertEqual(len(NcNslp.pe_inputs), len(SchoolLunch.pe_inputs) + 1)


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-1683](https://linear.app/myfriendben/issue/MFB-1683/bug-nc-school-meals-shown-to-over-income-households-bare-federal-nslp)

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Added `NcNslp(SchoolLunch)` `(programs/programs/cross_white_label/nslp/nc.py) `—>  inherits the federal eligibility/value logic unchanged and adds `NcStateCodeDependency` to `pe_inputs`.
- Added programs/migrations/0173_rename_nc_nslp.py —>  repoints NC's existing Program row from name_abbreviated="nslp" to "nc_nslp". 
- Added `programs/programs/cross_white_label/nslp/tests/test_nc.py` —> Added tests confirming the fix is wired up correctly, following the same pattern already used for other states with this same fix.


## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: `python manage.py migrate programs`
- Configuration updates needed:  None
- Environment variables/settings to add: None
- Manual testing steps:

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added North Carolina-specific support for the National School Lunch Program.
  * North Carolina meal benefit calculations now account for the household’s state code when determining eligibility and subsidy levels.

* **Bug Fixes**
  * Corrected North Carolina program routing so it uses the appropriate state-specific calculation instead of the federal default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->