### PR TITLE
MFB-1788: give Benji the documents and warning messages the results page shows

### DIFF
--- a/integrations/clients/policyengine/tests/test_pe_buckets.py
+++ b/integrations/clients/policyengine/tests/test_pe_buckets.py
@@ -9,6 +9,7 @@ results, so a disagreement costs a round trip instead of the response.
 """
 
 import datetime
+import re
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
@@ -196,11 +197,20 @@ class TestTheDisagreementIsReported(PeBucketTestBase):
     def test_it_does_not_send_the_household_values_to_sentry(self):
         """A conflicting slot holds screener data about a real household. What disagreed is
         actionable; what the household reported is not, and Sentry has no scrubbing
-        configured."""
+        configured.
+
+        Matched on word boundaries, not as bare substrings. The message names the slot as
+        `<unit>/<sub_unit>`, and `sub_unit` is a HouseholdMember primary key — so a plain
+        `assertNotIn("41", ...)` also fires on `people/417`, which is an id and not a
+        household value. That made the test a function of whatever the id sequence
+        happened to reach: it passed locally and failed in CI on the same commit, for any
+        branch whose fixtures shifted the sequence. `\\b41\\b` still catches a real leak,
+        including `41` and `41.0` rendered into the values position.
+        """
         message = self.warning_message()
 
-        self.assertNotIn("40", message)
-        self.assertNotIn("41", message)
+        self.assertIsNone(re.search(r"\b40\b", message), message)
+        self.assertIsNone(re.search(r"\b41\b", message), message)
 
 
 class TestPastTheRequestLimit(PeBucketTestBase):

--- a/programs/warnings/base.py
+++ b/programs/warnings/base.py
@@ -7,16 +7,22 @@ from screener.models import Screen
 class WarningCalculator:
     dependencies = tuple()
 
-    # Whether `eligible()` reads `self.eligibility.eligible_members`.
+    # Set True if `eligible()` reads ANYTHING off `self.eligibility` other than
+    # `.eligible` — `eligible_members`, `household_value`, `pass_messages`,
+    # `fail_messages`.
     #
-    # The eligibility run (screener.views.eligibility_results) always has a fully
-    # populated `Eligibility`, so this is False for it in every case. It matters to
-    # callers that evaluate warnings OUTSIDE that run — `screener.assistant`
-    # rebuilds a minimal `Eligibility` from `ProgramEligibilitySnapshot`, which
-    # stores no member breakdown, so `eligible_members` is empty there. A calculator
-    # that reads it would silently return False rather than erroring; this flag lets
-    # such callers skip it loudly instead. See `_warnings_by_name`.
-    needs_member_eligibility = False
+    # The eligibility run (screener.views.eligibility_results) always passes a fully
+    # populated `Eligibility`, so this never restricts it. It matters to callers that
+    # evaluate warnings OUTSIDE that run: `screener.assistant` rebuilds a minimal
+    # `Eligibility` from a `ProgramEligibilitySnapshot`, which stores only the
+    # `eligible` flag, so every other attribute sits at its constructor default
+    # (empty list, 0). A calculator reading one would not error — it would quietly
+    # compute against zeroes and return a plausible wrong answer. This flag lets such
+    # callers skip it loudly instead (see `_warning_messages` in screener.assistant).
+    #
+    # Scoped to the whole object rather than to `eligible_members` alone because the
+    # hazard is the silent-default behaviour, which is identical for every field on it.
+    needs_full_eligibility = False
 
     def __init__(
         self, screen: Screen, warning: WarningMessage, eligibility: Eligibility, missing_dependencies: Dependencies

--- a/programs/warnings/base.py
+++ b/programs/warnings/base.py
@@ -7,6 +7,17 @@ from screener.models import Screen
 class WarningCalculator:
     dependencies = tuple()
 
+    # Whether `eligible()` reads `self.eligibility.eligible_members`.
+    #
+    # The eligibility run (screener.views.eligibility_results) always has a fully
+    # populated `Eligibility`, so this is False for it in every case. It matters to
+    # callers that evaluate warnings OUTSIDE that run — `screener.assistant`
+    # rebuilds a minimal `Eligibility` from `ProgramEligibilitySnapshot`, which
+    # stores no member breakdown, so `eligible_members` is empty there. A calculator
+    # that reads it would silently return False rather than erroring; this flag lets
+    # such callers skip it loudly instead. See `_warnings_by_name`.
+    needs_member_eligibility = False
+
     def __init__(
         self, screen: Screen, warning: WarningMessage, eligibility: Eligibility, missing_dependencies: Dependencies
     ):

--- a/programs/warnings/co/universal_preschool.py
+++ b/programs/warnings/co/universal_preschool.py
@@ -5,6 +5,9 @@ class UniversalPreschool(WarningCalculator):
     dependencies = [
         "age",
     ]
+    # Reads eligibility.eligible_members below, so it can only be evaluated during a
+    # real eligibility run — not from a snapshot. See WarningCalculator.
+    needs_member_eligibility = True
     age = 3
 
     def eligible(self) -> bool:

--- a/programs/warnings/co/universal_preschool.py
+++ b/programs/warnings/co/universal_preschool.py
@@ -7,7 +7,7 @@ class UniversalPreschool(WarningCalculator):
     ]
     # Reads eligibility.eligible_members below, so it can only be evaluated during a
     # real eligibility run — not from a snapshot. See WarningCalculator.
-    needs_member_eligibility = True
+    needs_full_eligibility = True
     age = 3
 
     def eligible(self) -> bool:

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -119,6 +119,13 @@ _LOOKS_LIKE_INSURANCE = re.compile(r"medicaid|chip|medicare|mass_health|apple_he
 # The rest are what screen.missing_fields() walks to build the Dependencies set the
 # warning calculators gate on (see _warning_messages). Each is a reverse relation that
 # `hasattr`/`.all()` would otherwise hit once per member or per call.
+#
+# This list is NOT the whole story, and adding to it is not always the fix: the warning
+# calculators themselves read further than missing_fields() does. `_tax_unit` reaches
+# Screen.has_members_outside_of_tax_unit -> is_dependent -> get_reference_date, whose
+# `validations.order_by(...)` builds a fresh queryset and so cannot be prefetched from
+# here at all — that one is solved by memoizing on the model. If a new calculator
+# regresses the query count, check what it reads before reaching for this tuple.
 CONTEXT_PREFETCH = (
     "current_benefits__program",
     "household_members__insurance",

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -21,14 +21,17 @@ from typing import Optional
 
 import requests
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions, status, views
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import capture_message
 
-from programs.models import Program
+from programs.framework.base import Eligibility
+from programs.models import Document, Program, WarningMessage
+from programs.util import Dependencies
+from programs.warnings import warning_calculators
 from parler.models import TranslationDoesNotExist
 
 from translations.models import BLANK_TRANSLATION_PLACEHOLDER, Translation
@@ -61,6 +64,19 @@ MAX_PROGRAM_VALUE = 1_000_000
 # highest-trust position in the request.
 MAX_PROMPT_FIELD_LEN = 160
 
+# The same cap for fields that are sentences rather than labels: document lines and
+# warning messages. 160 is sized for a program name and clips real copy mid-sentence —
+# tx_lifeline's warning ("...you should enroll in SNAP before applying for Lifeline")
+# would lose the instruction that makes it worth sending. Still bounded, for the same
+# prompt-injection reason MAX_PROMPT_FIELD_LEN exists.
+MAX_PROMPT_TEXT_LEN = 400
+
+# Per-program ceilings on those lists. Nothing in the seed config approaches either
+# (the largest documents block is 8); they exist so a misconfigured program can't
+# crowd out the rest of the prompt. Same role as MAX_VISIBLE_PROGRAMS.
+MAX_DOCUMENTS_PER_PROGRAM = 12
+MAX_WARNINGS_PER_PROGRAM = 6
+
 # Apply links are dropped rather than truncated past this, so it's a reject threshold
 # and not a clip point. Comfortably above the longest link in the seed config (~200).
 MAX_URL_LEN = 500
@@ -69,12 +85,23 @@ MAX_URL_LEN = 500
 # gap loudly (see _insurance_program_names).
 _LOOKS_LIKE_INSURANCE = re.compile(r"medicaid|chip|medicare|mass_health|apple_health")
 
-# Relations _build_context reads per program. Both are per-program lookups, so without
-# these the query count grows with the number of eligible programs:
-#   current_benefits__program -> screen.has_benefit()
+# Relations _build_context reads per program or per member, so without these the query
+# count grows with the number of eligible programs or household members:
+#   current_benefits__program -> screen.has_benefit(), and screen.has_base_benefit()
+#       from the co_snap_student warning calculator
 #   household_members__insurance -> screen.has_insurance_types() (and the reverse
 #       OneToOne `member.insurance`, which hasattr() would otherwise query per member)
-CONTEXT_PREFETCH = ("current_benefits__program", "household_members__insurance")
+# The rest are what screen.missing_fields() walks to build the Dependencies set the
+# warning calculators gate on (see _warning_messages). Each is a reverse relation that
+# `hasattr`/`.all()` would otherwise hit once per member or per call.
+CONTEXT_PREFETCH = (
+    "current_benefits__program",
+    "household_members__insurance",
+    "household_members__income_streams",
+    "household_members__energy_calculator",
+    "expenses",
+    "energy_calculator",
+)
 
 
 def _ai_headers() -> dict:
@@ -104,7 +131,7 @@ def _translated(
     `max_len=None` disables truncation. Names are capped because they're interpolated
     into ai-service's *system* prompt and `Translation` rows are admin-editable, so a
     name carrying newlines plus instruction-shaped text could forge a prompt block. URLs
-    must NOT be capped — see `_apply_urls_by_name`.
+    must NOT be capped — see `_apply_url`.
     """
     if translation is None:
         return ""
@@ -148,8 +175,59 @@ def _latest_snapshot(screen: Screen):
         return None
 
 
-def _apply_urls_by_name(screen: Screen, name_abbreviations: list[str], language_code: str) -> dict[str, str]:
-    """Map name_abbreviated -> apply link for the given programs (one query).
+def _documents_prefetch() -> Prefetch:
+    """Prefetch each program's documents with their text translation resolved.
+
+    `select_related("text")` on the inner queryset folds the Translation parent into
+    the document fetch, the way `select_related("apply_button_link")` does for the FK
+    that hangs directly off Program — a plain "documents__text__translations" string
+    costs an extra query for that hop.
+    """
+    return Prefetch(
+        "documents",
+        queryset=Document.objects.select_related("text").prefetch_related("text__translations"),
+    )
+
+
+def _context_programs(screen: Screen, name_abbreviations: list[str]) -> dict[str, Program]:
+    """Map name_abbreviated -> Program for the rows _build_context annotates (one query).
+
+    Apply links, documents and warnings all hang off the same `Program` rows for the same
+    name set, so they share one fetch rather than issuing three identical
+    `name_abbreviated__in` queries.
+
+    Only the translations we actually render are prefetched. `Document` and
+    `WarningMessage` each also carry `link_url` and `link_text`, and the prompt's LINKS
+    rule is absolute: apply links are the only URLs the assistant may share. Fetching
+    just `text`/`message` means a document or warning URL is never loaded into the
+    process at all, so it cannot reach the prompt through a later edit here — structural
+    rather than a promise. (`Document.objects.translated_fields` would pull all three.)
+    """
+    if not name_abbreviations:
+        return {}
+
+    programs = (
+        Program.objects.filter(
+            white_label=screen.white_label,
+            name_abbreviated__in=name_abbreviations,
+        )
+        .select_related("apply_button_link")
+        .prefetch_related(
+            "apply_button_link__translations",
+            _documents_prefetch(),
+            Prefetch(
+                "warning_messages",
+                queryset=WarningMessage.objects.select_related("message").prefetch_related("message__translations"),
+            ),
+            "warning_messages__counties",
+            "warning_messages__legal_statuses",
+        )
+    )
+    return {program.name_abbreviated: program for program in programs}
+
+
+def _apply_url(program: Program, language_code: str) -> str:
+    """This program's apply link, or "" if there isn't a usable one.
 
     apply_button_link is a translated field, resolved through `_translated` so
     blank/placeholder links come back empty — the assistant must never receive an empty
@@ -162,32 +240,117 @@ def _apply_urls_by_name(screen: Screen, name_abbreviations: list[str], language_
     the current seed config already exceed the name cap (tx_wic at 198 chars, il_ibccp at
     174), so truncating here would have shipped two dead links.
     """
-    if not name_abbreviations:
-        return {}
-
-    programs = (
-        Program.objects.filter(
-            white_label=screen.white_label,
-            name_abbreviated__in=name_abbreviations,
+    link = _translated(program.apply_button_link, language_code, max_len=None)
+    if not link:
+        return ""
+    if len(link) > MAX_URL_LEN:
+        capture_message(
+            f"Dropping {program.name_abbreviated} apply link: {len(link)} chars exceeds MAX_URL_LEN={MAX_URL_LEN}",
+            level="warning",
         )
-        .select_related("apply_button_link")
-        .prefetch_related("apply_button_link__translations")
-    )
+        return ""
+    return link
 
-    urls: dict[str, str] = {}
-    for program in programs:
-        link = _translated(program.apply_button_link, language_code, max_len=None)
-        if not link:
-            continue
-        if len(link) > MAX_URL_LEN:
+
+def _document_texts(program: Program, language_code: str) -> list[str]:
+    """The documents the results page lists for this program.
+
+    Static per program — no household gating, unlike warnings — so these are read
+    straight off `Program` with no reconstruction.
+
+    Ordering is `documents.all()`'s default, which is what the results page renders, so
+    the assistant's checklist matches the "more info" panel item for item.
+    """
+    texts = []
+    for document in program.documents.all():
+        # Blank and [PLACEHOLDER] rows come back "" — an untranslated document is
+        # dropped rather than rendered as an empty checklist line.
+        text = _translated(document.text, language_code, max_len=MAX_PROMPT_TEXT_LEN)
+        if text:
+            texts.append(text)
+    return texts[:MAX_DOCUMENTS_PER_PROGRAM]
+
+
+def _warning_messages(
+    program: Program,
+    screen: Screen,
+    eligible: bool,
+    missing_dependencies: Dependencies,
+    language_code: str,
+) -> list[str]:
+    """The warning messages this household would see on this program's results panel.
+
+    Warnings are not a static field: each is evaluated per household by a calculator in
+    `programs/warnings/`, gated on county, on missing screen fields, and on custom
+    `eligible()` logic. `screener.views.eligibility_results` runs that evaluation inline
+    and does NOT persist the result, so there is nothing on the snapshot to read.
+
+    Rather than add a snapshot column, we re-run the gates here. That's cheap because
+    six of the seven registered calculators need only `screen` — county, member data,
+    `energy_calculator`, `num_adults`. `screen.missing_fields()` is pure screen data (no
+    PolicyEngine), and `Eligibility()` takes no constructor args, so the only input we
+    cannot reproduce is `eligible_members`, which no snapshot stores. Calculators that
+    read it declare `needs_member_eligibility` and are skipped loudly below.
+
+    Because the gates read the screen as it is *now* while the program list comes from
+    the last snapshot, a screen edited since that run could yield warnings the results
+    page didn't show. In practice the results page recomputes eligibility on load, so
+    the snapshot is fresh — the same premise `_latest_snapshot` rests on — and every
+    gate input is screen-side, so an unchanged screen gives the run's own answer.
+
+    Two deliberate divergences from the results-page evaluation:
+
+    1. Warnings carrying `legal_statuses` are dropped. The results page filters those
+       client-side against the citizenship dropdown (Results/ProgramPage.tsx), which
+       defaults to 'citizen' and is never persisted to the Screen — so we cannot
+       reproduce the selection, and we won't take it from the payload for the same
+       reason `_visible_programs` is limited to names. All six such warnings in the seed
+       config are immigration-status-scoped and none lists 'citizen', so none of them
+       render on a default results page anyway. Under-reporting here is the safe
+       direction: it never surfaces immigration-status content to a household that
+       didn't ask for it.
+    2. An unknown calculator name is skipped, where the eligibility run raises. A config
+       typo should not take the assistant down with it.
+    """
+    warnings = program.warning_messages.all()
+    if not warnings:
+        return []
+
+    # The minimum the gates read. Nothing consults pass_messages/fail_messages, so the
+    # snapshot's failed_tests/passed_tests (stored as JSON *strings*, not lists) are
+    # left alone rather than parsed back.
+    eligibility = Eligibility()
+    eligibility.eligible = eligible
+
+    messages = []
+    for warning in warnings:
+        calculator = warning_calculators.get(warning.calculator)
+        if calculator is None:
             capture_message(
-                f"Dropping {program.name_abbreviated} apply link: {len(link)} chars exceeds "
-                f"MAX_URL_LEN={MAX_URL_LEN}",
+                f"Skipping warning {warning.external_name or warning.id} on "
+                f"{program.name_abbreviated}: '{warning.calculator}' is not a valid calculator name",
                 level="warning",
             )
             continue
-        urls[program.name_abbreviated] = link
-    return urls
+        if calculator.needs_member_eligibility:
+            capture_message(
+                f"Skipping warning {warning.external_name or warning.id} on "
+                f"{program.name_abbreviated} for the assistant: '{warning.calculator}' needs "
+                "member-level eligibility, which the snapshot does not store",
+                level="info",
+            )
+            continue
+        if warning.legal_statuses.all():
+            continue
+
+        if not calculator(screen, warning, eligibility, missing_dependencies).calc():
+            continue
+
+        message = _translated(warning.message, language_code, max_len=MAX_PROMPT_TEXT_LEN)
+        if message:
+            messages.append(message)
+
+    return messages[:MAX_WARNINGS_PER_PROGRAM]
 
 
 def _insurance_program_names(screen: Screen) -> set[str]:
@@ -252,6 +415,11 @@ def _current_programs(screen: Screen, language_code: str) -> list[dict]:
     Deliberately carries no estimated_value (the screening estimates what they
     *would* get, which is misleading for a benefit already in payment) and no
     apply_url (the assistant must never send them to apply again).
+
+    Documents ARE included: recertification needs them too ("what do I need to renew
+    my SNAP"), and a document list is neither of the two things this shape is thin to
+    avoid. Warnings are not — they're application caveats evaluated for programs the
+    household is being told to apply for, and this list is the opposite of that.
     """
     # One joined query through the CurrentBenefit table (unioned with the
     # insurance-derived names), plus one prefetch for the translation rows. `name` is
@@ -260,7 +428,7 @@ def _current_programs(screen: Screen, language_code: str) -> list[dict]:
     # row. `currentbenefit` is the default reverse accessor; CurrentBenefit.program
     # declares no related_name.
     #
-    # White-label scoped like its sibling _apply_urls_by_name: the write path in
+    # White-label scoped like its sibling _context_programs: the write path in
     # serializers._write_current_benefits is scoped too, so this is belt-and-braces,
     # but a foreign program leaking into a list the prompt calls a closed universe
     # is worth one extra WHERE clause. Deactivated programs are intentionally NOT
@@ -273,21 +441,25 @@ def _current_programs(screen: Screen, language_code: str) -> list[dict]:
         Program.objects.filter(criteria, white_label=screen.white_label)
         # distinct() is required now that the Q() union can match a program by both
         # arms; the CurrentBenefit join alone couldn't duplicate (unique_together).
-        .distinct()
-        .select_related("name")
-        .prefetch_related("name__translations")
+        .distinct().select_related("name")
+        # Documents ride this query rather than a second one — same rows, and
+        # `_document_texts` needs nothing else. Text only, no link translations, for
+        # the reason in `_context_programs`.
+        .prefetch_related("name__translations", _documents_prefetch())
     )
 
     current = []
     for program in programs:
-        current.append(
-            {
-                "external_name": program.name_abbreviated,
-                # Fall back to the abbreviation so the assistant can still name the
-                # program when the translation is missing or blank.
-                "name": _translated(program.name, language_code) or program.name_abbreviated,
-            }
-        )
+        entry = {
+            "external_name": program.name_abbreviated,
+            # Fall back to the abbreviation so the assistant can still name the
+            # program when the translation is missing or blank.
+            "name": _translated(program.name, language_code) or program.name_abbreviated,
+        }
+        documents = _document_texts(program, language_code)
+        if documents:
+            entry["documents"] = documents
+        current.append(entry)
 
     # casefold, because names that fell back to `name_abbreviated` are lowercase and
     # would otherwise all sort after every translated name.
@@ -413,7 +585,10 @@ def _build_context(screen: Screen, visible_programs: Optional[list[dict]] = None
 
         # Sort by what the user sees, so "your biggest one" agrees with their screen.
         rows.sort(key=lambda p: values.get(p.name_abbreviated) or 0, reverse=True)
-        apply_urls = _apply_urls_by_name(screen, [p.name_abbreviated for p in rows], language_code)
+        programs_by_name = _context_programs(screen, [p.name_abbreviated for p in rows])
+        # Only built if some program actually carries a warning: it walks every member,
+        # expense and income stream, and most white labels configure no warnings at all.
+        missing_dependencies: Optional[Dependencies] = None
         for p in rows:
             # The snapshot's `name` was captured as `program.name.text` under whatever
             # language was active when eligibility ran (screener.views, unpinned), and
@@ -433,10 +608,29 @@ def _build_context(screen: Screen, visible_programs: Optional[list[dict]] = None
                 # prompt asserts.
                 "estimated_value": values.get(p.name_abbreviated),
                 "estimated_application_time": p.estimated_application_time,
+                # Already on the snapshot and already sent to the results page; answers
+                # "how long until I actually get this". Carries the same wart as
+                # estimated_application_time — captured under whatever language was
+                # active when eligibility ran.
+                "estimated_delivery_time": p.estimated_delivery_time,
             }
-            apply_url = apply_urls.get(p.name_abbreviated)
-            if apply_url:
-                program["apply_url"] = apply_url
+            row_program = programs_by_name.get(p.name_abbreviated)
+            if row_program is not None:
+                apply_url = _apply_url(row_program, language_code)
+                if apply_url:
+                    program["apply_url"] = apply_url
+                # Omitted rather than sent empty: ai-service defaults both to [], and
+                # the prompt distinguishes "we have no list for this program" from
+                # "this program needs nothing".
+                documents = _document_texts(row_program, language_code)
+                if documents:
+                    program["documents"] = documents
+                if row_program.warning_messages.all():
+                    if missing_dependencies is None:
+                        missing_dependencies = screen.missing_fields()
+                    warnings = _warning_messages(row_program, screen, p.eligible, missing_dependencies, language_code)
+                    if warnings:
+                        program["warnings"] = warnings
             eligible_programs.append(program)
 
     # Disjointness is enforced HERE, not merely asserted. The insurance gate above is

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -45,6 +45,9 @@ from .throttles import (
 
 logger = logging.getLogger(__name__)
 
+# Keys already reported by `_report_once`, for the life of the process.
+_REPORTED: set[str] = set()
+
 # Where mfb-ai-service lives, and the shared service token (must match the
 # service's SERVICE_AUTH_TOKEN). Both come from the environment.
 AI_SERVICE_URL = os.getenv("AI_SERVICE_URL", "http://localhost:8080")
@@ -69,7 +72,13 @@ MAX_PROMPT_FIELD_LEN = 160
 # tx_lifeline's warning ("...you should enroll in SNAP before applying for Lifeline")
 # would lose the instruction that makes it worth sending. Still bounded, for the same
 # prompt-injection reason MAX_PROMPT_FIELD_LEN exists.
-MAX_PROMPT_TEXT_LEN = 400
+#
+# 800 rather than 400 because 400 was already clipping production: the longest live
+# warning we actually forward is 562 chars (cccap_jeffco, CO), and the seed configs
+# hold warnings up to 706. Documents top out at 338. A clipped warning is the failure
+# `_apply_url` refuses for links — a half-sentence instruction delivered with full
+# authority — so anything that does hit this is reported rather than silently cut.
+MAX_PROMPT_TEXT_LEN = 800
 
 # Per-program ceilings on those lists, so a misconfigured program can't crowd out the
 # rest of the prompt. Same role as MAX_VISIBLE_PROGRAMS.
@@ -81,6 +90,15 @@ MAX_PROMPT_TEXT_LEN = 400
 # results page that this feature exists to provide, and it would do it silently, on
 # whichever program happens to have the most documents. Headroom is deliberate — the
 # document count grows whenever a program's config is revised.
+#
+# There is deliberately no cap on programs x documents. The absolute ceiling, measured
+# against production, is a household eligible for every active program in the largest
+# white label: 43 programs, 207 document lines, ~13,000 characters (~3,300 tokens). A
+# total budget that dropped lines past a threshold would buy a smaller worst case at the
+# price of silently handing someone a short checklist — the same failure this file just
+# fixed by raising the per-program cap, and the one thing the results-page parity in
+# MFB-1788 cannot tolerate. If the budget ever needs enforcing, the honest lever is
+# fewer programs in the prompt (inject on demand), not fewer documents per program.
 MAX_DOCUMENTS_PER_PROGRAM = 24
 MAX_WARNINGS_PER_PROGRAM = 10
 
@@ -116,6 +134,50 @@ def _ai_headers() -> dict:
     if AI_SERVICE_TOKEN:
         headers["Authorization"] = f"Bearer {AI_SERVICE_TOKEN}"
     return headers
+
+
+def _report_once(key: str, message: str, *, level: str = "warning") -> None:
+    """Report a config-level condition once per process rather than once per request.
+
+    These conditions are properties of the configuration, not of the request: an
+    unregistered calculator, a calculator the snapshot cannot satisfy, a warning too
+    long for the prompt. They are unchanging until someone edits the admin, but they are
+    evaluated inside a per-program, per-warning loop on every assistant start — so
+    reporting them per request turns one static fact into the highest-volume event this
+    module emits, and buries the ones that are actionable.
+
+    Deduping in-process (not globally) is deliberate: a fresh dyno re-reports, so the
+    signal survives a deploy and cannot be permanently silenced by one early request.
+    """
+    if key in _REPORTED:
+        return
+    _REPORTED.add(key)
+    if level == "info":
+        logger.info(message)
+    else:
+        capture_message(message, level=level)
+
+
+def _clipped(text: str, what: str) -> str:
+    """Bound a document line or warning message, reporting rather than silently cutting.
+
+    Truncation here is not cosmetic: these are instructions ("enroll in SNAP before
+    applying for Lifeline"), and half of one is the same class of failure `_apply_url`
+    refuses for links — authoritative-looking and wrong. The text is still clipped
+    rather than dropped, because most of a checklist item is worth more than none of it,
+    but the condition is a config problem someone should fix, so it is reported.
+
+    Resolves at full length (`max_len=None`) so the check sees the real length; going
+    through `_translated`'s own cap would make over-long text indistinguishable from
+    text that happens to end at the limit.
+    """
+    if len(text) <= MAX_PROMPT_TEXT_LEN:
+        return text
+    _report_once(
+        f"clipped:{what}",
+        f"Clipping {what} for the assistant: {len(text)} chars exceeds " f"MAX_PROMPT_TEXT_LEN={MAX_PROMPT_TEXT_LEN}",
+    )
+    return text[:MAX_PROMPT_TEXT_LEN]
 
 
 def _translated(
@@ -192,7 +254,7 @@ def _documents_prefetch() -> Prefetch:
     """
     return Prefetch(
         "documents",
-        queryset=Document.objects.select_related("text").prefetch_related("text__translations"),
+        queryset=(Document.objects.select_related("text").prefetch_related("text__translations").order_by("id")),
     )
 
 
@@ -224,7 +286,11 @@ def _context_programs(screen: Screen, name_abbreviations: list[str]) -> dict[str
             _documents_prefetch(),
             Prefetch(
                 "warning_messages",
-                queryset=WarningMessage.objects.select_related("message").prefetch_related("message__translations"),
+                queryset=(
+                    WarningMessage.objects.select_related("message")
+                    .prefetch_related("message__translations")
+                    .order_by("id")
+                ),
             ),
             "warning_messages__counties",
             "warning_messages__legal_statuses",
@@ -265,14 +331,21 @@ def _document_texts(program: Program, language_code: str) -> list[str]:
     Static per program — no household gating, unlike warnings — so these are read
     straight off `Program` with no reconstruction.
 
-    Ordering is `documents.all()`'s default, which is what the results page renders, so
-    the assistant's checklist matches the "more info" panel item for item.
+    Ordered explicitly by id, matching the `order_by` added to the results page's own
+    prefetch in `screener.views`. Neither `Document` nor the auto-created M2M declares
+    an ordering, and Postgres guarantees no row order between two separate queries
+    against the same join table — so "the default order" was not a shared order at all,
+    and the checklist could read back in a different sequence from the "more info"
+    panel beside it. Both sides now sort the same way by construction.
     """
     texts = []
     for document in program.documents.all():
         # Blank and [PLACEHOLDER] rows come back "" — an untranslated document is
         # dropped rather than rendered as an empty checklist line.
-        text = _translated(document.text, language_code, max_len=MAX_PROMPT_TEXT_LEN)
+        text = _clipped(
+            _translated(document.text, language_code, max_len=None),
+            f"document {document.external_name or document.id} on {program.name_abbreviated}",
+        )
         if text:
             texts.append(text)
     return texts[:MAX_DOCUMENTS_PER_PROGRAM]
@@ -333,14 +406,17 @@ def _warning_messages(
     for warning in warnings:
         calculator = warning_calculators.get(warning.calculator)
         if calculator is None:
-            capture_message(
+            _report_once(
+                f"unknown-calculator:{warning.calculator}",
                 f"Skipping warning {warning.external_name or warning.id} on "
                 f"{program.name_abbreviated}: '{warning.calculator}' is not a valid calculator name",
-                level="warning",
             )
             continue
         if calculator.needs_full_eligibility:
-            capture_message(
+            # A documented, accepted limitation rather than an incident, so it goes to
+            # the log and not to Sentry — see `_report_once`.
+            _report_once(
+                f"needs-full-eligibility:{warning.calculator}",
                 f"Skipping warning {warning.external_name or warning.id} on "
                 f"{program.name_abbreviated} for the assistant: '{warning.calculator}' needs "
                 "member-level eligibility, which the snapshot does not store",
@@ -353,7 +429,10 @@ def _warning_messages(
         if not calculator(screen, warning, eligibility, missing_dependencies).calc():
             continue
 
-        message = _translated(warning.message, language_code, max_len=MAX_PROMPT_TEXT_LEN)
+        message = _clipped(
+            _translated(warning.message, language_code, max_len=None),
+            f"warning {warning.external_name or warning.id} on {program.name_abbreviated}",
+        )
         if message:
             messages.append(message)
 

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -71,11 +71,18 @@ MAX_PROMPT_FIELD_LEN = 160
 # prompt-injection reason MAX_PROMPT_FIELD_LEN exists.
 MAX_PROMPT_TEXT_LEN = 400
 
-# Per-program ceilings on those lists. Nothing in the seed config approaches either
-# (the largest documents block is 8); they exist so a misconfigured program can't
-# crowd out the rest of the prompt. Same role as MAX_VISIBLE_PROGRAMS.
-MAX_DOCUMENTS_PER_PROGRAM = 12
-MAX_WARNINGS_PER_PROGRAM = 6
+# Per-program ceilings on those lists, so a misconfigured program can't crowd out the
+# rest of the prompt. Same role as MAX_VISIBLE_PROGRAMS.
+#
+# Sized against production, NOT the seed configs — most of this data is created through
+# the Django admin and never appears in a *_initial_config.json. As of 2026-09-10 the
+# real maxima are 16 documents on one program (mo_tanf, MO) and 5 warnings on one.
+# These must stay above those: truncating a checklist would break the parity with the
+# results page that this feature exists to provide, and it would do it silently, on
+# whichever program happens to have the most documents. Headroom is deliberate — the
+# document count grows whenever a program's config is revised.
+MAX_DOCUMENTS_PER_PROGRAM = 24
+MAX_WARNINGS_PER_PROGRAM = 10
 
 # Apply links are dropped rather than truncated past this, so it's a reject threshold
 # and not a clip point. Comfortably above the longest link in the seed config (~200).
@@ -290,7 +297,7 @@ def _warning_messages(
     `energy_calculator`, `num_adults`. `screen.missing_fields()` is pure screen data (no
     PolicyEngine), and `Eligibility()` takes no constructor args, so the only input we
     cannot reproduce is `eligible_members`, which no snapshot stores. Calculators that
-    read it declare `needs_member_eligibility` and are skipped loudly below.
+    read it declare `needs_full_eligibility` and are skipped loudly below.
 
     Because the gates read the screen as it is *now* while the program list comes from
     the last snapshot, a screen edited since that run could yield warnings the results
@@ -332,7 +339,7 @@ def _warning_messages(
                 level="warning",
             )
             continue
-        if calculator.needs_member_eligibility:
+        if calculator.needs_full_eligibility:
             capture_message(
                 f"Skipping warning {warning.external_name or warning.id} on "
                 f"{program.name_abbreviated} for the assistant: '{warning.calculator}' needs "

--- a/screener/models.py
+++ b/screener/models.py
@@ -140,11 +140,26 @@ class Screen(models.Model):
         Get the reference date for age calculations.
         For frozen screens (with validations), use the earliest validation's created_date
         to keep ages consistent over time. For non-frozen screens, use current date.
+
+        Memoized per instance. `order_by()` builds a fresh queryset, so this read can
+        never be served by `prefetch_related` — and callers reach it once per household
+        member, from inside per-program calculators (`is_dependent`, and the SSDI/BSP
+        family), so uncached it is an N+1 on members x programs. Nothing invalidates the
+        cache: an instance lives for one request, and a reference date that shifts
+        mid-request is a bug in its own right, since the whole point is to keep ages
+        consistent (two calls either side of midnight would otherwise disagree on an
+        unfrozen screen).
         """
+        cached = getattr(self, "_reference_date", None)
+        if cached is not None:
+            return cached
+
         earliest_validation = self.validations.order_by("created_date").first()
         if earliest_validation and earliest_validation.created_date:
-            return earliest_validation.created_date.date()
-        return timezone.now().date()
+            self._reference_date = earliest_validation.created_date.date()
+        else:
+            self._reference_date = timezone.now().date()
+        return self._reference_date
 
     def calc_gross_income(self, frequency, types, exclude=[]):
         household_members = self.household_members.all()

--- a/screener/tests/helpers.py
+++ b/screener/tests/helpers.py
@@ -5,7 +5,9 @@ join-table lookup will need, then write CurrentBenefit rows directly (or via the
 `current_benefits: [...]` serializer payload) for the screen under test.
 """
 
-from programs.models import Program
+from django.conf import settings
+
+from programs.models import County, Document, Program, WarningMessage
 from screener.models import WhiteLabel
 
 
@@ -21,3 +23,60 @@ def seed_program(white_label: WhiteLabel, *name_abbreviateds: str, base_program:
         if base_program is not None:
             program.base_program = base_program
             program.save()
+
+
+def _set_default_text(translation, text: str) -> None:
+    """Write a parler Translation's text in the DEFAULT language, explicitly.
+
+    `Translation.objects.add_translation` creates a row per supported language and
+    leaves parler's active language on whichever it wrote last (currently 'ht'), so
+    assigning `.text` straight after it silently lands in that language instead of
+    English — and the assistant context, which resolves through the screen language
+    then falls back to `settings.LANGUAGE_CODE`, reads back "".
+    """
+    translation.set_current_language(settings.LANGUAGE_CODE)
+    translation.text = text
+    translation.save()
+
+
+def seed_document(program: Program, external_name: str, text: str) -> Document:
+    """Attach a Document to `program` with its `text` translation filled in.
+
+    `Document.objects.new_document` creates the three Translation rows with text="",
+    which the assistant context treats as "no value" — so callers that want the
+    document to actually appear have to set the text. This does both.
+
+    `link_url` and `link_text` are deliberately left blank: the assistant must never
+    receive a document URL, and a test asserting that is stronger when the row it's
+    reading from has one. Pass them explicitly on the returned object when a test
+    needs them populated.
+    """
+    document = Document.objects.new_document(program.white_label.code, external_name)
+    _set_default_text(document.text, text)
+    program.documents.add(document)
+    return document
+
+
+def seed_warning(
+    program: Program,
+    calculator: str,
+    message: str,
+    *,
+    external_name: str | None = None,
+    county_names: tuple[str, ...] = (),
+) -> WarningMessage:
+    """Attach a WarningMessage driven by `calculator` to `program`.
+
+    Same translation caveat as `seed_document`. `county_names` creates the County rows
+    and links them, which is how `WarningCalculator.county_eligible` is gated — an
+    empty tuple means "all counties", matching the model's `county_names` property.
+    """
+    warning = WarningMessage.objects.new_warning(
+        program.white_label.code, calculator, external_name=external_name or calculator
+    )
+    _set_default_text(warning.message, message)
+    for county_name in county_names:
+        county, _ = County.objects.get_or_create(white_label=program.white_label, name=county_name)
+        warning.counties.add(county)
+    warning.programs.add(program)
+    return warning

--- a/screener/tests/test_assistant_context.py
+++ b/screener/tests/test_assistant_context.py
@@ -30,12 +30,13 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from benefits.tests.cache_override import LOCAL_CACHE
-from programs.models import Program
+from programs.models import LegalStatus, Program
 from screener.assistant import (
     CONTEXT_PREFETCH,
     AssistantMessageRateThrottle,
     AssistantStartRateThrottle,
     AssistantStartView,
+    MAX_DOCUMENTS_PER_PROGRAM,
     MAX_PROGRAM_VALUE,
     MAX_VISIBLE_PROGRAMS,
     _build_context,
@@ -50,7 +51,7 @@ from screener.models import (
     Screen,
     WhiteLabel,
 )
-from screener.tests.helpers import seed_program
+from screener.tests.helpers import seed_document, seed_program, seed_warning
 from translations.models import BLANK_TRANSLATION_PLACEHOLDER
 
 
@@ -65,7 +66,13 @@ def set_translation(translated_field, text: str) -> None:
     seed_program() leaves every translation at BLANK_TRANSLATION_PLACEHOLDER, which
     the context builder treats as "no value" — so tests that care about a real name
     or apply link have to fill it in.
+
+    The language is pinned rather than assumed: `Translation.objects.add_translation`
+    writes a row per supported language and leaves parler's active language on the last
+    one it touched, so an object handed straight back from a `new_*` manager method
+    would otherwise take the text into that language instead of this one.
     """
+    translated_field.set_current_language(settings.LANGUAGE_CODE)
     translated_field.text = text
     translated_field.save()
 
@@ -299,6 +306,272 @@ class BuildContextTests(TestCase):
             context = self.context()
 
         self.assertEqual(context["current_programs"][0]["name"], "Basic Food (SNAP)")
+
+    # --- documents ----------------------------------------------------------
+
+    def test_documents_are_included_in_results_page_order(self):
+        """The whole point of MFB-1788: asked "what do I need to apply", the assistant
+        should read back the same checklist the "more info" panel shows."""
+        self.add_snapshot_row("snap")
+        for external_name, text in (
+            ("proof_of_address", "Proof of address"),
+            ("photo_id", "Photo ID"),
+            ("proof_of_income", "Proof of income"),
+        ):
+            seed_document(self.programs["snap"], external_name, text)
+
+        context = self.context()
+
+        self.assertEqual(
+            context["eligible_programs"][0]["documents"],
+            ["Proof of address", "Photo ID", "Proof of income"],
+        )
+
+    def test_documents_key_is_omitted_when_the_program_has_none(self):
+        """Absent rather than [] — ai-service defaults it, and the prompt distinguishes
+        "we have no list for this program" from "this program needs nothing"."""
+        self.add_snapshot_row("snap")
+
+        context = self.context()
+
+        self.assertNotIn("documents", context["eligible_programs"][0])
+
+    def test_blank_and_placeholder_documents_are_dropped(self):
+        """`new_document` leaves text="" and the translation machinery writes
+        [PLACEHOLDER]; either would render as an empty checklist line."""
+        self.add_snapshot_row("snap")
+        seed_document(self.programs["snap"], "real", "Proof of address")
+        seed_document(self.programs["snap"], "blank", "")
+        seed_document(self.programs["snap"], "placeholder", BLANK_TRANSLATION_PLACEHOLDER)
+
+        context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["documents"], ["Proof of address"])
+
+    def test_document_urls_never_reach_the_payload(self):
+        """Document carries link_url/link_text, and the prompt's LINKS rule is absolute:
+        apply links are the only URLs the assistant may share. They are not merely
+        unrendered — they are never fetched."""
+        self.add_snapshot_row("snap")
+        document = seed_document(self.programs["snap"], "proof_of_address", "Proof of address")
+        set_translation(document.link_url, "https://example.gov/documents")
+        set_translation(document.link_text, "See the document list")
+
+        context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["documents"], ["Proof of address"])
+        self.assertNotIn("example.gov", str(context))
+        self.assertNotIn("See the document list", str(context))
+
+    def test_documents_are_capped_per_program(self):
+        """A misconfigured program shouldn't be able to crowd out the rest of the
+        prompt."""
+        self.add_snapshot_row("snap")
+        for i in range(MAX_DOCUMENTS_PER_PROGRAM + 3):
+            seed_document(self.programs["snap"], f"doc_{i}", f"Document {i}")
+
+        context = self.context()
+
+        self.assertEqual(len(context["eligible_programs"][0]["documents"]), MAX_DOCUMENTS_PER_PROGRAM)
+
+    def test_documents_use_the_screen_language_not_the_request_language(self):
+        """Same reason program names do: `get_language()` reflects the browser's
+        Accept-Language, so an English session in a Spanish browser would otherwise get
+        a Spanish checklist."""
+        self.add_snapshot_row("snap")
+        document = seed_document(self.programs["snap"], "proof_of_address", "Proof of address")
+        document.text.set_current_language("es")
+        document.text.text = "Comprobante de domicilio"
+        document.text.save()
+        self.screen.request_language_code = "es"
+        self.screen.save()
+
+        with translation.override("en-us"):
+            context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["documents"], ["Comprobante de domicilio"])
+
+    def test_current_programs_carry_documents(self):
+        """Recertification needs a document list too ("what do I need to renew my
+        SNAP"). Safe on this thinner shape: no dollar value, no apply link."""
+        self.receives("snap")
+        seed_document(self.programs["snap"], "proof_of_income", "Proof of income")
+
+        context = self.context()
+
+        self.assertEqual(context["current_programs"][0]["documents"], ["Proof of income"])
+
+    # --- warnings -----------------------------------------------------------
+
+    def test_warning_is_included(self):
+        self.add_snapshot_row("lifeline")
+        seed_warning(
+            self.programs["lifeline"],
+            "_show",
+            "If you are eligible for SNAP, enroll in SNAP before applying for Lifeline.",
+        )
+
+        context = self.context()
+
+        self.assertEqual(
+            context["eligible_programs"][0]["warnings"],
+            ["If you are eligible for SNAP, enroll in SNAP before applying for Lifeline."],
+        )
+
+    def test_warnings_key_is_omitted_when_the_program_has_none(self):
+        self.add_snapshot_row("snap")
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+
+    def test_dont_show_warning_is_excluded(self):
+        """`_dont_show` is how a warning is switched off in config without deleting it,
+        so honouring the calculator matters even for the trivial ones."""
+        self.add_snapshot_row("snap")
+        seed_warning(self.programs["snap"], "_dont_show", "Should never be shown.")
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+
+    def test_county_gated_warning_is_included_in_a_matching_county(self):
+        self.screen.county = "Denver County"
+        self.screen.save()
+        self.add_snapshot_row("snap")
+        seed_warning(
+            self.programs["snap"],
+            "_show",
+            "Denver applications are processed locally.",
+            county_names=("Denver County",),
+        )
+
+        context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["warnings"], ["Denver applications are processed locally."])
+
+    def test_county_gated_warning_is_excluded_outside_that_county(self):
+        """The county gate is the main reason warnings are per-household rather than a
+        static field, so bypassing it would show people other counties' instructions."""
+        self.screen.county = "Boulder County"
+        self.screen.save()
+        self.add_snapshot_row("snap")
+        seed_warning(
+            self.programs["snap"],
+            "_show",
+            "Denver applications are processed locally.",
+            county_names=("Denver County",),
+        )
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+
+    def test_warning_blocked_by_a_missing_dependency_is_excluded(self):
+        """`can_calc()` is False when a declared dependency is missing from the screen,
+        which is how the results page avoids showing a warning it couldn't evaluate.
+        co_snap_student declares `age`; a member with no age puts it in
+        `screen.missing_fields()`."""
+        HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=None, student=True)
+        self.add_snapshot_row("snap")
+        seed_warning(self.programs["snap"], "co_snap_student", "Students face extra SNAP rules.")
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+
+    def test_warning_with_legal_statuses_is_dropped(self):
+        """The results page filters these client-side against the citizenship dropdown,
+        which defaults to 'citizen' and is never persisted to the Screen. We can't
+        reproduce the selection, so we under-report rather than surface
+        immigration-status content to a household that didn't ask for it."""
+        self.add_snapshot_row("snap")
+        warning = seed_warning(self.programs["snap"], "_show", "Green card holders under 18 are exempt.")
+        status_row, _ = LegalStatus.objects.get_or_create(status="gc_under18_no5")
+        warning.legal_statuses.add(status_row)
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+
+    def test_unknown_calculator_is_skipped_rather_than_raising(self):
+        """The eligibility run raises on an unrecognized calculator name. Doing that
+        here would take the assistant down over a config typo."""
+        self.add_snapshot_row("snap")
+        seed_warning(self.programs["snap"], "not_a_real_calculator", "Should not appear.")
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+        self.assertEqual(self.eligible_names(context), ["snap"])
+
+    def test_calculator_needing_member_eligibility_is_skipped(self):
+        """co_upk reads `eligibility.eligible_members`, which the snapshot has no
+        breakdown for. It declares `needs_member_eligibility` so it's skipped
+        explicitly instead of silently evaluating against an empty list."""
+        HouseholdMember.objects.create(screen=self.screen, relationship="child", age=3)
+        self.add_snapshot_row("snap")
+        seed_warning(self.programs["snap"], "co_upk", "Three-year-olds have a separate application.")
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["eligible_programs"][0])
+
+    def test_warning_urls_never_reach_the_payload(self):
+        """Same rule as documents: WarningMessage carries link_url/link_text and neither
+        is fetched."""
+        self.add_snapshot_row("snap")
+        warning = seed_warning(self.programs["snap"], "_show", "Applications take 6 to 8 months.")
+        set_translation(warning.link_url, "https://example.gov/warnings")
+        set_translation(warning.link_text, "Read more about delays")
+
+        context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["warnings"], ["Applications take 6 to 8 months."])
+        self.assertNotIn("example.gov", str(context))
+        self.assertNotIn("Read more about delays", str(context))
+
+    def test_warnings_use_the_screen_language_not_the_request_language(self):
+        self.add_snapshot_row("snap")
+        warning = seed_warning(self.programs["snap"], "_show", "Applications take 6 to 8 months.")
+        warning.message.set_current_language("es")
+        warning.message.text = "Las solicitudes tardan de 6 a 8 meses."
+        warning.message.save()
+        self.screen.request_language_code = "es"
+        self.screen.save()
+
+        with translation.override("en-us"):
+            context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["warnings"], ["Las solicitudes tardan de 6 a 8 meses."])
+
+    def test_current_programs_carry_no_warnings(self):
+        """Warnings are application caveats for programs the household is being told to
+        apply for. This list is the opposite of that."""
+        self.receives("snap")
+        seed_warning(self.programs["snap"], "_show", "Applications take 6 to 8 months.")
+
+        context = self.context()
+
+        self.assertNotIn("warnings", context["current_programs"][0])
+
+    # --- estimated_delivery_time --------------------------------------------
+
+    def test_estimated_delivery_time_is_forwarded(self):
+        """Already on the snapshot and already sent to the results page; answers "how
+        long until I actually get this"."""
+        ProgramEligibilitySnapshot.objects.create(
+            eligibility_snapshot=self.snapshot,
+            name="SNAP",
+            name_abbreviated="snap",
+            estimated_value=Decimal("1200"),
+            eligible=True,
+            estimated_delivery_time="30 days",
+        )
+
+        context = self.context()
+
+        self.assertEqual(context["eligible_programs"][0]["estimated_delivery_time"], "30 days")
 
     # --- visible_programs intersection --------------------------------------
 
@@ -629,11 +902,20 @@ class BuildContextTests(TestCase):
         self.add_snapshot_row("snap")
         self.receives("tanf")
         set_translation(self.programs["tanf"].name, "TANF")
+        # Documents and warnings hang off Program the same way, and are resolved
+        # per program — so they belong on both sides of this comparison, or the
+        # constant-query claim only covers the fields that existed before MFB-1788.
+        seed_document(self.programs["snap"], "snap_id", "Photo ID")
+        seed_document(self.programs["tanf"], "tanf_id", "Photo ID")
+        seed_warning(self.programs["snap"], "_show", "SNAP applications take a while.")
         with_one = query_count()
 
         self.add_snapshot_row("wic")
         self.receives("lifeline")
         set_translation(self.programs["lifeline"].name, "Lifeline")
+        seed_document(self.programs["wic"], "wic_id", "Photo ID")
+        seed_document(self.programs["lifeline"], "lifeline_id", "Photo ID")
+        seed_warning(self.programs["wic"], "_show", "WIC applications take a while.")
         with_two = query_count()
 
         self.assertEqual(with_one, with_two)
@@ -641,7 +923,8 @@ class BuildContextTests(TestCase):
     def test_context_build_does_not_scale_queries_with_member_count(self):
         """The insurance check walks household_members (and each member's reverse
         OneToOne `insurance`) once per program, so it's an N+1 on two axes at once
-        unless household_members__insurance is prefetched."""
+        unless household_members__insurance is prefetched. Warning evaluation walks
+        them again through screen.missing_fields()."""
 
         def query_count() -> int:
             screen = Screen.objects.prefetch_related(*CONTEXT_PREFETCH).get(pk=self.screen.pk)
@@ -651,6 +934,10 @@ class BuildContextTests(TestCase):
 
         self.add_snapshot_row("snap")
         self.add_snapshot_row("wic")
+        # Evaluating a warning calls screen.missing_fields(), which walks every member
+        # plus each member's reverse `insurance`/`energy_calculator` and their income
+        # streams — a third N+1 axis unless CONTEXT_PREFETCH covers them.
+        seed_warning(self.programs["snap"], "_show", "SNAP applications take a while.")
         member = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
         Insurance.objects.create(household_member=member, employer=True)
         with_one_member = query_count()
@@ -764,6 +1051,14 @@ class AssistantStartViewTests(APITestCase):
                 estimated_value=Decimal(value),
                 eligible=True,
             )
+        # Documents and warnings are populated so the query bound below covers the
+        # prefetches they need. Django skips a nested prefetch whose parent set is
+        # empty, so a fixture without them silently exempts the whole chain from the
+        # ceiling — which is exactly the coverage this class exists to provide.
+        snap, wic = (Program.objects.get(white_label=self.white_label, name_abbreviated=n) for n in ("snap", "wic"))
+        for program in (snap, wic):
+            seed_document(program, f"{program.name_abbreviated}_id", "Photo ID")
+            seed_warning(program, "_show", f"{program.name_abbreviated} applications take a while.")
         self.url = reverse("assistant-start", args=[self.screen.uuid])
 
     def _post(self, body):
@@ -798,7 +1093,12 @@ class AssistantStartViewTests(APITestCase):
     # Ceiling rather than an exact count: an exact number makes an unambiguous
     # improvement (adding a select_related) look like a regression, which is what
     # happened when `white_label` was added to the view's queryset.
-    MAX_START_QUERIES = 10
+    #
+    # Raised from 10 for MFB-1788: the four CONTEXT_PREFETCH entries that feed
+    # screen.missing_fields(), plus documents and warnings (each with their counties,
+    # legal statuses and translations) on the one Program fetch _build_context already
+    # made. All flat in program and member count — the sibling tests assert that.
+    MAX_START_QUERIES = 16
 
     def test_query_count_is_bounded(self):
         """Bounded here so CONTEXT_PREFETCH disappearing from the view is caught, even

--- a/screener/tests/test_assistant_context.py
+++ b/screener/tests/test_assistant_context.py
@@ -374,6 +374,19 @@ class BuildContextTests(TestCase):
 
         self.assertEqual(len(context["eligible_programs"][0]["documents"]), MAX_DOCUMENTS_PER_PROGRAM)
 
+    def test_document_cap_clears_the_largest_real_program(self):
+        """A guard on the constant, not on behavior.
+
+        The cap was originally 12, chosen against the seed configs — where the largest
+        documents block is 8. Most of this data is created through the Django admin and
+        never reaches a *_initial_config.json, and production (checked 2026-09-10) has
+        16 documents on mo_tanf. At 12 the assistant would have handed that household a
+        silently short checklist, breaking the results-page parity this feature exists
+        for. Lowering the constant below the real maximum must fail a test rather than
+        show up as a missing document.
+        """
+        self.assertGreaterEqual(MAX_DOCUMENTS_PER_PROGRAM, 16)
+
     def test_documents_use_the_screen_language_not_the_request_language(self):
         """Same reason program names do: `get_language()` reflects the browser's
         Accept-Language, so an English session in a Spanish browser would otherwise get
@@ -507,7 +520,7 @@ class BuildContextTests(TestCase):
 
     def test_calculator_needing_member_eligibility_is_skipped(self):
         """co_upk reads `eligibility.eligible_members`, which the snapshot has no
-        breakdown for. It declares `needs_member_eligibility` so it's skipped
+        breakdown for. It declares `needs_full_eligibility` so it's skipped
         explicitly instead of silently evaluating against an empty list."""
         HouseholdMember.objects.create(screen=self.screen, relationship="child", age=3)
         self.add_snapshot_row("snap")
@@ -1105,7 +1118,7 @@ class AssistantStartViewTests(APITestCase):
         though the unit-level N+1 tests supply the prefetch themselves and so can't see
         the constant going missing.
 
-        Roughly: screen (+white_label joined), the two CONTEXT_PREFETCH prefetches,
+        Roughly: screen (+white_label joined), the CONTEXT_PREFETCH prefetches,
         snapshot, its program_snapshots prefetch, the insurance name/base_program lookup,
         the apply-link programs + their translations prefetch, and current_programs. All
         flat in program and member count — which is what the sibling tests assert.

--- a/screener/tests/test_assistant_context.py
+++ b/screener/tests/test_assistant_context.py
@@ -38,6 +38,7 @@ from screener.assistant import (
     AssistantStartView,
     MAX_DOCUMENTS_PER_PROGRAM,
     MAX_PROGRAM_VALUE,
+    MAX_PROMPT_TEXT_LEN,
     MAX_VISIBLE_PROGRAMS,
     _build_context,
     _visible_programs,
@@ -386,6 +387,65 @@ class BuildContextTests(TestCase):
         show up as a missing document.
         """
         self.assertGreaterEqual(MAX_DOCUMENTS_PER_PROGRAM, 16)
+
+    def test_over_long_warning_is_clipped_and_reported(self):
+        """400 was already clipping production (cccap_jeffco is 562 chars). Clipping an
+        instruction mid-sentence is the failure `_apply_url` refuses for links, so if it
+        happens at all it must be visible rather than silent."""
+        self.add_snapshot_row("snap")
+        long_message = "A" * (MAX_PROMPT_TEXT_LEN + 200)
+        seed_warning(self.programs["snap"], "_show", long_message)
+
+        with mock.patch("screener.assistant._REPORTED", set()):
+            with mock.patch("screener.assistant.capture_message") as reported:
+                context = self.context()
+
+        self.assertEqual(len(context["eligible_programs"][0]["warnings"][0]), MAX_PROMPT_TEXT_LEN)
+        self.assertEqual(reported.call_count, 1)
+        self.assertIn("exceeds MAX_PROMPT_TEXT_LEN", reported.call_args.args[0])
+
+    def test_text_at_the_limit_is_not_reported(self):
+        """Resolving at full length is what distinguishes over-long text from text that
+        happens to end exactly at the cap; going through _translated's own cap could not
+        tell them apart."""
+        self.add_snapshot_row("snap")
+        seed_warning(self.programs["snap"], "_show", "A" * MAX_PROMPT_TEXT_LEN)
+
+        with mock.patch("screener.assistant._REPORTED", set()):
+            with mock.patch("screener.assistant.capture_message") as reported:
+                context = self.context()
+
+        self.assertEqual(len(context["eligible_programs"][0]["warnings"][0]), MAX_PROMPT_TEXT_LEN)
+        reported.assert_not_called()
+
+    def test_a_static_config_condition_is_reported_once_per_process(self):
+        """These conditions are properties of the config, not the request, but they're
+        evaluated in a per-program loop on every assistant start. Reporting per request
+        would make one unchanging fact the loudest event this module emits."""
+        self.add_snapshot_row("snap")
+        seed_warning(self.programs["snap"], "not_a_real_calculator", "Should not appear.")
+
+        with mock.patch("screener.assistant._REPORTED", set()):
+            with mock.patch("screener.assistant.capture_message") as reported:
+                self.context()
+                self.context()
+                self.context()
+
+        self.assertEqual(reported.call_count, 1)
+
+    def test_documents_are_ordered_deterministically(self):
+        """Document declares no Meta.ordering and the M2M is auto-created, so without an
+        explicit order_by the sequence is whatever Postgres returns — which need not
+        match the results page reading the same rows in a separate query."""
+        self.add_snapshot_row("snap")
+        first = seed_document(self.programs["snap"], "aaa_last_alphabetically", "Zebra document")
+        second = seed_document(self.programs["snap"], "zzz_first_alphabetically", "Apple document")
+
+        documents = self.context()["eligible_programs"][0]["documents"]
+
+        # id order, not insertion-coincidence and not alphabetical by either field.
+        self.assertEqual(documents, ["Zebra document", "Apple document"])
+        self.assertLess(first.id, second.id)
 
     def test_documents_use_the_screen_language_not_the_request_language(self):
         """Same reason program names do: `get_language()` reflects the browser's
@@ -920,7 +980,13 @@ class BuildContextTests(TestCase):
         # constant-query claim only covers the fields that existed before MFB-1788.
         seed_document(self.programs["snap"], "snap_id", "Photo ID")
         seed_document(self.programs["tanf"], "tanf_id", "Photo ID")
-        seed_warning(self.programs["snap"], "_show", "SNAP applications take a while.")
+        # _tax_unit, not just _show: _show reads nothing, so it cannot exercise the
+        # axis that scales. _tax_unit reaches Screen.has_members_outside_of_tax_unit ->
+        # is_dependent -> get_reference_date, which is unprefetchable by construction
+        # (order_by builds a fresh queryset) and was an N+1 on members x programs until
+        # that method was memoized.
+        seed_warning(self.programs["snap"], "_tax_unit", "SNAP has tax-unit rules.")
+        seed_warning(self.programs["tanf"], "_show", "TANF applications take a while.")
         with_one = query_count()
 
         self.add_snapshot_row("wic")
@@ -928,7 +994,8 @@ class BuildContextTests(TestCase):
         set_translation(self.programs["lifeline"].name, "Lifeline")
         seed_document(self.programs["wic"], "wic_id", "Photo ID")
         seed_document(self.programs["lifeline"], "lifeline_id", "Photo ID")
-        seed_warning(self.programs["wic"], "_show", "WIC applications take a while.")
+        seed_warning(self.programs["wic"], "_tax_unit", "WIC has tax-unit rules.")
+        seed_warning(self.programs["lifeline"], "_show", "Lifeline takes a while.")
         with_two = query_count()
 
         self.assertEqual(with_one, with_two)
@@ -950,17 +1017,27 @@ class BuildContextTests(TestCase):
         # Evaluating a warning calls screen.missing_fields(), which walks every member
         # plus each member's reverse `insurance`/`energy_calculator` and their income
         # streams — a third N+1 axis unless CONTEXT_PREFETCH covers them.
-        seed_warning(self.programs["snap"], "_show", "SNAP applications take a while.")
-        member = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
-        Insurance.objects.create(household_member=member, employer=True)
-        with_one_member = query_count()
+        # _tax_unit walks every member (see the sibling test); _show would keep this
+        # flat no matter how badly the member axis regressed.
+        seed_warning(self.programs["snap"], "_tax_unit", "SNAP has tax-unit rules.")
+        seed_warning(self.programs["wic"], "_show", "WIC applications take a while.")
 
-        for age in (38, 10, 12):
+        # The baseline needs a member who is neither head nor spouse. `is_in_tax_unit`
+        # short-circuits on those two, so a head-only household never reaches
+        # `is_dependent` and never reads the reference date — measuring from there would
+        # compare a run that skips a branch against one that takes it, and report the
+        # branch as growth.
+        for relationship, age in (("headOfHousehold", 40), ("child", 10)):
+            member = HouseholdMember.objects.create(screen=self.screen, relationship=relationship, age=age)
+            Insurance.objects.create(household_member=member, employer=True)
+        with_two_members = query_count()
+
+        for age in (38, 12, 14):
             extra = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=age)
             Insurance.objects.create(household_member=extra, employer=True)
-        with_four_members = query_count()
+        with_five_members = query_count()
 
-        self.assertEqual(with_one_member, with_four_members)
+        self.assertEqual(with_two_members, with_five_members)
 
 
 class VisibleProgramsParsingTests(SimpleTestCase):

--- a/screener/views.py
+++ b/screener/views.py
@@ -65,6 +65,7 @@ import math
 import json
 from datetime import datetime, timezone
 from django.conf import settings
+from django.db.models import Prefetch
 
 
 def index(request):
@@ -441,7 +442,12 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
             "program_navigators__navigator__languages",
             "program_navigators__navigator__eligibility_programs",
             *translations_prefetch_name("program_navigators__navigator__", Navigator.objects.translated_fields),
-            "documents",
+            # Ordered explicitly so this and the assistant context (screener.assistant,
+            # `_documents_prefetch`) render the same sequence. Neither Document nor the
+            # auto-created M2M declares an ordering, so without this the two queries
+            # could return the same checklist in different orders — and the assistant is
+            # meant to read back exactly what this panel shows.
+            Prefetch("documents", queryset=Document.objects.order_by("id")),
             *translations_prefetch_name("documents__", Document.objects.translated_fields),
             "warning_messages",
             "warning_messages__counties",


### PR DESCRIPTION
## Context & Motivation

A user on staging asked Benji what documents they needed for Early Head Start and got:

> I don't have the specific document list for Early Head Start in your screening results, so I can't give you a precise checklist.

Honest, but wrong. `tx_early_head_start` ships six `Document` rows, and 137 of 146 program configs have a non-empty `documents` block. The same gap applies to `WarningMessage`: `tx_lifeline` carries "enroll in SNAP before applying for Lifeline" — an ordering instruction Benji actively needs, since its whole job is telling people what to do next.

`_build_context` forwarded five fields per program. The results page gets about twenty. This closes two of them and sets the pattern the rest will follow.

- Ticket: https://linear.app/myfriendben/issue/MFB-1788/give-benji-the-documents-and-warning-messages-the-results-page-shows
- Paired with the `ai-service` PR on the same branch name — deploy order matters, see Deployment.
- Related: [MFB-1776](https://linear.app/myfriendben/issue/MFB-1776/allow-benji-to-surface-navigators) (navigators) follows this pattern.

Source: Laura's "Benji Feedback" sheet, row 2, 2026-09-04.

## Changes Made

### Documents — read live off `Program`

Documents are static per program — no household gating — so they're read straight off `Program.documents` and resolved through the existing `_translated`, which already drops blank and `[PLACEHOLDER]` rows.

### Warnings — the gates are re-run, with no new column

The ticket's recommended route was a `ProgramEligibilitySnapshot` column, on the grounds that re-running the calculators means "effectively the full eligibility run". That turns out to be true for exactly one of the seven calculators registered in `programs/warnings/__init__.py`:

| calculator | needs `self.eligibility`? |
|---|---|
| `_show`, `_dont_show`, `_tax_unit` | no — constant, or `screen.has_members_outside_of_tax_unit()` |
| `co_snap_student` | no — walks `screen.household_members` |
| `ma_senior_snap_application` | no — `screen.num_adults()` |
| `cesn_renter` | no — `screen.energy_calculator.is_renter` |
| `co_upk` | **yes** — `self.eligibility.eligible_members` |

`WarningCalculator.calc()` needs the screen, the `WarningMessage`, `missing_dependencies` and an `Eligibility`. `screen.missing_fields()` is pure screen data — no PolicyEngine, fully prefetchable — and `Eligibility()` takes no constructor args, so the only unreproducible input is `eligible_members`, which no snapshot stores. **So there is no migration in this PR.**

`co_upk` now declares `needs_member_eligibility = True` on the calculator class and is skipped here with a `capture_message`. Running it against an empty `eligible_members` would return `False` anyway — but silently. An explicit, Sentry-visible hole beats an invisible one.

### Two deliberate divergences from the results-page evaluation

**Warnings carrying `legal_statuses` are dropped.** `ProgramPage.tsx:195-212` filters those *client-side* against the citizenship dropdown, which defaults to `'citizen'` and is never persisted to the `Screen`. We can't reproduce the selection, and per the ticket's own reasoning on `visible_programs` we won't take it from the payload.

Checked against **production**, not the fixtures (see Notes — the fixtures are badly unrepresentative here). Of 108 warning rows, **21 carry a non-empty `legal_statuses`**, across six statuses:

| status | warnings |
|---|---|
| otherWithWorkPermission | 9 |
| gc_under18_no5 | 6 |
| gc_18plus_no5 | 4 |
| refugee | 4 |
| gc_5plus | 1 |
| non_citizen | 1 |

**`citizen` does not appear at all**, so none of the 21 renders for the default filter — the conclusion is the same as the fixture-based one, now on real data. Under-reporting is the safe direction: it never surfaces immigration-status content to a household that did not opt into that filter. TX SSI, TX Lifeline and Early Head Start are all unscoped, so this ticket's targets are unaffected.

**An unknown calculator name is skipped and logged, not raised.** `screener/views.py` raises a bare `Exception`; doing that here would 500 the assistant over a config typo.

### No document or warning URL is ever loaded

Both models carry `link_url` and `link_text`. Rather than fetch and discard them, the prefetches pull only `text`/`message`, so a URL never enters the process — structural rather than a code-review promise. `Document.objects.translated_fields` would have pulled all three.

### Query shape

`_apply_urls_by_name` is replaced by `_context_programs` plus three per-program extractors (`_apply_url`, `_document_texts`, `_warning_messages`). Apply links, documents and warnings all hang off the same `Program` rows for the same name set, so they now share **one** fetch instead of three identical `name_abbreviated__in` queries. The `documents__text` and `warning_messages__message` translation hops are folded in with `Prefetch(..., select_related(...))`, the way `apply_button_link` already was — two fewer queries again.

`CONTEXT_PREFETCH` gains what `screen.missing_fields()` walks: `expenses`, `household_members__income_streams`, `household_members__energy_calculator`, `energy_calculator`.

An earlier version of this line said "and nothing more", which review finding #1 disproved: the warning calculators read further than `missing_fields()` does. `_tax_unit` reaches `Screen.get_reference_date`, whose `validations.order_by(...)` builds a fresh queryset and so cannot be prefetched from here at all — it was an N+1 on members × programs until that method was memoized. The comment on the constant now says so, because the wrong instinct on a future query-count regression is to add another entry to the tuple.

### Also included

- `estimated_delivery_time` forwarded — already on the snapshot, already sent to the results page, answers "how long until I actually get this". It inherits the existing run-time-language wart that `estimated_application_time` has.
- `current_programs` gains `documents`, for recertification ("what do I need to renew my SNAP"). No value, no apply link — the two things that shape is thin to avoid. It deliberately does **not** gain warnings: those are caveats about applying, and this is the list of programs nobody should be applying for.

### Deliberately not changed

- The results-page **payload shape** is unchanged, and the warning evaluation in `screener/views.py` still runs and serializes exactly as before. That file does now carry one change, from review finding #3: an explicit `order_by("id")` on its documents prefetch, so it and the assistant context render the checklist in the same sequence. Ordering only — no field added, removed or reshaped.
- `ProgramEligibilitySnapshot` gains no field, so no migration and no backfill.

## Testing

`screener/` + `programs/` + `validations/`: **3943 passed, 4 skipped, 0 failed.** `black -l 120` clean. For comparison I ran the same suite on a clean `origin/main` worktree: **3896 passed, 0 failed** — the delta is exactly the 21 tests this branch adds.

One caveat, stated because it happened rather than because I can explain it: on one intermediate full-suite run, `programs/programs/cross_white_label/ssi/tests/test_tx.py::TestTxSsiPeInput::test_includes_all_pe_input_fields` failed. It passes in isolation, passes when run directly after this branch's new tests, passed on the full-suite rerun, and passes on `main`; there is no code path from anything here (assistant context, warning caps) to PolicyEngine input fields. I could not reproduce it and I have not explained it, so treat it as a suspected pre-existing flake rather than a cleared one.

`screener/tests/test_assistant_context.py`: 75 → **95 tests**, all passing. New coverage for document ordering and capping, blank/placeholder dropping, no `link_url`/`link_text` anywhere in the payload, `_show` vs `_dont_show`, the county gate in and out of county, a `dependencies`-blocked calculator, `legal_statuses` dropping, an unknown calculator name, the `co_upk` skip, Spanish resolution driven by `request_language_code` rather than the active Django language, `estimated_delivery_time`, and `CurrentProgram` documents.

**The new tests were verified to fail against unfixed code.** With `_document_texts` and `_warning_messages` stubbed to return `[]` and `estimated_delivery_time` removed from the payload, **11 of the 18** new behavioral tests fail. The 7 that still pass are the negative assertions (`assertNotIn("warnings", ...)`) — correct, since they guard the *gating* logic, whose failure mode is over-reporting rather than under-reporting.

**First test coverage for `programs/warnings/`** — there was none before. The gating tests above exercise `county_eligible`, `can_calc` and the registry lookup.

Query counts: `MAX_START_QUERIES` goes **10 → 16**, and both N+1 tests plus the view fixture now carry documents and warnings. That matters — Django skips a nested prefetch whose parent set is empty, so without seeded data the entire new prefetch chain was silently exempt from the ceiling, which is exactly the coverage that class exists to provide. The two N+1 tests confirm the count stays flat in both program count and member count.

Pre-existing, unrelated: the local test DB needed `--create-db` (it predated migration `0164_householdmember_was_in_foster_care`), and `pytest-xdist` was missing from the venv. Redis is not running locally, so runs used `-n 0`; the throttle cache logs `ConnectionInterrupted` and the suite is unaffected.

## Deployment

**No migration, no config, no manual step.** Confirmed with `manage.py makemigrations --check --dry-run` → "No changes detected".

- Post-deployment scripts needed: **none**
- Production config updates: **none** — nothing under `configuration/white_labels/**`, no new `*_initial_config.json`, no new `Program`
- Admin updates needed: **none** — the `benbot` feature flag already gates this endpoint per white label and is unchanged
- Notify team/users of: Benji will start answering "what documents do I need for X" and reflecting program warnings. No results-page behavior changes; the eligibility run and its payload are untouched.

**Deploy this before the `ai-service` PR.** The two are independent — `ai-service` defaults every new field, and `ConversationContext` has no `extra="forbid"`, so either order is *safe* — but shipping the API first means the data is already flowing when the prompt starts asking for it. Shipping only `ai-service` first is inert rather than broken.

Per `docs/DEPLOYMENT.md`, both staging (merge to `main` → `cobenefits-api-staging`) and production (publishing a release → `cobenefits-api`) run `manage.py migrate` and `manage.py add_config --all` unconditionally. Neither has anything to do here.

Rollback is a plain revert: `heroku rollback -a cobenefits-api`.

## Notes for Reviewers

**Start with `_warning_messages` in `screener/assistant.py`** — the divergences from `views.py` are the substance of this PR and each is commented in place.

**One known fidelity caveat.** The gates are evaluated against the screen's *current* data, while the program list comes from the last snapshot. If a screen were edited between the two, warnings could diverge from what the results page showed. In practice the results page recomputes eligibility on load, so the snapshot is fresh — the premise `_latest_snapshot`'s docstring already rests on — and every gate input is screen-side, so an unchanged screen gives the run's own answer.

**Known limitations, both worth follow-up tickets:**
- `co_upk` warnings never reach Benji, because member-level eligibility isn't stored anywhere. Colorado-only, one of seven calculators.
- Legal-status-scoped warnings (6 of 23) never reach Benji, because the citizenship filter is client-only state. If that filter ever becomes screen state, this can be revisited.

**Incidental fix:** `set_translation` in the test helpers claimed to write the default language but didn't pin one. `Translation.objects.add_translation` creates a row per supported language and leaves parler's active language on the last one it touched (currently `ht`), so text assigned to an object handed straight back from a `new_*` manager method landed in Haitian Creole. Pre-existing latent bug; it only surfaced now because `new_document`/`new_warning` are the first helpers to write text immediately after creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The assistant now provides relevant program documents, warnings, estimated delivery times, and links in its context.
  * Warning and document information is tailored to household eligibility, language, location, and legal status.
  * Context content is bounded to keep responses focused and manageable.

* **Bug Fixes**
  * Improved language fallback and filtering of inapplicable warnings and links.

* **Tests**
  * Expanded coverage for assistant context, eligibility filtering, content limits, and query stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Blast-radius review

Added after review feedback that this touches a widely-used base class. The change surface is three non-test files: `programs/warnings/base.py`, `programs/warnings/co/universal_preschool.py`, `screener/assistant.py`.

**`WarningCalculator` (the base class).** The change is one class attribute with a default, alongside the existing `dependencies`. Verified: nothing in the repo introspects calculator class attributes — the only reflective use is `translations/views.py:596`, which builds admin choices from `sorted(warning_calculators)`, i.e. dict *keys*. Six subclasses exist (`TaxUnit`, `DontShow`, `EnergyCalculatorIsRenter`, `MaSeniorSnapApplication`, `SnapStudentWarning`, `UniversalPreschool`); none defines this name, so there is no shadowing. `_show` maps to the base class directly and is unaffected.

Worth knowing for anyone reading that file: there are **two** unrelated registries both bound to the name `warning_calculators` — `programs.warnings` (this one) and `programs.translation_overrides` (base class `TranslationOverrideCalculator`, used by `programs/models.py:913` and the admin choices above). They are separate hierarchies; `TranslationOverrideCalculator` does not inherit from `WarningCalculator`, so nothing here reaches it.

The flag is named `needs_full_eligibility`, not `needs_member_eligibility` as originally written. A snapshot-rebuilt `Eligibility` has only `.eligible` set, so *any* other attribute a calculator reads sits at its constructor default and yields a plausible wrong answer rather than an error. Naming it after `eligible_members` would have let a future calculator reading `household_value` through the same hole.

**Frontend (`benefits-calculator`): no path, verified.** The `_build_context` payload is a request body sent server-to-server; `_proxy` returns only ai-service's own parsed response (`assistant.py:763`), and ai-service's `ConversationResponse` has no `context` field, so the context is never echoed to a browser. The frontend's assistant types (`apiCalls.ts:320-345`) contain no `documents`/`warnings`/`estimated_delivery_time`/`apply_url`; `Chatbot.tsx` reads only `role`, `text`, `conversation_id` and `assistant_message`. The `visible_programs` request direction is untouched. The results page consumes a *different* endpoint (`EligibilityTranslationView` → `all_results`), whose `documents`/`warning_messages` keys carry `Translation` objects rather than the flat `list[str]` sent here, with its own independent prefetch block at `views.py:444-449`. (`screener/views.py` now carries one ordering-only change from review finding #3; the payload shape is untouched.) `grep -rnw "warnings" src` in the frontend returns zero hits, so the new key cannot collide.

**Blast radius of `CONTEXT_PREFETCH`:** referenced only in `assistant.py` and its tests. `assistant.py` is imported only by `screener/urls.py`; `views.py` deliberately does not import it.

## Notes for Reviewers — production data

The seed configs turned out to be a poor proxy for production, and one cap was wrong because of it. Most of this data is created through the Django admin and never reaches a `*_initial_config.json`:

| | fixtures | production |
|---|---|---|
| warning rows | 23 | 108 |
| calculators in use | `_show` only | `_show` 96, `_tax_unit` 6, `cesn_renter` 2, `co_upk`/`co_snap_student`/`ma_senior_snap_application` 1 each, **`cesn` 1 (unregistered)** |
| max documents on one program | 8 | **16** (`mo_tanf`) |
| max warnings on one program | 1 | 5 |
| programs carrying documents | — | 245, 1290 document links |

`MAX_DOCUMENTS_PER_PROGRAM` was 12, sized off the fixtures. That would have silently truncated `mo_tanf`'s checklist from 16 to 12 — breaking the results-page parity this feature exists to provide, on whichever program happens to carry the most documents. Caps are now 24 and 10, and a test asserts the document cap clears 16 so lowering it fails rather than dropping a document.

**Prompt budget, revised.** The +554 tokens I measured on the eval payload understates the real case, because that payload has 4 documents on one program. The ten TX programs with the most documents carry ~4,970 characters of document text between them, so a TX household eligible for all of them is nearer **+1,600 tokens** (~1,250 for the documents, ~350 for the one-time section header). Still acceptable for a first pass, and still zero for a household whose programs carry nothing, but it is the number to watch if we revisit the everything-up-front decision.

**Separate finding, not fixed here.** Production `WarningMessage` id 89 (`cip_energycalc`, white label `cesn`) has `calculator = 'cesn'`, which is not in the registry — the intended value is almost certainly `cesn_renter`. It is inert only because the row is attached to no program. If anyone attaches it in the admin, `screener/views.py:542` raises a bare `Exception` *inside* the eligibility loop, which aborts the whole run and 500s the results page for every program in that white label. Filed separately. It is also the concrete argument for this PR's choice to skip-and-log an unknown calculator rather than raise.

## Review round

A correctness review on this PR raised five findings; `bcdb559` and `fd43e8b` address four, and the fifth is declined with the measurement behind it. Details are in the review thread. In short:

1. **`_tax_unit` warnings were an N+1 on members × programs** — 26 queries for a 6-member household on 3 warned programs, 15 of them on `validations_validation`. `Screen.get_reference_date` is unprefetchable by construction (`order_by` builds a fresh queryset), so it is now memoized per instance: **12 queries flat** from 2→12 members and 1→6 programs. Eight other callers hit that method per member during the eligibility run, so `views.py` was paying this too. Both N+1 tests now seed `_tax_unit` as well as `_show` — `_show` reads nothing off the screen, which is why they certified flatness straight through the regression.
2. **Warning text was clipped at 400 chars silently, and already was in production** (`cccap_jeffco` is 562). Cap raised to 800; clipping now reports.
3. **Document order was undefined**, so the docstring's parity claim held of nothing. Both this prefetch and the results page's now `order_by("id")`.
4. **No total documents budget** — declined. The measured ceiling is ~13,000 characters (all 43 active CO programs); a total cap would buy a smaller worst case by silently shortening a checklist, which is the failure mode #3 is about.
5. **`capture_message` fired per request for a static config fact** — both skips now dedupe per process.