### PR TITLE
MFB-1415/MFB-1765/MFB-1074: Add FCS, Ticket to Work, and Lawrence Transit additional resources

### DIFF
--- a/programs/management/commands/import_urgent_need_config_data/data/co_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/co_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "co"
+  },
+  "need": {
+    "external_name": "co_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "childs_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/co_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/co_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/co_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/co_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "co"
+  },
+  "need": {
+    "external_name": "co_ticket_to_work",
+    "category_type": {
+      "external_name": "job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/il_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/il_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/il_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/il_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "il"
+  },
+  "need": {
+    "external_name": "il_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "il_child_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/il_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/il_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "il"
+  },
+  "need": {
+    "external_name": "il_ticket_to_work",
+    "category_type": {
+      "external_name": "il_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/ks_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ks_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/ks_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ks_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "need": {
+    "external_name": "ks_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "ks_child_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/ks_lawrence_transit_fare_free.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ks_lawrence_transit_fare_free.json
@@ -1,0 +1,30 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "need": {
+    "external_name": "ks_lawrence_transit_fare_free",
+    "category_type": {
+      "external_name": "ks_transportation"
+    },
+    "type_short": [
+      "transportation"
+    ],
+    "translations": {
+      "name": "Lawrence Transit Fare-Free Service",
+      "description": "Lawrence Transit offers fare-free fixed-route bus service in Lawrence. Anyone can ride the regular buses without applying. T Lift offers free rides to people with disabilities who cannot use regular bus routes. Riders must apply and qualify for T Lift. On Demand is a shared-ride service for evenings and Sundays that you book through an app or online for $3 each way.",
+      "link": "https://lawrencetransit.org/",
+      "warning": "",
+      "website_description": "Find fare-free bus routes, schedules, and transit services in Lawrence.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "counties": [
+      "Douglas County"
+    ],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/ks_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ks_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "need": {
+    "external_name": "ks_ticket_to_work",
+    "category_type": {
+      "external_name": "ks_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/ma_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ma_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/ma_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ma_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "ma"
+  },
+  "need": {
+    "external_name": "ma_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "ma_childs_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/ma_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/ma_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "ma"
+  },
+  "need": {
+    "external_name": "ma_ticket_to_work",
+    "category_type": {
+      "external_name": "ma_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/mo_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/mo_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/mo_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/mo_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "need": {
+    "external_name": "mo_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "mo_child_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/mo_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/mo_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "need": {
+    "external_name": "mo_ticket_to_work",
+    "category_type": {
+      "external_name": "mo_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/nc_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/nc_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/nc_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/nc_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "nc"
+  },
+  "need": {
+    "external_name": "nc_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "nc_childs_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/nc_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/nc_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "nc"
+  },
+  "need": {
+    "external_name": "nc_ticket_to_work",
+    "category_type": {
+      "external_name": "nc_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "tx"
+  },
+  "need": {
+    "external_name": "tx_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "tx_child_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "tx"
+  },
+  "need": {
+    "external_name": "tx_ticket_to_work",
+    "category_type": {
+      "external_name": "tx_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/wa_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/wa_dolly_parton_imagination_library.json
@@ -12,7 +12,7 @@
     ],
     "translations": {
       "name": "Dolly Parton's Imagination Library",
-      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "description": "Dolly Parton's Imagination Library gives free books to children. In areas with a local program partner, any child from birth to age five can receive a free book every month.",
       "link": "https://imaginationlibrary.com/usa/",
       "warning": "",
       "website_description": "Check if your area takes part and sign up for free monthly books.",

--- a/programs/management/commands/import_urgent_need_config_data/data/wa_dolly_parton_imagination_library.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/wa_dolly_parton_imagination_library.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "wa"
+  },
+  "need": {
+    "external_name": "wa_dolly_parton_imagination_library",
+    "category_type": {
+      "external_name": "wa_child_development"
+    },
+    "type_short": [
+      "child dev"
+    ],
+    "translations": {
+      "name": "Dolly Parton's Imagination Library",
+      "description": "Dolly Parton's Imagination Library gives free books to children. Any child from birth to age five can receive a free book every month.",
+      "link": "https://imaginationlibrary.com/usa/",
+      "warning": "",
+      "website_description": "Check if your area takes part and sign up for free monthly books.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18654289606",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/wa_fcs.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/wa_fcs.json
@@ -7,12 +7,13 @@
     },
     "type_short": ["housing"],
     "functions": [],
+    "phone_number": "+18444512828",
     "counties": [],
     "required_expense_types": [],
     "translations": {
       "name": "Foundational Community Supports (FCS)",
-      "description": "FCS is a free Apple Health (Medicaid) service for people 16 and older who have complex health needs. Supportive Housing helps you find a home and keep it. Supported Employment helps you find a job and keep it. You, a provider, or someone helping you can send a referral to get started.",
-      "link": "https://www.hca.wa.gov/about-hca/programs-and-initiatives/medicaid-transformation-project-mtp/foundational-community-supports",
+      "description": "FCS is a free Apple Health (Medicaid) service for people 16 and older who have complex health needs. Supportive Housing helps you find a home and keep it. Supported Employment helps you find a job and keep it. You, a provider, or someone helping you can send a referral to Wellpoint to get started.",
+      "link": "https://www.provider.wellpoint.com/washington-provider/patient-care/foundational-community-supports",
       "warning": "",
       "website_description": "Housing and employment support for Apple Health members, plus the FCS referral form.",
       "notification_message": ""

--- a/programs/management/commands/import_urgent_need_config_data/data/wa_fcs.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/wa_fcs.json
@@ -13,9 +13,9 @@
     "translations": {
       "name": "Foundational Community Supports (FCS)",
       "description": "FCS is a free Apple Health (Medicaid) service for people 16 and older who have complex health needs. Supportive Housing helps you find a home and keep it. Supported Employment helps you find a job and keep it. You, a provider, or someone helping you can send a referral to Wellpoint to get started.",
-      "link": "https://www.provider.wellpoint.com/washington-provider/patient-care/foundational-community-supports",
+      "link": "https://www.wellpoint.com/wa/medicaid/washington-fcs",
       "warning": "",
-      "website_description": "Housing and employment support for Apple Health members, plus the FCS referral form.",
+      "website_description": "Housing and employment support for Apple Health members, and how to start a referral.",
       "notification_message": ""
     },
     "active": true,

--- a/programs/management/commands/import_urgent_need_config_data/data/wa_fcs.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/wa_fcs.json
@@ -1,0 +1,24 @@
+{
+  "white_label": { "code": "wa" },
+  "need": {
+    "external_name": "wa_fcs",
+    "category_type": {
+      "external_name": "wa_housing_rent_utilities"
+    },
+    "type_short": ["housing"],
+    "functions": [],
+    "counties": [],
+    "required_expense_types": [],
+    "translations": {
+      "name": "Foundational Community Supports (FCS)",
+      "description": "FCS is a free Apple Health (Medicaid) service for people 16 and older who have complex health needs. Supportive Housing helps you find a home and keep it. Supported Employment helps you find a job and keep it. You, a provider, or someone helping you can send a referral to get started.",
+      "link": "https://www.hca.wa.gov/about-hca/programs-and-initiatives/medicaid-transformation-project-mtp/foundational-community-supports",
+      "warning": "",
+      "website_description": "Housing and employment support for Apple Health members, plus the FCS referral form.",
+      "notification_message": ""
+    },
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/wa_ticket_to_work.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/wa_ticket_to_work.json
@@ -1,0 +1,29 @@
+{
+  "white_label": {
+    "code": "wa"
+  },
+  "need": {
+    "external_name": "wa_ticket_to_work",
+    "category_type": {
+      "external_name": "wa_job_resources"
+    },
+    "type_short": [
+      "job resources"
+    ],
+    "translations": {
+      "name": "Ticket to Work",
+      "description": "Ticket to Work is a free Social Security program for people ages 18 to 64 who get SSDI or SSI disability benefits and want to work. You can get free career counseling, job training, and help finding a job. Special rules let you keep your cash benefits and your Medicare or Medicaid coverage while you try working. Taking part is voluntary and you can stop at any time.",
+      "link": "https://choosework.ssa.gov/",
+      "warning": "",
+      "website_description": "Free career counseling, job training, and job placement for people who get SSDI or SSI.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18669687842",
+    "counties": [],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}


### PR DESCRIPTION
## What

Adds four additional resources (18 urgent need configs) — MFB-1415, MFB-1765, MFB-1074, plus Dolly Parton's Imagination Library.

Per direction on this work, **none of these resources have eligibility criteria at this time** — every config ships with empty `functions` and `required_expense_types`, regardless of what the tickets describe.

| Ticket | Resource | White labels | Tile | Scoping |
| --- | --- | --- | --- | --- |
| MFB-1415 | Foundational Community Supports (FCS) | wa | housing | statewide |
| MFB-1765 | Ticket to Work | co, il, ks, ma, mo, nc, tx, wa | job resources | statewide |
| MFB-1074 | Lawrence Transit Fare-Free Service | ks | transportation | Douglas County |
| — | Dolly Parton's Imagination Library | co, il, ks, ma, mo, nc, tx, wa | child dev | statewide |

## Decisions worth a reviewer's eye

**FCS was descoped from a program to a resource.** MFB-1415 shipped a `wa_fcs_spec.md` (custom calculator, $975/mo blended value, Apple Health + 16+ gates). That's intentionally not implemented — none of those criteria appear here. WA has no Health Care tile for additional resources, so it surfaces under `housing`; the copy still describes both service lines (Supportive Housing and Supported Employment) since they're one program.

**Ticket to Work goes to all eight white labels**, following the Dollar For rollout in #1699. `jobResources` is a base tile, so it's live everywhere. It matches `job resources` only — not `disability resources` (which exists in just il/ma/tx) — to keep behavior uniform and stay with the repo's one-`type_short`-per-need shape. The SSA Help Line ships as `phone_number` in E.164 (`+18669687842`), which `NeedCard.tsx` formats for display.

**Lawrence Transit keeps its Douglas County filter.** The service is physically Lawrence-only, so this is geographic scoping rather than an eligibility test — same treatment as `ks_ridekc` (Wyandotte/Johnson) and `ks_wichita_transit_half_fare` (Sedgwick). `"Douglas County"` matches the KS `counties_by_zipcode` naming convention.

**Imagination Library's category types have three different naming shapes.** The child development type is `childs_development` in co (unprefixed), `{wl}_child_development` in il/ks/mo/tx/wa, and `{wl}_childs_development` in ma/nc — no formula covers all eight, so each config names its type explicitly. `childDevelopment` is a base tile, so it's live everywhere. Copy is the partner-supplied text verbatim; the `website_description` nudges users to check local availability, since Imagination Library only runs where a local affiliate funds it. `child dev` follows the `tx_books_beginning_at_birth` precedent for a free-books resource.

**`category_type` carries `external_name` only.** All eighteen referenced `UrgentNeedType` rows already exist. Supplying `name` would re-run `_bulk_update_entity_translations` against a shared section header and overwrite any manual non-English edits, so the configs omit `name`/`icon` per the README gotcha — the same thing `il_employment_connection.json` and `il_worknet_dupage.json` already do.

**CO's job resources type is unprefixed.** It's stored as `job_resources`, not `co_job_resources` — CO's category types predate the white-label prefix convention. `co_ticket_to_work.json` points at `job_resources` accordingly. Confirmed on prod: `job_resources` exists and is owned by `co`, `co_job_resources` does not exist, and there are exactly 8 job-resources types (one per white label) — prod matches local. This matters because `_get_or_create_category_type` resolves `external_name` globally rather than per white label, so a mismatch would either create a second identically-named CO header or reassign another white label's type to CO.

## Testing

- All 18 configs pass `import_urgent_need_config --dry-run`.
- All 18 imported cleanly into the local DB (IDs 1009–1026). Verified category type, `type_short`, counties, phone number, and `active` on each; the `UrgentNeedType` count was unchanged at 101, so no new category types were created and no existing section header was relabeled.
- Spot-checked auto-translation (es/vi) on `ks_lawrence_transit_fare_free`, `co_ticket_to_work`, and `co_dolly_parton_imagination_library`.
- Verified against prod that the 10 `UrgentNeedType` rows referenced by the first three resources exist with the expected white label. The 8 child development types are confirmed on local only — see the deploy note.
- `pytest programs/management/commands/tests/test_import_urgent_need_config.py test_import_all_urgent_need_configs.py` — 15 passed.

## Deploy

These are config files; the resources don't exist until imported per environment:

```bash
python manage.py import_all_urgent_need_configs --list   # confirm the 18 are pending
python manage.py import_all_urgent_need_configs
```

Before importing, confirm the child development types on the target environment match local — `_get_or_create_category_type` resolves `external_name` globally, so a name that's absent creates a duplicate header and a name owned by another white label gets reassigned:

```bash
python manage.py shell -c "
from programs.models import UrgentNeedType
qs = UrgentNeedType.objects.filter(external_name__icontains='develop')
for t in qs.order_by('white_label__code'):
    print(repr(t.external_name), '|', t.white_label.code)
print('total:', qs.count())
"
```

Expected: 8 rows — `childs_development` (co), `il_child_development`, `ks_child_development`, `ma_childs_development`, `mo_child_development`, `nc_childs_development`, `tx_child_development`, `wa_child_development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added urgent-need resources for Dolly Parton’s Imagination Library and Ticket to Work across Colorado, Illinois, Kansas, Massachusetts, Missouri, North Carolina, Texas, and Washington.
  * Added Kansas Lawrence Transit Fare-Free Service information for Douglas County.
  * Added Washington FCS housing assistance information.
  * Resources include program descriptions, enrollment or informational links, contact numbers, availability details, and benefit-display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->