### PR TITLE
MFB-1761: make the production test gate reachable and blocking

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    outputs:
+      sha: ${{ steps.resolve_sha.outputs.sha }}
+
     env:
       SECRET_KEY: django-insecure-test-key-ci-github-actions-only
       DJANGO_SETTINGS_MODULE: benefits.settings
@@ -55,6 +58,31 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
+          # No later step performs an authenticated Git operation, and this job
+          # runs repository test code, so don't leave a usable token behind.
+          persist-credentials: false
+
+      # Pin the commit the tag resolved to and hand it to `deploy`. Tags are
+      # mutable: resolving `tag_name` independently in both jobs would let a tag
+      # moved mid-run ship a commit that was never tested.
+      - name: Resolve release commit
+        id: resolve_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Fail loudly rather than quietly thinning the suite. Wiring the input
+      # does not prove the secret has a value, and pytest_collection_modifyitems
+      # skips the HUD integration tests when it is empty -- so an unset secret
+      # would deploy on a green run with that coverage silently missing.
+      # Checked here rather than in the shared run-tests action, where fork PRs
+      # are meant to pass with no secrets at all.
+      - name: Require a HUD API token
+        env:
+          HUD_API_TOKEN: ${{ secrets.HUD_API_TOKEN }}
+        run: |
+          if [ -z "$HUD_API_TOKEN" ]; then
+            echo "::error::HUD_API_TOKEN is empty - the HUD integration tests would be skipped."
+            exit 1
+          fi
 
       # Django system checks and migrations (the build equivalent -- a config or
       # import error otherwise surfaces only at the push to Heroku) plus the full
@@ -69,8 +97,8 @@ jobs:
           # pinned to versions it has since rolled past.
           vcr-mode: none
           upload-coverage: 'false'
-          # Keep this wired: pytest_collection_modifyitems skips the HUD tests
-          # when the token is absent, so dropping it loses coverage silently.
+          # Guarded as non-empty above, since an absent token silently skips
+          # the HUD integration tests rather than failing.
           hud-api-token: ${{ secrets.HUD_API_TOKEN }}
 
       - name: Send verification failure notification to Slack
@@ -85,6 +113,10 @@ jobs:
 
   deploy:
     needs: [verify]
+    # `published` fires for prereleases too. Keeping them off production also
+    # makes a throwaway prerelease a safe way to exercise `verify` -- it runs,
+    # this job skips, production is untouched.
+    if: github.event.release.prerelease == false
     name: Deploy Backend to Heroku Production
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -93,10 +125,11 @@ jobs:
       url: https://cobenefits-api.herokuapp.com
 
     steps:
-      - name: Checkout release tag
+      # The exact commit `verify` tested, not the tag it came from.
+      - name: Checkout verified commit
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.verify.outputs.sha }}
 
       - name: Deploy to Heroku
         uses: ./.github/actions/deploy-to-heroku

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,14 +2,13 @@ name: Deploy to Production
 
 on:
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
-  test:
-    name: Run Tests with Real API Calls
+  verify:
+    name: Verify Release Tag
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.event.release.draft == true
 
     env:
       SECRET_KEY: django-insecure-test-key-ci-github-actions-only
@@ -20,8 +19,11 @@ jobs:
       DB_HOST: localhost
       DB_PORT: 5432
       ENABLE_GOOGLE_INTEGRATIONS: false
-      VCR_MODE: all
-      HUD_API_TOKEN: ${{ secrets.HUD_API_TOKEN }}
+      # Mirrors deploy-staging. Without this, settings.py takes the LocMemCache
+      # branch, TestRedisBackend skips itself, and the whole django_redis path
+      # goes untested -- the gap that let a Redis config error reach staging
+      # with a green build.
+      REDIS_URL: redis://localhost:6379/0
 
     services:
       postgres:
@@ -38,21 +40,51 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout release tag
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Run tests with real API calls
+      # Django system checks and migrations (the build equivalent -- a config or
+      # import error otherwise surfaces only at the push to Heroku) plus the full
+      # test suite, run against the tag being shipped rather than the branch the
+      # PR gate saw.
+      - name: Run tests
         uses: ./.github/actions/run-tests
         with:
-          vcr-mode: all
+          # Strict playback, same as PR validation and staging. Recording live
+          # here would 422 rather than gate anything: the private PolicyEngine
+          # API serves only `current` and `frontier`, and most cassettes are
+          # pinned to versions it has since rolled past.
+          vcr-mode: none
           upload-coverage: 'false'
+          # Keep this wired: pytest_collection_modifyitems skips the HUD tests
+          # when the token is absent, so dropping it loses coverage silently.
           hud-api-token: ${{ secrets.HUD_API_TOKEN }}
 
+      - name: Send verification failure notification to Slack
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+          environment: production
+          release-tag: ${{ github.event.release.tag_name }}
+          release-url: ${{ github.event.release.html_url }}
+
   deploy:
-    if: github.event.action == 'published'
+    needs: [verify]
     name: Deploy Backend to Heroku Production
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Context & Motivation

- Fixes [MFB-1761](https://linear.app/myfriendben/issue/MFB-1761/benefits-api-deploy-production-test-gate-has-never-run-9292-releases)
- Related PR: MyFriendBen/benefits-calculator#2193 ([MFB-1736](https://linear.app/myfriendben/issue/MFB-1736)) — same class of gap in the frontend; this mirrors its shape. Also unblocks the second acceptance criterion on [MFB-1565](https://linear.app/myfriendben/issue/MFB-1565).

The `test` job in `deploy-production.yml` has **never executed once**. Verified at job level across the full retained history — all **94 runs** from `2025-11-25` through `2026-09-04` report `Run Tests with Real API Calls = skipped`, including on `published` events where `Deploy Backend to Heroku Production = success`. Every production backend release for ~9 months has shipped with its test gate skipped.

Two independent defects compound:

1. **The job was unreachable.** It ran only `if: github.event.release.draft == true`. `published` implies the release is not a draft, and in practice releases are published directly rather than created as drafts, so neither subscribed type could satisfy it.
2. **Even if it ran, it gated nothing.** `deploy` had no `needs:` — there were zero `needs:` in the file — so it never waited on `test` and never consumed its result.

Introduced with the workflow in `da637712` ([MFB-459](https://linear.app/myfriendben/issue/MFB-459)). Pre-existing; found while reviewing #1742 ([MFB-1757](https://linear.app/myfriendben/issue/MFB-1757)), not caused by it.

### Why the gate is strict playback, not a live run

Live PolicyEngine calls don't belong on the release path — they belong in the scheduled drift job, which is tracked as its own body of work. `verify` therefore runs the same strict playback as PR validation and staging: deterministic, **~7 min** (measured on staging's `test` job at `vcr-mode: none`, 2026-09-04: `14:13:48 → 14:20:26`), and no dependency on an external service being reachable before production can ship.

Worth recording that the `VCR_MODE=all` this replaces could never have worked as a gate regardless. The private PolicyEngine API serves exactly two versions:

```
$ curl -s https://household.api.policyengine.org/versions/us
{"current":"1.821.2","frontier":"1.821.10"}
```

The committed cassettes send an explicit `"version"` in the request body, at four pins: `1.786.5` (1), `1.794.2` (36), `1.815.1` (47), `1.821.2` (5). **84 of 89 are aged out**, so a live re-record returns 422. Adding `needs:` to that job would have blocked every production deploy rather than gating one.

Dropping `VCR_MODE=all` also closes MFB-1565's second acceptance criterion and unblocks it: since the job never ran once, removing `all` deletes dead config rather than giving up coverage.

## Changes Made

Single file, `.github/workflows/deploy-production.yml`:

- **`test` → `verify` ("Verify Release Tag")**, with the unreachable `if: github.event.release.draft == true` dropped. It checks out the release tag and runs the shared `run-tests` action: `manage.py check --fail-level WARNING` and `migrate` (the build equivalent — a config or import error otherwise surfaces only at the push to Heroku) plus the full pytest suite.
- **`deploy` now has `needs: [verify]`**, so a failing tag cannot reach production. Its now-redundant `if: github.event.action == 'published'` is removed.
- **Trigger narrowed to `types: [published]`.** `created` gated nothing and only produced a second, fully-skipped run per release — 45 of the 94 runs were that noise run.
- **`vcr-mode: all` → `none`**, and the redundant job-level `VCR_MODE` / `HUD_API_TOKEN` env entries dropped (`run-tests` takes both as inputs).
- **Added the `redis` service and `REDIS_URL`** that `deploy-staging.yml` already sets and this job lacked. Per that file's own comment, without it `settings.py` takes the `LocMemCache` branch, `TestRedisBackend` skips itself, and the whole `django_redis` path goes untested — the gap that let a Redis config error reach staging with a green build.
- **`hud-api-token` kept wired.** `conftest.py:667` (`pytest_collection_modifyitems`) skips the HUD integration tests when the token is absent, so dropping it would lose that coverage silently rather than fail.
- **Slack notification when `verify` fails.** Because `deploy` is skipped rather than failed when `verify` fails, its own `if: failure()` notification never fires — without this a blocked release deploy would be silent.

Added in review:

- **Prereleases no longer reach production.** `deploy` gets `if: github.event.release.prerelease == false`. `published` fires for prereleases, so a beta or RC would otherwise have deployed. Not hypothetical — `v0.0.1-test` ("Test Release - Timeout Fix", 2025-11-25) is exactly that, cut to exercise this workflow when it was introduced, and it is the one prerelease in 45 releases.
- **`deploy` now checks out the commit `verify` tested**, not the tag. `verify` exports `git rev-parse HEAD` as a job output and `deploy` uses that SHA. Both jobs previously resolved `tag_name` independently, so a tag moved during the ~7 min verification window could ship a commit that was never tested — which defeats the gate. The deploy path already runs from a detached HEAD today, and `akhileshns/heroku-deploy` pushes `HEAD`, so a SHA checkout behaves identically.
- **`verify` fails when `HUD_API_TOKEN` is empty.** Wiring the input doesn't prove the secret has a value, and `pytest_collection_modifyitems` skips the HUD integration tests when it's missing — so an unset secret would deploy on a green run with that coverage silently gone. Guarded in the job rather than in the shared `run-tests` action, where fork PRs are *meant* to pass with no secrets at all.
- **`persist-credentials: false`** on the `verify` checkout: nothing after it performs an authenticated Git operation, and the job runs repository test code. Left as-is on the `deploy` checkout, whose Heroku push is unrelated to the GitHub token.

Deliberately **not** included: a `lint` job. Staging gates on `needs: [test, lint]`, but the release tag is a commit on `main` that black already checked on push, so it would be a duplicate check on the release path. Easy to add if reviewers want the symmetry.

### Audit of the other workflows (ticket AC #5)

The `needs:`-less pattern existed only in `deploy-production.yml`, in each repo:

- **benefits-api** — `deploy-staging.yml` has `needs: [test, lint]`. `format.yaml`, `oncall-rotation.yml` and `pr-validation.yaml` are single-job or PR-only with no deploy step to gate.
- **benefits-calculator** — `deploy-staging.yml` has `needs: [test, lint]`. `lint.yml`, `playwright.yml` and `tests-and-coverage.yml` are PR-only with nothing to gate. Its `deploy-production.yml` is fixed in #2193.

## Testing

- Migrations to run: none
- Configuration updates needed: none — unlike the frontend, this repo already has `HEROKU_PROD_APP_NAME`, `HEROKU_API_KEY`, `HEROKU_EMAIL`, `HUD_API_TOKEN` and `SLACK_WEBHOOK_URL` defined, and the `production` GitHub environment already exists (this workflow has deployed through it 44 times)
- Environment variables/settings to add: none
- Manual testing steps:
  - Unlike #2193, a clean push proves nothing here — this file already loaded and ran fine; only its gate was broken. Structural check:
    ```
    venv/bin/python -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy-production.yml')); v=d['jobs']['verify']; dep=d['jobs']['deploy']; print(d[True], list(d['jobs']), dep.get('needs'), dep.get('if'), v.get('if'), v.get('outputs'), dep['steps'][0]['with'])"
    ```
    Confirms `{'release': {'types': ['published']}}`, jobs `['verify', 'deploy']`, `deploy.needs == ['verify']`, `deploy.if == "github.event.release.prerelease == false"`, no `if:` on `verify`, `verify.outputs.sha` wired to `steps.resolve_sha`, and `deploy`'s checkout `ref` pointing at `needs.verify.outputs.sha` rather than the tag.
  - The `verify` job's contents are already exercised on every PR and every push to main — same `run-tests` action, same `vcr-mode: none`, and now the same postgres+redis services as staging. What is new is only *where* it runs (the tag) and *that it blocks*.
  - **Proving it is no longer `skipped` can be done safely, without shipping anything.** Publish a throwaway *prerelease* (e.g. `v0.0.0-gate-test`): the prerelease guard means `verify` runs while `deploy` skips, so production is untouched. `gh run view <id> --json jobs` should then show `Verify Release Tag` with a conclusion of `success` — the first time that job has ever reported anything but `skipped` — and `Deploy Backend to Heroku Production` as `skipped`. Delete the prerelease afterwards.
  - The full path, `verify` → `deploy`, still only runs on a real publish. **The first release after merge should be watched.**

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none. Optionally, required reviewers could be added to the existing `production` GitHub environment — see *Known limitations*.
- Notify team/users of: **publishing a GitHub Release now runs a ~7 min verification before the deploy, and a failure stops the deploy.** The happy path is otherwise unchanged apart from that delay.
  - **Merging a PR to main still deploys staging only.** `deploy-production.yml` has no `push` trigger and isn't getting one — production stays release-triggered.
  - **Publishing a prerelease verifies but does not deploy.** Handy for exercising the gate; also means a prerelease can no longer reach production by accident.
  - If `verify` fails, production is left untouched and Slack gets a failure notification. Recovery is manual — see *Known limitations*.

## Notes for Reviewers

- Known limitations:
  - **Nothing self-heals on failure, and the two failure points differ.**
    - **`verify` fails.** Production was never touched and keeps serving the previous code, but the Release stays published while pointing at a commit that never shipped. Roll the Release back (delete or un-publish it) so the release list still reflects production, fix `main`, and cut a fresh release. Re-running the workflow won't help — the tag still points at the bad commit.
    - **`deploy` fails.** Heroku may have taken a slug that then crashed. Check `heroku releases --app cobenefits-api` and `heroku releases:rollback --app cobenefits-api` before dealing with the GitHub Release.
  - **Stale-draft risk.** Publishing now deploys immediately, so publishing an old draft would ship an older commit over newer production. Narrowed but not eliminated by the review round: a stale *prerelease* draft is now harmless, a stale stable draft is not. Required reviewers on the `production` environment would backstop the rest; deliberately not added, since publishing a release is already a deliberate act and this matches #2193's shape.
  - `verify` re-runs tests that already passed on the PR and on push-to-main. Intentional: it pins the check to the exact tagged commit, which nothing checked before.
  - The `slack-notify` composite action's failure copy is deploy-centric ("Production Deployment Failed"). It reads acceptably for a verification failure — the deploy genuinely didn't happen — but isn't tailored to it. Changing the composite would touch the staging path, so it's left alone.
  - Migrations still run *after* the Heroku deploy, unchanged here. `verify` runs `migrate` against a scratch database, so a broken migration is now caught before the deploy, but the production-side ordering is untouched.
- Future considerations:
  - **The Slack success signal has been meaningless the whole time.** The `Run validations` and `Sync translations to staging` steps are hardcoded `run: exit 1` under `continue-on-error: true` (MFB-470, MFB-471, MFB-472), so `Determine final status` evaluates to `completed-with-warnings` on *every* production deploy. Pre-existing and out of scope here.
  - MFB-1565's `VCR_MODE=all` removal criterion can be closed once this merges, and its "Blocked on M6" note dropped.
  - Live PolicyEngine coverage is deliberately out of scope here: every CI path is strict playback, and live PE calls belong to the scheduled drift job tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production deployments now run verification against the exact release commit before deployment.
  * Deployments are restricted to non-prerelease releases.
  * Added stricter test validation, including Redis service checks and required deployment credentials.
  * Added Slack notifications when production verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->