### PR TITLE
Guard the Head Start/EHS actual-receipt contract for Missouri (MFB-1766)

### DIFF
--- a/integrations/clients/policyengine/tests/test_pe_buckets.py
+++ b/integrations/clients/policyengine/tests/test_pe_buckets.py
@@ -73,7 +73,12 @@ class PeBucketTestBase(TestCase):
             household_size=1,
             completed=False,
         )
-        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
+        # Explicit pk. The conflict message addresses the slot as ``people/<member id>``,
+        # and an auto-assigned id eventually lands on one containing "40" or "41" -- 407, say
+        # -- which makes the redaction assertion below fail on a sequence value rather than
+        # on anything the message actually leaked. Sequences are not reset between tests, so
+        # which id this gets depends on how many rows the rest of the suite created first.
+        self.head = HouseholdMember.objects.create(id=9, screen=self.screen, relationship="headOfHousehold", age=40)
         self.head_id = str(self.head.id)
 
     def calculator(self, inputs, period=PERIOD):

--- a/programs/programs/cross_white_label/early_head_start/specs/mo.md
+++ b/programs/programs/cross_white_label/early_head_start/specs/mo.md
@@ -17,7 +17,7 @@
 
 Early Head Start eligibility is determined by PolicyEngine using the federal eligibility rules (45 CFR § 1302.12: a child under age 3 or a pregnant woman, with family income at/below the federal poverty guideline, categorical eligibility via TANF/SNAP/SSI, homelessness, or foster care). No Missouri-specific eligibility rule was identified — Missouri DESE's EHS page describes the same federal framework with no MO-specific carve-out.
 
-This light spec does not reimplement or exhaustively test federal eligibility. Its scenarios isolate Missouri's state-specific benefit value, person-level calculation, and MFB's aggregation behavior — see Implementation Coverage below.
+This light spec does not reimplement or exhaustively test federal eligibility. Its scenarios isolate Missouri's state-specific benefit value, person-level calculation, and MFB's aggregation behavior, plus the one piece of eligibility that is MFB's own wiring rather than PE's rule — the actual-receipt categorical contract below. See Implementation Coverage.
 
 **Screener-to-PE field mapping** (verified against `screener/models.py` and `screener/serializers.py` on `benefits-api`'s `origin/main`):
 
@@ -33,6 +33,21 @@ This light spec does not reimplement or exhaustively test federal eligibility. I
 | SSI | `HouseholdMember.income_streams` row of type `"sSI"` — no dedicated `receivesSsi` field. Also auto-written into `Screen.current_benefits` (`_write_current_benefits()` OR's in an SSI-implied benefit name whenever an `"sSI"` income stream is present, independent of whether the SSI tile was ticked) | The `Ssi` PE dependency (`programs/framework/pe_dependencies/member.py`) reads the income stream directly, not `current_benefits`. |
 
 One federal pathway — homelessness — cannot currently be evaluated by MFB's PE integration; see Implementation Coverage below for the limitation and its scope.
+
+### Categorical Eligibility Is Actual Receipt, Not Simulated Eligibility (verified)
+
+The SNAP/TANF/SSI categorical pathway keys off **reported receipt** (`receives_snap`, `receives_tanf`, `receives_ssi`, each with its take-up flag), not off a benefit PolicyEngine simulated the household as eligible for. `EarlyHeadStart.pe_inputs` carries the full `receipt_contract` bundle, so MFB sends the distinction. Verified in both directions at PolicyEngine **1.821.2**:
+
+| PolicyEngine / MFB result | No SNAP reported | SNAP reported |
+|---|---:|---:|
+| `is_snap_eligible` | True | True |
+| `snap_if_takes_up` | $2,765.17 | $2,765.17 |
+| `snap` | **$0** | **$2,765.17** |
+| `mo_early_head_start` | **$0** | **$19,616.668** |
+
+Stripping the receipt/take-up inputs from the payload — the pre-#1685 request shape — makes the non-reporter eligible for $19,616.668 again, which is the false positive this pathway corrects.
+
+**Scenario-design constraint.** The negative case only tests receipt-versus-simulation while the household sits in a narrow income band: **above** the EHS income test (`spm_unit_fpg` = $27,320 for a household of three) so the ordinary pathway is closed, and **below** Missouri SNAP's simulated-eligibility ceiling so PolicyEngine still returns a would-be SNAP benefit to suppress. Raise the income and PolicyEngine stops simulating SNAP at all — the scenario then returns $0 under both the old and new contracts and passes for the wrong reason. Any future edit to Scenarios 4 and 5 has to keep them inside that band.
 
 ---
 
@@ -51,6 +66,8 @@ One federal pathway — homelessness — cannot currently be evaluated by MFB's 
 5. The result applies to each PE-eligible person who takes up EHS (take-up defaults true).
 6. PE does not round in the `early_head_start` variable — it returns the raw, uprated, unrounded float. MFB sums PE's raw person-level outputs and truncates the aggregated value once at serialization ($19,616.668 + $19,616.668 = $39,233.336 → truncate once to $39,233, for a two-participant household), confirmed through source inspection (`rest_framework/fields.py`'s `int()` truncation, `programs/calc.py`'s float summation with no intermediate rounding) and the live integrated run.
 
+**Re-verified 2026-09-09 at PolicyEngine 1.821.2**: the per-participant figure is unchanged at **$19,616.668**. No benefit-value edit was required.
+
 **Person-level values (live-confirmed, 2026-07-27)**:
 - Missouri, single participant: **$19,616** (raw $19,616.668, truncated)
 - Missouri, two participants: **$39,233** (raw $19,616.668 × 2 = $39,233.336, summed then truncated once)
@@ -68,7 +85,7 @@ One federal pathway — homelessness — cannot currently be evaluated by MFB's 
 
 - ✅ Evaluable criteria: age (under 3) or pregnancy, income at/below FPL, categorical via TANF/SNAP/SSI (self-report), foster care (from `relationship == "fosterChild"` or the per-member `was_in_foster_care` tile).
 - ⚠️ Data gap: homelessness. The screener doesn't collect current housing status, and PE's `is_homeless` variable defaults to `false` when not provided — the same as every shipped Head Start/EHS sibling. A household that qualifies *solely* through the homelessness pathway will not be found eligible by this integration; a household that qualifies through any other pathway is unaffected. This is a shared PE/MFB limitation across the whole Head Start/EHS program family, not a Missouri-specific gap.
-- This is a **light spec**: eligibility is federal and trusted to PolicyEngine, so the scenario suite below isolates Missouri's state-specific *value* and its aggregation rather than re-testing every federal eligibility branch. No negative federal-eligibility scenario is included — a household with no child under 3 and no pregnancy isn't a Missouri state-value isolation test, and federal eligibility branch coverage is PE's responsibility, not this spec's.
+- This is a **light spec**: eligibility is federal and trusted to PolicyEngine, so Scenarios 1-3 isolate Missouri's state-specific *value* and its aggregation rather than re-testing every federal eligibility branch. The one exception is the actual-receipt contract (Scenarios 4 and 5): that is MFB's own input wiring rather than PE's rule, it has regressed once, and no wiring test can catch it — so it is asserted behaviorally. Beyond that, no negative federal-eligibility scenario is included; a household with no child under 3 and no pregnancy isn't a Missouri state-value isolation test.
 
 ---
 
@@ -86,6 +103,8 @@ One federal pathway — homelessness — cannot currently be evaluated by MFB's 
 - [x] Scenario 1 (Missouri, single participant — golden path): User should be **eligible** — $19,616/year
 - [x] Scenario 2 (Missouri, two eligible participants — aggregation test): User should be **eligible** — $39,233/year
 - [x] Scenario 3 (Missouri, pregnant-only applicant — `PregnancyDependency` integration check): User should be **eligible** — $19,616/year
+- [ ] Scenario 4 (SNAP not reported, income above the test): User should be **not eligible** — $0
+- [ ] Scenario 5 (SNAP reported, same household): User should be **eligible** — $19,616/year
 
 ---
 
@@ -119,6 +138,32 @@ One federal pathway — homelessness — cannot currently be evaluated by MFB's 
 - **Person 4**: Child, birth_year 2025, birth_month 3 (age 1), no income
 
 **Why this matters**: 4-person household (2 adults, 2 age-eligible children) with income far below the 100% FPL threshold for a household of 4, so the income gate is not in question — only the per-participant value and aggregation are being tested.
+
+---
+
+### Scenario 4: SNAP Not Reported, Income Above the Test
+**What we're checking**: A household PolicyEngine would pay SNAP to, that reports no SNAP, with income above the EHS income test. The receipt contract has to suppress the would-be SNAP benefit so it confers no categorical eligibility.
+**Expected**: **Not eligible**. Value = **$0**.
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 3 people
+- **Person 1**: Head of household, age 30, employment income $2,600/month ($31,200/year)
+- **Person 2**: Child, age 4 (Head Start's participant, not EHS's; present so one household serves this spec and Head Start's)
+- **Person 3**: Child, age 1 (the only possible EHS participant here)
+- **Current Benefits**: none
+
+**Why this matters**: Before #1685 this household was found eligible for $19,616 on the strength of a SNAP benefit it was not receiving. The income pathway is closed at $31,200, so categorical eligibility is the only way in and reported receipt is the only thing that should open it.
+
+---
+
+### Scenario 5: SNAP Reported, Same Household
+**What we're checking**: The positive half of the contract, and — since exactly one participant qualifies — Missouri's per-participant value at income above the test.
+**Expected**: Eligible. Value = **$19,616** (raw $19,616.668, truncated at MFB serialization).
+
+**Steps**: identical to Scenario 4, plus **Current Benefits**: SNAP.
+
+**Why this matters**: Asserted alongside Scenario 4 so a change that simply denies everyone cannot pass both. One participant, so the expected figure is the single-participant value rather than an aggregate.
 
 ---
 

--- a/programs/programs/cross_white_label/early_head_start/specs/mo.md
+++ b/programs/programs/cross_white_label/early_head_start/specs/mo.md
@@ -103,8 +103,8 @@ Stripping the receipt/take-up inputs from the payload — the pre-#1685 request 
 - [x] Scenario 1 (Missouri, single participant — golden path): User should be **eligible** — $19,616/year
 - [x] Scenario 2 (Missouri, two eligible participants — aggregation test): User should be **eligible** — $39,233/year
 - [x] Scenario 3 (Missouri, pregnant-only applicant — `PregnancyDependency` integration check): User should be **eligible** — $19,616/year
-- [ ] Scenario 4 (SNAP not reported, income above the test): User should be **not eligible** — $0
-- [ ] Scenario 5 (SNAP reported, same household): User should be **eligible** — $19,616/year
+- [x] Scenario 4 (SNAP not reported, income above the test): User should be **not eligible** — $0
+- [x] Scenario 5 (SNAP reported, same household): User should be **eligible** — $19,616/year
 
 ---
 
@@ -117,7 +117,7 @@ Stripping the receipt/take-up inputs from the payload — the pre-#1685 request 
 
 **Why this matters**: Missouri's spending/enrollment parameters are the only thing this ticket adds — eligibility itself is entirely federal. If a future PE parameter update changes Missouri's EHS spending or enrollment figures, this is what catches it: a passing scenario with a wrong dollar amount would mean MO's value has silently drifted from its source, decoupled from any change in eligibility logic.
 
-- **Location**: ZIP `65101`, County `Cole`, State `MO`
+- **Location**: ZIP `65101`, County `Cole County`, State `MO`
 - **Household**: 2 people
 - **Person 1**: Head of household, birth_year 1996, birth_month 3 (age 30), employment income $1,000/month, citizen, no current benefits
 - **Person 2**: Child, birth_year 2025, birth_month 3 (age 1), no income
@@ -130,7 +130,7 @@ Stripping the receipt/take-up inputs from the payload — the pre-#1685 request 
 **Expected**: Eligible. Value = **$39,233** (MFB sums the raw per-person floats, $19,616.668 × 2 = $39,233.336, and truncates once at serialization; integrated MFB-to-PE path — see `mo_ehs_pe_delta_report.md`).
 
 **Steps**:
-- **Location**: ZIP `65101`, County `Cole`
+- **Location**: ZIP `65101`, County `Cole County`
 - **Household**: 4 people
 - **Person 1**: Head of household, birth_year 1996, birth_month 3 (age 30), employment income $1,200/month, citizen, no current benefits
 - **Person 2**: Spouse, birth_year 1998, birth_month 3 (age 28), no income
@@ -146,7 +146,7 @@ Stripping the receipt/take-up inputs from the payload — the pre-#1685 request 
 **Expected**: **Not eligible**. Value = **$0**.
 
 **Steps**:
-- **Location**: ZIP `65101`, County `Cole`
+- **Location**: ZIP `65101`, County `Cole County`
 - **Household**: 3 people
 - **Person 1**: Head of household, age 30, employment income $2,600/month ($31,200/year)
 - **Person 2**: Child, age 4 (Head Start's participant, not EHS's; present so one household serves this spec and Head Start's)
@@ -176,7 +176,7 @@ Stripping the receipt/take-up inputs from the payload — the pre-#1685 request 
 **Expected**: Eligible (federal financial/categorical eligibility). Value = **$19,616** (same single-person figure as Scenario 1; integrated MFB-to-PE path). Display copy should note this reflects federal eligibility only — local prenatal-service availability should be confirmed with the specific grantee.
 
 **Steps**:
-- **Location**: ZIP `65101`, County `Cole`
+- **Location**: ZIP `65101`, County `Cole County`
 - **Household**: 1 person
 - **Person 1**: Head of household, birth_year 1996, birth_month 3 (age 30), pregnant, employment income $1,000/month (clearly below the 100% FPL threshold for a household of 1), no current benefits
 

--- a/programs/programs/cross_white_label/early_head_start/tests/cassettes/TestScenarioSnapNotReported.test_income_above_the_test_and_no_reported_snap_is_ineligible.yaml
+++ b/programs/programs/cross_white_label/early_head_start/tests/cassettes/TestScenarioSnapNotReported.test_income_above_the_test_and_no_reported_snap_is_ineligible.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"301": {"age": {"2026": 30}, "is_pregnant": {"2026":
+      false}, "was_in_foster_care": {"2026": null}, "employment_income": {"2026":
+      31200}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0},
+      "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "early_head_start": {"2026": null}}, "302": {"age": {"2026":
+      4}, "is_pregnant": {"2026": false}, "was_in_foster_care": {"2026": null}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "early_head_start": {"2026": null}}, "303": {"age": {"2026":
+      1}, "is_pregnant": {"2026": false}, "was_in_foster_care": {"2026": null}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "early_head_start": {"2026": null}}}, "tax_units": {"main_tax_unit":
+      {"members": ["301", "302", "303"]}}, "families": {"family": {"members": ["301",
+      "302", "303"]}}, "households": {"household": {"members": ["301", "302", "303"],
+      "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["301",
+      "302", "303"], "tanf": {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+      {"2026": false}}}, "marital_units": {}}, "version": "1.821.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"301": {"age":
+        {"2026": 30}, "is_pregnant": {"2026": false}, "was_in_foster_care": {"2026":
+        false}, "employment_income": {"2026": 31200}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0},
+        "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+        "early_head_start": {"2026": 0.0}}, "302": {"age": {"2026": 4}, "is_pregnant":
+        {"2026": false}, "was_in_foster_care": {"2026": false}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0},
+        "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi":
+        {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "early_head_start":
+        {"2026": 0.0}}, "303": {"age": {"2026": 1}, "is_pregnant": {"2026": false},
+        "was_in_foster_care": {"2026": false}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "early_head_start": {"2026": 0.0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["301", "302", "303"]}}, "families": {"family": {"members": ["301",
+        "302", "303"]}}, "households": {"household": {"members": ["301", "302", "303"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["301",
+        "302", "303"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+        {"2026": false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.821.2", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '2243'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Sep 2026 14:37:56 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-4a2f25ca612d71d7a9d422f0070ec190-13dc5a13002110dd-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 4a2f25ca612d71d7a9d422f0070ec190
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 478303ef-4461-44f0-bfba-30e1e4e77032
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/early_head_start/tests/cassettes/TestScenarioSnapReported.test_reported_snap_qualifies_the_participant_categorically.yaml
+++ b/programs/programs/cross_white_label/early_head_start/tests/cassettes/TestScenarioSnapReported.test_reported_snap_qualifies_the_participant_categorically.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"401": {"age": {"2026": 30}, "is_pregnant": {"2026":
+      false}, "was_in_foster_care": {"2026": null}, "employment_income": {"2026":
+      31200}, "self_employment_income": {"2026": 0}, "rental_income": {"2026": 0},
+      "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "early_head_start": {"2026": null}}, "402": {"age": {"2026":
+      4}, "is_pregnant": {"2026": false}, "was_in_foster_care": {"2026": null}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "early_head_start": {"2026": null}}, "403": {"age": {"2026":
+      1}, "is_pregnant": {"2026": false}, "was_in_foster_care": {"2026": null}, "employment_income":
+      {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+      0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0}, "unemployment_compensation":
+      {"2026": 0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions":
+      {"2026": 0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "early_head_start": {"2026": null}}}, "tax_units": {"main_tax_unit":
+      {"members": ["401", "402", "403"]}}, "families": {"family": {"members": ["401",
+      "402", "403"]}}, "households": {"household": {"members": ["401", "402", "403"],
+      "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["401",
+      "402", "403"], "tanf": {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": true}, "takes_up_snap_if_eligible":
+      {"2026": true}}}, "marital_units": {}}, "version": "1.821.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2145'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"401": {"age":
+        {"2026": 30}, "is_pregnant": {"2026": false}, "was_in_foster_care": {"2026":
+        false}, "employment_income": {"2026": 31200}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0},
+        "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+        "early_head_start": {"2026": 0.0}}, "402": {"age": {"2026": 4}, "is_pregnant":
+        {"2026": false}, "was_in_foster_care": {"2026": false}, "employment_income":
+        {"2026": 0}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0},
+        "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi":
+        {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "early_head_start":
+        {"2026": 0.0}}, "403": {"age": {"2026": 1}, "is_pregnant": {"2026": false},
+        "was_in_foster_care": {"2026": false}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "early_head_start": {"2026": 19616.668}}}, "tax_units": {"main_tax_unit":
+        {"members": ["401", "402", "403"]}}, "families": {"family": {"members": ["401",
+        "402", "403"]}}, "households": {"household": {"members": ["401", "402", "403"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["401",
+        "402", "403"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": true}, "takes_up_snap_if_eligible":
+        {"2026": true}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.821.2", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '2247'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Sep 2026 14:37:59 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-3f9995da2bacbf31c28c9e5a5f6c7bdc-ca50405c3eaf3963-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 3f9995da2bacbf31c28c9e5a5f6c7bdc
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 44ca2d8d-cf96-4cdd-a4a3-d122e572ac39
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/early_head_start/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/early_head_start/tests/test_mo_scenarios.py
@@ -58,7 +58,7 @@ class MoEarlyHeadStartReceiptTestCase(PeIntegrationTestCase):
             state_code="MO",
             household_size=3,
             zipcode="65101",
-            county="Cole",
+            county="Cole County",
         )
         self.program = make_program("mo", "mo_early_head_start", YEAR)
 

--- a/programs/programs/cross_white_label/early_head_start/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/early_head_start/tests/test_mo_scenarios.py
@@ -1,0 +1,124 @@
+"""
+Receipt-contract regression scenarios for MO Early Head Start — one test per Test Scenario
+in ``specs/mo.md``.
+
+The Head Start suite's module docstring
+(``cross_white_label/head_start/tests/test_mo_scenarios.py``) explains the contract and the
+income band these scenarios depend on; both suites run the same Missouri household and
+differ only in which calculator reads it. Kept as two suites rather than one because a
+cassette records one calculator's payload, and ``mo_early_head_start`` sends a
+``PregnancyDependency`` that ``mo_head_start`` does not.
+
+In short: $2,600/month is above ``spm_unit_fpg`` ($27,320 for this household of three), so
+Early Head Start's ordinary income pathway is closed, and below Missouri SNAP's
+simulated-eligibility ceiling, so PolicyEngine still returns a would-be SNAP benefit the
+receipt contract has to suppress for a non-reporter. Moving the income out of that band
+makes the negative scenario pass for the wrong reason.
+"""
+
+import pytest
+
+from programs.programs.cross_white_label.early_head_start.mo import MoEarlyHeadStart
+from programs.programs.testing_fixtures.pe_integration import (
+    PeIntegrationTestCase,
+    add_income,
+    add_member,
+    calc_pe_program,
+    make_program,
+    make_screen,
+    screener_value,
+)
+from screener.serializers import _write_current_benefits
+from screener.tests.helpers import seed_program
+
+PE_VERSION = "1.821.2"
+YEAR = "2026"
+
+# See the Head Start suite: above the Head Start/EHS income test, below MO SNAP's ceiling.
+MONTHLY_WAGES = 2_600
+
+# PolicyEngine's per-participant Missouri EHS figure is $19,616.668; the screener truncates.
+MO_PER_PARTICIPANT_VALUE = 19_616
+
+
+class MoEarlyHeadStartReceiptTestCase(PeIntegrationTestCase):
+    """Shared household builder — the same one the Head Start suite uses."""
+
+    pe_version = PE_VERSION
+
+    # Distinct per subclass so each scenario's cassette pins its own household.
+    screen_id = 0
+
+    def build(self, reports_snap):
+        # make_screen creates the white label; make_program looks it up, so it has to run
+        # second.
+        screen = make_screen(
+            self.screen_id,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=3,
+            zipcode="65101",
+            county="Cole",
+        )
+        self.program = make_program("mo", "mo_early_head_start", YEAR)
+
+        adult = self.add_person(screen, 1, "headOfHousehold", 30)
+        add_income(adult, MONTHLY_WAGES)
+        # The 4-year-old is Head Start's participant, not EHS's, and is kept so both suites
+        # describe one household. Only the 1-year-old can be an EHS participant here, which
+        # is what makes the expected value the single-participant figure.
+        self.add_person(screen, 2, "child", 4)
+        self.add_person(screen, 3, "child", 1)
+
+        if reports_snap:
+            # `screen_reports_snap` resolves the tile through `has_base_benefit`, so the row
+            # needs `base_program="snap"` rather than a literal name.
+            seed_program(screen.white_label, "mo_snap_current", base_program="snap")
+            _write_current_benefits(screen, ["mo_snap_current"])
+            screen.invalidate_current_benefits_cache()
+
+        return screen
+
+    def add_person(self, screen, offset, relationship, age):
+        """A member at a fixed age — VCR matches the request body exactly, so an age derived
+        from the wall clock would break the suite on a calendar boundary."""
+        return add_member(screen, self.screen_id * 100 + offset, relationship, age)
+
+    def assert_result(self, screen, expected_eligible, expected_annual_value):
+        result = calc_pe_program(screen, MoEarlyHeadStart, self.program)
+        self.assertEqual(
+            (bool(result.eligible), screener_value(result)),
+            (expected_eligible, expected_annual_value),
+        )
+
+
+@pytest.mark.integration
+class TestScenarioSnapNotReported(MoEarlyHeadStartReceiptTestCase):
+    """Simulated SNAP eligibility alone must not confer Early Head Start eligibility."""
+
+    screen_id = 3
+
+    def test_income_above_the_test_and_no_reported_snap_is_ineligible(self):
+        """PolicyEngine would pay this household $2,765/year of SNAP, but it reports none.
+        The receipt contract suppresses that would-be benefit, so the categorical pathway is
+        shut and the income pathway is already closed at $31,200 — the under-3 child is not
+        an eligible participant.
+
+        Before #1685 the same household was found eligible for $19,616.
+        """
+        screen = self.build(reports_snap=False)
+        self.assert_result(screen, False, 0)
+
+
+@pytest.mark.integration
+class TestScenarioSnapReported(MoEarlyHeadStartReceiptTestCase):
+    """Reported SNAP receipt confers Early Head Start eligibility above the income test."""
+
+    screen_id = 4
+
+    def test_reported_snap_qualifies_the_participant_categorically(self):
+        """Identical household, SNAP ticked on the Current Benefits tile. One participant —
+        the under-3 child — so this also re-pins Missouri's per-participant value.
+        """
+        screen = self.build(reports_snap=True)
+        self.assert_result(screen, True, MO_PER_PARTICIPANT_VALUE)

--- a/programs/programs/cross_white_label/head_start/specs/mo.md
+++ b/programs/programs/cross_white_label/head_start/specs/mo.md
@@ -55,7 +55,7 @@ Scenarios 1 and 2 are both eligible, so the expected dollar amount changes if Mi
 **Expected**: Eligible, $16,314 (unrounded PE output $16,314.723, truncated per MFB's whole-dollar convention)
 
 **Steps**:
-- **Location**: ZIP `65101`, County `Cole`
+- **Location**: ZIP `65101`, County `Cole County`
 - **Household**: 2 people
 - **Person 1**: Head of Household, `birth_year` 1990, `birth_month` 3, income $1,000/mo ($12,000/yr, clearly under the 100% FPL threshold for HH2), US citizen
 - **Person 2**: Child, `birth_year` 2021, `birth_month` 8 (age 4), no income
@@ -68,7 +68,7 @@ Scenarios 1 and 2 are both eligible, so the expected dollar amount changes if Mi
 **Expected**: Eligible, $32,629 — `trunc(16,314.723 + 16,314.723) = trunc(32,629.446) = 32,629`.
 
 **Steps**:
-- **Location**: ZIP `65101`, County `Cole`
+- **Location**: ZIP `65101`, County `Cole County`
 - **Household**: 3 people
 - **Person 1**: Head of Household, `birth_year` 1990, `birth_month` 3, income $1,200/mo ($14,400/yr, clearly under the 100% FPL threshold for HH3), US citizen
 - **Person 2**: Child, `birth_year` 2022, `birth_month` 1 (age 4), no income
@@ -82,7 +82,7 @@ Scenarios 1 and 2 are both eligible, so the expected dollar amount changes if Mi
 **Expected**: **Not eligible**, $0
 
 **Steps**:
-- **Location**: ZIP `65101`, County `Cole`
+- **Location**: ZIP `65101`, County `Cole County`
 - **Household**: 3 people
 - **Person 1**: Head of Household, age 30, employment income $2,600/mo ($31,200/yr)
 - **Person 2**: Child, age 4 (Head Start band)

--- a/programs/programs/cross_white_label/head_start/specs/mo.md
+++ b/programs/programs/cross_white_label/head_start/specs/mo.md
@@ -11,7 +11,24 @@
 
 ## Scope
 
-Eligibility for Head Start Preschool is federal and is **not** being re-researched or tested here. This spec isolates and verifies Missouri's state-specific **benefit value** only.
+Eligibility for Head Start Preschool is federal and is not re-researched here. This spec covers two things: Missouri's state-specific **benefit value**, and the **actual-receipt categorical pathway** — the one federal behavior Missouri has already regressed on, verified end to end below.
+
+## Categorical Eligibility — Actual Receipt, Not Simulated Eligibility
+
+Head Start is categorically eligible for a household receiving **SNAP, TANF or SSI**, regardless of income. PolicyEngine keys that off **reported receipt** (`receives_snap`, `receives_tanf`, `receives_ssi`, each alongside its take-up flag), not off a benefit PolicyEngine simulated the household as eligible for. `HeadStart.pe_inputs` carries the full `receipt_contract` bundle, so MFB sends the distinction.
+
+This is verified in both directions, measured at PolicyEngine **1.821.2**:
+
+| PolicyEngine / MFB result | No SNAP reported | SNAP reported |
+|---|---:|---:|
+| `is_snap_eligible` | True | True |
+| `snap_if_takes_up` | $2,765.17 | $2,765.17 |
+| `snap` | **$0** | **$2,765.17** |
+| `mo_head_start` | **$0** | **$16,314.723** |
+
+Stripping the receipt/take-up inputs from the payload — the pre-#1685 request shape — makes the non-reporter eligible for $16,314.723 again, which is the false positive this pathway corrects.
+
+**Scenario-design constraint.** The negative case only tests receipt-versus-simulation while the household sits in a narrow income band: **above** Head Start's income test (`spm_unit_fpg` = $27,320 for a household of three) so the ordinary pathway is closed, and **below** Missouri SNAP's simulated-eligibility ceiling so PolicyEngine still returns a would-be SNAP benefit to suppress. Raise the income and PolicyEngine stops simulating SNAP at all — the scenario then returns $0 under both the old and new contracts and passes for the wrong reason. Any future edit to Scenarios 3 and 4 has to keep them inside that band.
 
 ## Benefit Value
 
@@ -30,9 +47,9 @@ The raw benchmark is PolicyEngine's own 2023 parameter-file value before the 202
 
 **Source**: HeadStart.gov's "Head Start Program Facts — Fiscal Year 2024" reports Missouri's Head Start Preschool Funded Enrollment as 9,225 and Annual Operations Funded Amount as $139,641,784 — matching PolicyEngine's parameter file exactly. See Research Sources below.
 
-## Light Value Scenarios
+## Test Scenarios
 
-Both scenarios are eligible, so the expected dollar amount changes if Missouri's state-specific value drifts. Eligibility itself is not being tested — feed clearly-eligible households directly to isolate the value calculation.
+Scenarios 1 and 2 are both eligible, so the expected dollar amount changes if Missouri's state-specific value drifts — they feed clearly-eligible households directly to isolate the value calculation. Scenarios 3 and 4 are the receipt-contract regression guards and are the only scenarios here that test eligibility.
 
 ### Scenario 1: One Eligible Missouri Child
 **Expected**: Eligible, $16,314 (unrounded PE output $16,314.723, truncated per MFB's whole-dollar convention)
@@ -61,6 +78,30 @@ Both scenarios are eligible, so the expected dollar amount changes if Missouri's
 
 ---
 
+### Scenario 3: SNAP Not Reported, Income Above the Test
+**Expected**: **Not eligible**, $0
+
+**Steps**:
+- **Location**: ZIP `65101`, County `Cole`
+- **Household**: 3 people
+- **Person 1**: Head of Household, age 30, employment income $2,600/mo ($31,200/yr)
+- **Person 2**: Child, age 4 (Head Start band)
+- **Person 3**: Child, age 1 (not Head Start eligible at any income; present so one household serves this spec and Early Head Start's)
+- **Current Benefits**: none
+
+**Why this matters**: PolicyEngine finds this household SNAP-eligible and would pay it $2,765/year, but it reports no SNAP. Under the actual-receipt contract that would-be benefit is suppressed, so nothing satisfies the categorical test and the income pathway is already closed at $31,200. Before #1685 the same household was told it qualified for $16,314 of Head Start on the strength of a SNAP benefit it was not receiving.
+
+---
+
+### Scenario 4: SNAP Reported, Same Household
+**Expected**: Eligible, $16,314 (unrounded PE output $16,314.723)
+
+**Steps**: identical to Scenario 3, plus **Current Benefits**: SNAP.
+
+**Why this matters**: The positive half of the contract. Reported receipt satisfies the categorical test on its own, so the age-eligible child qualifies despite income above `spm_unit_fpg`. Asserted alongside Scenario 3 so a change that simply denies everyone cannot pass both.
+
+---
+
 ## Research Sources
 
 - [PolicyEngine US — `head_start.py` variable, pinned commit `1d80e33cb87286888aa94d29202e434363d6bf2f`](https://github.com/PolicyEngine/policyengine-us/blob/1d80e33cb87286888aa94d29202e434363d6bf2f/policyengine_us/variables/gov/hhs/head_start/head_start.py) — the `spending ÷ enrollment` formula
@@ -75,6 +116,8 @@ Both scenarios are eligible, so the expected dollar amount changes if Missouri's
 
 [ ] Scenario 1 (One Eligible Missouri Child): Eligible, $16,314
 [ ] Scenario 2 (Two Eligible Missouri Children): Eligible, $32,629
+[ ] Scenario 3 (SNAP Not Reported, Income Above the Test): Not eligible, $0
+[ ] Scenario 4 (SNAP Reported, Same Household): Eligible, $16,314
 
 ## Program Configuration
 File: `mo_head_start_initial_config.json`

--- a/programs/programs/cross_white_label/head_start/tests/cassettes/TestScenarioSnapNotReported.test_income_above_the_test_and_no_reported_snap_is_ineligible.yaml
+++ b/programs/programs/cross_white_label/head_start/tests/cassettes/TestScenarioSnapNotReported.test_income_above_the_test_and_no_reported_snap_is_ineligible.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"101": {"age": {"2026": 30}, "was_in_foster_care":
+      {"2026": null}, "employment_income": {"2026": 31200}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+      0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026": 0},
+      "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "head_start": {"2026": null}}, "102": {"age": {"2026": 4},
+      "was_in_foster_care": {"2026": null}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+      0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026": 0},
+      "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "head_start": {"2026": null}}, "103": {"age": {"2026": 1},
+      "was_in_foster_care": {"2026": null}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+      0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026": 0},
+      "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "head_start": {"2026": null}}}, "tax_units": {"main_tax_unit":
+      {"members": ["101", "102", "103"]}}, "families": {"family": {"members": ["101",
+      "102", "103"]}}, "households": {"household": {"members": ["101", "102", "103"],
+      "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["101",
+      "102", "103"], "tanf": {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+      {"2026": false}}}, "marital_units": {}}, "version": "1.821.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2033'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"101": {"age":
+        {"2026": 30}, "was_in_foster_care": {"2026": false}, "employment_income":
+        {"2026": 31200}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0},
+        "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi":
+        {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "head_start":
+        {"2026": 0.0}}, "102": {"age": {"2026": 4}, "was_in_foster_care": {"2026":
+        false}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0},
+        "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+        "head_start": {"2026": 0.0}}, "103": {"age": {"2026": 1}, "was_in_foster_care":
+        {"2026": false}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "head_start": {"2026": 0.0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["101", "102", "103"]}}, "families": {"family": {"members": ["101",
+        "102", "103"]}}, "households": {"household": {"members": ["101", "102", "103"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["101",
+        "102", "103"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": false}, "takes_up_snap_if_eligible":
+        {"2026": false}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.821.2", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '2129'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Sep 2026 14:37:53 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-a5ac4dfef887741d85f09cd257225809-844923120fd92dc7-01
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - a5ac4dfef887741d85f09cd257225809;o=1
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - 801f8e31-ee05-4974-baff-f8197efc3194
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/head_start/tests/cassettes/TestScenarioSnapReported.test_reported_snap_qualifies_the_child_categorically.yaml
+++ b/programs/programs/cross_white_label/head_start/tests/cassettes/TestScenarioSnapReported.test_reported_snap_qualifies_the_child_categorically.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"201": {"age": {"2026": 30}, "was_in_foster_care":
+      {"2026": null}, "employment_income": {"2026": 31200}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+      0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026": 0},
+      "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "head_start": {"2026": null}}, "202": {"age": {"2026": 4},
+      "was_in_foster_care": {"2026": null}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+      0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026": 0},
+      "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "head_start": {"2026": null}}, "203": {"age": {"2026": 1},
+      "was_in_foster_care": {"2026": null}, "employment_income": {"2026": 0}, "self_employment_income":
+      {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+      0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026": 0},
+      "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+      0}, "ssi": {"2026": null}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+      {"2026": false}, "head_start": {"2026": null}}}, "tax_units": {"main_tax_unit":
+      {"members": ["201", "202", "203"]}}, "families": {"family": {"members": ["201",
+      "202", "203"]}}, "households": {"household": {"members": ["201", "202", "203"],
+      "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["201",
+      "202", "203"], "tanf": {"2026": null}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+      {"2026": false}, "receives_snap": {"2026": true}, "takes_up_snap_if_eligible":
+      {"2026": true}}}, "marital_units": {}}, "version": "1.821.2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2031'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://household.api.policyengine.org/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"201": {"age":
+        {"2026": 30}, "was_in_foster_care": {"2026": false}, "employment_income":
+        {"2026": 31200}, "self_employment_income": {"2026": 0}, "rental_income": {"2026":
+        0}, "taxable_pension_income": {"2026": 0}, "social_security": {"2026": 0},
+        "unemployment_compensation": {"2026": 0}, "long_term_capital_gains": {"2026":
+        0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0}, "receives_ssi":
+        {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false}, "head_start":
+        {"2026": 0.0}}, "202": {"age": {"2026": 4}, "was_in_foster_care": {"2026":
+        false}, "employment_income": {"2026": 0}, "self_employment_income": {"2026":
+        0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026": 0}, "social_security":
+        {"2026": 0}, "unemployment_compensation": {"2026": 0}, "long_term_capital_gains":
+        {"2026": 0}, "taxable_ira_distributions": {"2026": 0}, "ssi": {"2026": 0.0},
+        "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible": {"2026": false},
+        "head_start": {"2026": 16314.723}}, "203": {"age": {"2026": 1}, "was_in_foster_care":
+        {"2026": false}, "employment_income": {"2026": 0}, "self_employment_income":
+        {"2026": 0}, "rental_income": {"2026": 0}, "taxable_pension_income": {"2026":
+        0}, "social_security": {"2026": 0}, "unemployment_compensation": {"2026":
+        0}, "long_term_capital_gains": {"2026": 0}, "taxable_ira_distributions": {"2026":
+        0}, "ssi": {"2026": 0.0}, "receives_ssi": {"2026": false}, "takes_up_ssi_if_eligible":
+        {"2026": false}, "head_start": {"2026": 0.0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["201", "202", "203"]}}, "families": {"family": {"members": ["201",
+        "202", "203"]}}, "households": {"household": {"members": ["201", "202", "203"],
+        "state_code": {"2026": "MO"}}}, "spm_units": {"spm_unit": {"members": ["201",
+        "202", "203"], "tanf": {"2026": 0.0}, "receives_tanf": {"2026": false}, "takes_up_tanf_if_eligible":
+        {"2026": false}, "receives_snap": {"2026": true}, "takes_up_snap_if_eligible":
+        {"2026": true}}}, "marital_units": {}}, "policyengine_bundle": {"model_version":
+        "1.821.2", "data_version": null, "dataset": null}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Content-Length:
+      - '2133'
+      access-control-allow-origin:
+      - '*'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Sep 2026 14:37:55 GMT
+      server:
+      - Google Frontend
+      traceparent:
+      - 00-30486dd6f36fced72f4e71dcaefef52d-72bf0bd4a46cfd04-00
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - 30486dd6f36fced72f4e71dcaefef52d
+      x-policyengine-backend:
+      - modal
+      x-policyengine-primary-backend:
+      - modal
+      x-policyengine-primary-state:
+      - healthy
+      x-policyengine-request-id:
+      - f6292bb3-f14e-40ab-bc9e-89afeaa9ae88
+      x-policyengine-route-channel:
+      - current
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/cross_white_label/head_start/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/head_start/tests/test_mo_scenarios.py
@@ -1,0 +1,147 @@
+"""
+Receipt-contract regression scenarios for MO Head Start — one test per Test Scenario in
+``specs/mo.md``.
+
+``head_start`` is categorically eligible for a household receiving SNAP, TANF or SSI. Since
+PR #1685 that means *reported* receipt: ``receives_snap`` and its take-up siblings, not a
+SNAP amount PolicyEngine simulated the household as eligible for. These two scenarios pin
+that distinction end to end, because it is the one thing about Head Start that has already
+regressed once and that no wiring test can catch — ``pe_inputs`` can list every receipt
+dependency while PolicyEngine still answers from simulated eligibility.
+
+Both scenarios are the same Missouri household, changing only whether SNAP is reported. The
+$2,600/month income is load-bearing and deliberately narrow:
+
+* $31,200/year is **above** ``spm_unit_fpg`` ($27,320 for this household of three), so Head
+  Start's ordinary income pathway is closed and categorical eligibility is the only way in;
+* it is **below** Missouri SNAP's simulated-eligibility ceiling, so PolicyEngine still
+  returns ``is_snap_eligible = True`` and ``snap_if_takes_up = $2,765.17`` for the
+  non-reporter — a would-be benefit the receipt contract has to suppress.
+
+Raise the income and the negative case starts passing for the wrong reason: PolicyEngine
+stops simulating SNAP at all, so $0 proves nothing about receipt versus simulation. Anyone
+adjusting these households has to keep them inside that band.
+
+Verified against pre-#1685 behavior at the recorded version: stripping the receipt/take-up
+inputs from the payload and leaving everything else alone makes the non-reporter eligible
+for $16,314 again. So the negative scenario fails if that contract is ever undone.
+"""
+
+import pytest
+
+from programs.programs.cross_white_label.head_start.mo import MoHeadStart
+from programs.programs.testing_fixtures.pe_integration import (
+    PeIntegrationTestCase,
+    add_income,
+    add_member,
+    calc_pe_program,
+    make_program,
+    make_screen,
+    screener_value,
+)
+from screener.serializers import _write_current_benefits
+from screener.tests.helpers import seed_program
+
+PE_VERSION = "1.821.2"
+YEAR = "2026"
+
+# Above spm_unit_fpg ($27,320 for a household of three), below MO SNAP's simulated ceiling.
+# See the module docstring — this is the band the scenarios depend on.
+MONTHLY_WAGES = 2_600
+
+# PolicyEngine's per-child Missouri Head Start figure is $16,314.723; the screener truncates.
+MO_PER_CHILD_VALUE = 16_314
+
+
+class MoHeadStartReceiptTestCase(PeIntegrationTestCase):
+    """Shared household builder. Jefferson City, ZIP 65101, matching the spec's other
+    scenarios: Head Start's value is state-keyed, so the county is presentation only."""
+
+    pe_version = PE_VERSION
+
+    # Distinct per subclass so each scenario's cassette pins its own household.
+    screen_id = 0
+
+    def build(self, reports_snap):
+        # make_screen creates the white label; make_program looks it up, so it has to run
+        # second.
+        screen = make_screen(
+            self.screen_id,
+            white_label_code="mo",
+            state_code="MO",
+            household_size=3,
+            zipcode="65101",
+            county="Cole",
+        )
+        self.program = make_program("mo", "mo_head_start", YEAR)
+
+        adult = self.add_person(screen, 1, "headOfHousehold", 30)
+        add_income(adult, MONTHLY_WAGES)
+        # One child in the Head Start band (3-5) and one under 3. The under-3 child is not
+        # Head Start eligible at any income and is here so a single household serves both
+        # this suite and the Early Head Start one, which asserts on the same two scenarios.
+        self.add_person(screen, 2, "child", 4)
+        self.add_person(screen, 3, "child", 1)
+
+        if reports_snap:
+            # The Current Benefits tile is the only SNAP signal the screener captures --
+            # there is no reported amount -- and `screen_reports_snap` resolves it through
+            # `has_base_benefit`, so the row needs `base_program="snap"` rather than a
+            # literal name.
+            seed_program(screen.white_label, "mo_snap_current", base_program="snap")
+            _write_current_benefits(screen, ["mo_snap_current"])
+            screen.invalidate_current_benefits_cache()
+
+        return screen
+
+    def add_person(self, screen, offset, relationship, age):
+        """A member at a fixed age.
+
+        Ages are stated outright rather than derived from a birth year: VCR matches on the
+        exact request body, so an age that moved with the wall clock would break the whole
+        suite on a calendar boundary.
+        """
+        return add_member(screen, self.screen_id * 100 + offset, relationship, age)
+
+    def assert_result(self, screen, expected_eligible, expected_annual_value):
+        result = calc_pe_program(screen, MoHeadStart, self.program)
+        self.assertEqual(
+            (bool(result.eligible), screener_value(result)),
+            (expected_eligible, expected_annual_value),
+        )
+
+
+@pytest.mark.integration
+class TestScenarioSnapNotReported(MoHeadStartReceiptTestCase):
+    """Simulated SNAP eligibility alone must not confer Head Start eligibility."""
+
+    screen_id = 1
+
+    def test_income_above_the_test_and_no_reported_snap_is_ineligible(self):
+        """PolicyEngine finds this household SNAP-eligible and would pay it $2,765/year, but
+        the household reports no SNAP. Under the actual-receipt contract that would-be
+        benefit is suppressed, so nothing satisfies Head Start's categorical test and the
+        income pathway is already closed at $31,200.
+
+        This is the case that regressed before #1685: the same household was told it
+        qualified for $16,314 of Head Start on the strength of a SNAP benefit it was not
+        receiving.
+        """
+        screen = self.build(reports_snap=False)
+        self.assert_result(screen, False, 0)
+
+
+@pytest.mark.integration
+class TestScenarioSnapReported(MoHeadStartReceiptTestCase):
+    """Reported SNAP receipt confers Head Start eligibility above the income test."""
+
+    screen_id = 2
+
+    def test_reported_snap_qualifies_the_child_categorically(self):
+        """Identical household, SNAP ticked on the Current Benefits tile. Receipt satisfies
+        the categorical test on its own, so the age-eligible child qualifies despite income
+        above ``spm_unit_fpg`` — the positive half of the contract, asserted alongside the
+        negative one so a change that simply denies everyone cannot pass this suite.
+        """
+        screen = self.build(reports_snap=True)
+        self.assert_result(screen, True, MO_PER_CHILD_VALUE)

--- a/programs/programs/cross_white_label/head_start/tests/test_mo_scenarios.py
+++ b/programs/programs/cross_white_label/head_start/tests/test_mo_scenarios.py
@@ -71,7 +71,7 @@ class MoHeadStartReceiptTestCase(PeIntegrationTestCase):
             state_code="MO",
             household_size=3,
             zipcode="65101",
-            county="Cole",
+            county="Cole County",
         )
         self.program = make_program("mo", "mo_head_start", YEAR)
 


### PR DESCRIPTION
## Context & Motivation

Lands the prepared Head Start / Early Head Start spec and regression-test changes from MFB-1628. QA and research were complete; this was the only remaining in-scope blocker on that ticket.

PR #1685 changed the shared PolicyEngine contract so downstream programs distinguish **reported receipt** of SNAP/TANF/SSI from PolicyEngine's **simulated would-be eligibility**. Head Start and Early Head Start take categorical eligibility from that signal. Missouri was outside #1685's QA matrix, and `mo_head_start` / `mo_early_head_start` had already been signed off against pre-contract behavior.

The calculators are correct — `HeadStart.pe_inputs` and `EarlyHeadStart.pe_inputs` already carry the full `receipt_contract` bundle, and no calculator change is needed here. What was missing is a behavioral guard. `pe_inputs` can list every receipt dependency while PolicyEngine still answers from simulated eligibility, so the existing wiring tests structurally cannot catch a regression to pre-#1685 behavior.

- Closes MFB-1766
- Unblocks MFB-1628
- Related: MFB-1312 / #1685

## Changes Made

**Regression tests** (4 new VCR scenarios, one household, changing only whether SNAP is reported):

- `cross_white_label/head_start/tests/test_mo_scenarios.py` — `mo_head_start`: no SNAP reported → `$0` / ineligible; SNAP reported → `$16,314` / eligible
- `cross_white_label/early_head_start/tests/test_mo_scenarios.py` — `mo_early_head_start`: no SNAP reported → `$0` / ineligible; SNAP reported → `$19,616` / eligible

Both assert eligibility **and** value, and both directions are asserted so a change that simply denies everyone cannot pass the suite.

**The income band is load-bearing.** $2,600/month is:

- **above** the Head Start income test (`spm_unit_fpg` = $27,320 for this household of three), so the ordinary income pathway is closed and categorical eligibility is the only way in; and
- **below** Missouri SNAP's simulated-eligibility ceiling, so PolicyEngine still returns `is_snap_eligible = True` and `snap_if_takes_up = $2,765.17` for the non-reporter — a would-be benefit the receipt contract has to suppress.

Outside that band the negative case returns `$0` under the old contract too, and passes for the wrong reason. The constraint is written into both specs and both module docstrings so a future edit doesn't quietly break the guard while leaving it green.

**Specs:**

- `head_start/specs/mo.md` — replaced the scope note that said eligibility "is **not** being re-researched or tested here" (which the new scenarios contradict), added the verified actual-receipt pathway with its measurement table, renamed "Light Value Scenarios" → "Test Scenarios", added Scenarios 3 and 4 and their acceptance criteria. Existing value scenarios untouched.
- `early_head_start/specs/mo.md` — added the actual-receipt verification note and table, added Scenarios 4 and 5, corrected the "no negative federal-eligibility scenario is included" claim, and recorded that Missouri's per-participant value re-verified **unchanged** at $19,616.668.
- Both specs and both test modules — qualified the county as `Cole County`. The MO ZIP→county map keys `65101` with the suffix, `CountyDependency` normalizes a bare `Cole` to `COLE_MO`, and PolicyEngine silently falls back on an unknown `county_str` rather than erroring. Head Start sends no county input so nothing changes in these cassettes, but the Steps drive api-qa runs where a bare `Cole` won't match the county selector. The EHS acceptance criteria for Scenarios 4 and 5 are also checked off now that both have passing tests.

**Test fixture:**

- `integrations/clients/policyengine/tests/test_pe_buckets.py` — pinned the shared base household member's pk. The dependency-conflict message addresses the slot as `people/<member id>`, so an auto-assigned id that lands on one containing `40` or `41` (`407`, say) fails the redaction assertion on a sequence value rather than on anything the message actually leaked. Sequences aren't reset between tests, so which id the member got depended on how many rows the rest of the suite created first — unrelated to Head Start, but it surfaced while running this suite.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  ```
  VCR_MODE=none venv/bin/pytest programs/programs/cross_white_label/head_start \
                                programs/programs/cross_white_label/early_head_start -q
  ```

Results:

- Head Start + Early Head Start, strict offline replay: **131 passed**
- Full suite, `VCR_MODE=none`: **4236 passed, 4 skipped**

**Mutation check.** Verified at the recorded version that the guard actually guards: stripping the receipt/take-up inputs from the payload (the pre-#1685 request shape) and leaving everything else alone makes the non-reporter eligible for `$16,314.723` / `$19,616.668` again. That is the exact false positive the contract corrects, so these tests fail if it is ever undone.

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: nothing user-facing — tests and specs only, no calculator or config change

## Notes for Reviewers

**Cassettes are pinned at PolicyEngine 1.821.2, not the 1.815.1 the original QA used.** PolicyEngine serves only what `current`/`frontier` currently resolve to and 422s anything else, so 1.815.1 could not be re-recorded (`current` is now 1.821.2, `frontier` 1.821.10). Everything reproduced unchanged at 1.821.2:

| | MFB-1628 @ 1.815.1 | This PR @ 1.821.2 |
|---|---:|---:|
| `spm_unit_fpg` | $27,320 | $27,320 |
| `head_start_countable_income` | $31,200 | $31,200 |
| `mo_head_start` (SNAP reported) | $16,314.723 | $16,314.723 |
| `mo_early_head_start` (SNAP reported) | $19,616.668 | $19,616.668 |

The one difference is `snap_if_takes_up`, which moved from $223.70/month to $2,765.17/year (~$230.43/month) between the two versions. Nothing here asserts on it — it only has to be non-zero for the scenario to be in the band, and it is.

- Known limitations: the two suites build the same household but live in separate files, because a cassette records one calculator's payload and `mo_early_head_start` sends a `PregnancyDependency` that `mo_head_start` does not. The duplication is deliberate; the Early Head Start docstring points at the Head Start one for the full rationale.
- Future considerations: MFB-1628 routed three adjacent findings elsewhere and none are addressed here — NSLP's non-adoption of the receipt contract and its `is_head_start_eligible` coupling (MFB-1651), `MoPts` sending SSI without the contract (MFB-1726), and the Head Start/EHS homelessness categorical inputs MFB does not collect (MFB-1616 / MFB-1614).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Missouri Head Start and Early Head Start eligibility now reflects reported SNAP, TANF, or SSI receipt for categorical qualification.
  - Added coverage for both reported-benefit and unreported-benefit scenarios, including participant-level eligibility results.

- **Documentation**
  - Updated Missouri program specifications, acceptance criteria, verification notes, and county labels to clarify receipt-based eligibility requirements.

- **Tests**
  - Added regression coverage and recorded calculation scenarios to validate eligibility outcomes.
  - Improved test stability by using a fixed household identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
