### PR TITLE
Add KS Weatherization Assistance Program (ks_wap) custom calculator (MFB-1067)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_lieap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lieap_initial_config.json
@@ -31,7 +31,7 @@
     "base_program": "liheap",
     "show_on_current_benefits": true,
     "has_calculator": true,
-    "show_in_has_benefits_step": false
+    "show_in_has_benefits_step": true
   },
   "documents": [
     {

--- a/programs/management/commands/import_program_config_data/data/ks_wap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_wap_initial_config.json
@@ -27,6 +27,7 @@
     "estimated_value": "",
     "value_format": "lump_sum",
     "website_description": "Free home energy upgrades to lower your bills",
+    "active": true,
     "show_on_current_benefits": true,
     "has_calculator": true,
     "show_in_has_benefits_step": false

--- a/programs/management/commands/import_program_config_data/data/ks_wap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_wap_initial_config.json
@@ -1,0 +1,76 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "program_category": {
+    "external_name": "housing"
+  },
+  "program": {
+    "name_abbreviated": "ks_wap",
+    "base_program": "wap",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission"
+    ],
+    "name": "Weatherization Assistance Program (WAP)",
+    "description": "The Weatherization Assistance Program (WAP) offers free home energy upgrades. These can cut your energy bills and make your home safer and more comfortable. A local provider will check your home and see what work could help you save energy. Some home conditions may need to be fixed first.\n\nYou may qualify if you get LIEAP, help from certain HUD programs, or USDA rural housing help. You may also qualify if someone in your home got SSI, TANF, or other qualifying cash assistance in the past year. Tell your provider if any of these apply. They will also confirm who lives in the home.\n\nThe provider may look at recent income or a longer income history. They may count self-employment, rental, or investment income differently. For Social Security, they use the amount after Medicare is taken out.\n\nYou can get help whether you own or rent your home, but you must live there. If you rent, your landlord must agree to the work. Homes that received weatherization in the last 15 years usually cannot get it again.\n\nOlder adults, people with disabilities, and families with children get priority. Households with high energy use or high energy costs may also get priority. To apply, fill out the Kansas Weatherization application. Your county's provider will contact you about next steps.",
+    "description_short": "Free home energy upgrades to lower your bills",
+    "learn_more_link": "https://kshousingcorp.org/weatherization-assistance/",
+    "apply_button_link": "https://kansasepp.formstack.com/forms/weatherization_application_ps",
+    "apply_button_description": "",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": "lump_sum",
+    "website_description": "Free home energy upgrades to lower your bills",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "warning_message": {
+    "external_name": "ks_wap_warning",
+    "calculator": "_show",
+    "message": "Weatherization services may have a waiting list, so help may not be immediate. If your furnace does not work or is unsafe, contact your county provider right away. Emergencies may receive priority."
+  },
+  "navigators": [
+    {
+      "external_name": "ks_wap_211",
+      "name": "Kansas 211",
+      "email": "",
+      "description": "Kansas 211 helps you find local utility, housing, and other support. This is useful while you wait for weatherization services.",
+      "assistance_link": "https://211.org/get-help",
+      "counties": [],
+      "languages": []
+    }
+  ],
+  "documents": [
+    {
+      "external_name": "ks_wap_income_proof",
+      "text": "Proof of income for all household members (ex: pay stubs or benefit letters)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_wap_fuel_release",
+      "text": "Signed Fuel Information Release Form",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_wap_landlord_permission",
+      "text": "Signed Landlord Permission Form, if you rent or rent to own",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_wap_no_income_affidavit",
+      "text": "Notarized statement for anyone age 19 or older with no income or income without proof",
+      "link_url": "",
+      "link_text": ""
+    }
+  ]
+}

--- a/programs/migrations/0175_ks_lieap_on_has_benefits_step.py
+++ b/programs/migrations/0175_ks_lieap_on_has_benefits_step.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+# Kansas has no energy-assistance tile on the has-benefits step, so no
+# CurrentBenefit row for LIEAP can ever be written and `has_base_benefit("liheap")`
+# is false on every Kansas screen. ks_wap admits a LIEAP household regardless of
+# income — Kansas's most prominently advertised categorical route — so without
+# this flag that route is unreachable.
+#
+# The config file carries the same value for a fresh import; this migration is
+# what moves the rows that already exist. Every other white label with a LIHEAP
+# program (co, il, ma, nc, mo) already has its tile.
+WHITE_LABEL_CODE = "ks"
+NAME_ABBREVIATED = "ks_lieap"
+
+
+def forward(apps, schema_editor):
+    Program = apps.get_model("programs", "Program")
+    Program.objects.filter(white_label__code=WHITE_LABEL_CODE, name_abbreviated=NAME_ABBREVIATED).update(
+        show_in_has_benefits_step=True
+    )
+
+
+def reverse(apps, schema_editor):
+    Program = apps.get_model("programs", "Program")
+    Program.objects.filter(white_label__code=WHITE_LABEL_CODE, name_abbreviated=NAME_ABBREVIATED).update(
+        show_in_has_benefits_step=False
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("programs", "0174_consolidate_missed_program_categories"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/programs/programs/cross_white_label/weatherization/ks.py
+++ b/programs/programs/cross_white_label/weatherization/ks.py
@@ -1,0 +1,242 @@
+from typing import ClassVar
+
+import programs.framework.eligibility_messages as messages
+from programs.framework.base import Eligibility, ProgramCalculator
+from screener.models import HouseholdMember
+
+
+class KsWap(ProgramCalculator):
+    """KS Weatherization Assistance Program — free home energy upgrades
+    (insulation, air sealing, heating repair) delivered by Kansas's local
+    weatherization subrecipients under a Kansas Housing Resources Corporation
+    subgrant.
+
+    Eligibility (see specs/ks.md) is `(criterion 1 OR criterion 3) AND
+    criterion 4 AND criterion 5`. Categorical receipt substitutes for the
+    income test; it is never ANDed with it.
+
+      * Criterion 1: countable annual income at or below 200% of the federal
+        poverty guideline for the household size. The program row's `year` pin
+        selects the guideline edition — 2026, whose 200% figures reproduce the
+        table KHRC prints on its own application exactly, at every size from 1
+        to 16 ($31,920 / $43,280 / $54,640 / $66,000 … $202,320).
+      * Criterion 2 defines what "income" means for criterion 1: gross cash
+        receipts less the exclusions the current DOE Weatherization Program
+        Notice lists. See `excluded_income_types` and
+        `student_excluded_income_types`.
+      * Criterion 3: categorical income eligibility. Kansas admits a household
+        currently receiving SSI, TANF (which Kansas administers as TAF) or
+        LIEAP, and has also taken both DOE expansions to HUD and USDA
+        means-tested programs — of which Section 8 / HCV is the only one MFB
+        records. Any one of these bypasses the income test outright.
+      * Criterion 6 fixes the unit both criteria measure over: WAP's family
+        unit is everyone living in the dwelling. `household_size` and the
+        entered member list are used as entered, never reconstructed from
+        tax-unit or relationship fields — the Kansas LIEAP convention.
+
+    Handled outside the calculator:
+      * Criterion 4 (at least one citizen or Qualified Alien resides at the
+        address) — the program's `legal_status_required` config, which commits
+        to citizen / gc_5plus / gc_5less / refugee / otherWithWorkPermission and
+        excludes the generic `non_citizen`.
+      * Criterion 5 (the dwelling is in Kansas) — white-label routing. Each
+        subrecipient must serve the whole of its own territory, so service area
+        adds no restriction inside Kansas.
+      * Priority order (emergencies; then age 60+, disabled, families with
+        children 18 or under; then high energy use or burden). These set the
+        order of a waiting list among households already eligible, not whether
+        one qualifies.
+
+    Data gaps, none of which the calculator treats as disproving eligibility:
+      * The HUD and USDA categorical routes beyond Section 8 / HCV, and cash
+        assistance received earlier in the preceding twelve months, are
+        affirmative pathways MFB cannot observe. Absence of a record is not
+        read as proof the pathway does not apply — but neither is it inferred
+        true, which would resolve the eligibility disjunction for every Kansas
+        household and reduce criterion 1 to dead code. They are disclosed to
+        the user in the program description instead.
+      * `selfEmployment`, `rental`, `boarder` and `investment` are dropped in
+        full because MFB cannot produce the net figures the notice counts (see
+        `excluded_income_types`). This is the one inclusive proxy that can
+        produce an actionable false positive.
+      * The full-time high-school-student disregard is applied to any full-time
+        student regardless of age, because MFB records no level of schooling.
+        Over-excluding lowers countable income, so it can only widen results.
+      * Income is compared as the annualized current recurring figure MFB
+        holds. `IncomeStream` carries no dates, so Kansas's twelve-month and
+        three-month-annualized methods cannot be reproduced.
+      * Occupancy of the dwelling applied for, dwelling type, and the 15-year
+        re-weatherization bar are not collected at all.
+
+    SNAP is deliberately absent. Kansas's categorical list names SSI, TANF and
+    LIEAP, and the DOE expansions reach HUD and USDA programs — not SNAP. So
+    unlike `tx_wap`, `cowap` and `wa_wap`, SNAP receipt does not qualify here.
+
+    Benefit value is a flat $7,475 — Kansas's most recently published average
+    program-operations cost per dwelling unit ($7,474.93, 2025 state plan),
+    rounded to the dollar. `value_format: lump_sum` on the program row: the
+    measures are installed once, and this estimates the in-kind work rather
+    than promising a payment.
+    """
+
+    program_code = "ks_wap"
+
+    #: Kansas's average cost per weatherized dwelling unit — an estimate of the
+    #: in-kind work, delivered once. Not a payment and not a ceiling: the
+    #: $8,550 figure in the same state plan caps the grantee's statewide
+    #: average, not what one household receives.
+    amount = 7_475
+
+    #: 42 U.S.C. § 6862(7)(A) and 10 CFR 440.22(a)(1). The `year` pin on the
+    #: program row, not this multiple, is what selects the guideline edition.
+    fpl_percent = 2
+
+    #: Excluded from countable income for every member.
+    #:
+    #: `childSupport` because DOE WPN 25-3 Section E excludes it on both sides,
+    #: and `gifts` per Section C — those two are the notice's own policy
+    #: exclusions. The rest are MFB inclusive proxies standing in for figures
+    #: MFB cannot compute: `selfEmployment`, `rental` and `boarder` because the
+    #: notice counts those *net* of business, farm and property expenses (B.2,
+    #: B.6) and MFB collects no such expense; `investment` because MFB's single
+    #: figure fuses countable dividends and interest (B.5) with excluded
+    #: capital gains (C.1) and cannot split them.
+    #:
+    #: `alimony` is countable (B.3) and deliberately stays in.
+    excluded_income_types: ClassVar[tuple[str, ...]] = (
+        "childSupport",
+        "gifts",
+        "selfEmployment",
+        "rental",
+        "boarder",
+        "investment",
+    )
+
+    #: Also excluded for a member WPN 25-3 Section D.1 disregards: "earned
+    #: income or unemployment compensation for minors under the age of 18 (or
+    #: full-time high school students)". Their unearned income — SSI, a
+    #: survivor benefit — still counts. `selfEmployment` is the third earned
+    #: stream and is already excluded for everyone above.
+    student_excluded_income_types: ClassVar[tuple[str, ...]] = ("wages", "unemployment")
+
+    #: Section D.1's age threshold. Under this the disregard is outright,
+    #: whatever the member's student status.
+    minor_age = 18
+
+    #: Income streams that evidence a categorical route on their own, mapped to
+    #: the base program each one stands for. The stream test is a backstop to
+    #: the current-benefit row, not a replacement for it: the single-benefit
+    #: toggle endpoint does not re-derive the current-benefit row, so a screen
+    #: can carry the stream without the row. For TANF it is doing the whole job
+    #: — MFB files TANF dollars under `cashAssistance` and never under `tanf`.
+    categorical_income_types: ClassVar[tuple[str, ...]] = ("sSI", "cashAssistance")
+
+    #: Base programs whose current receipt admits the household outright.
+    #: Matched structurally so any white-label variant counts: `ks_ssi`,
+    #: `ks_tanf` and `ks_lieap` today, and a Kansas voucher row the day one is
+    #: added. `section_8` is wired ahead of the data — Kansas has no HCV row, so
+    #: it changes no current verdict.
+    categorical_base_programs: ClassVar[tuple[str, ...]] = ("ssi", "tanf", "liheap", "section_8")
+
+    dependencies: ClassVar[list[str]] = [
+        "household_size",
+        "income_amount",
+        "income_frequency",
+    ]
+
+    def household_eligible(self, e: Eligibility):
+        # Criterion 3 substitutes for the income test rather than adding to it.
+        if self._categorically_eligible():
+            e.condition(True, messages.presumed_eligibility())
+            return
+
+        # Criterion 1
+        income_limit = self._income_limit()
+
+        if income_limit is None:
+            # household_size is nullable, and the limit is indexed to it. With
+            # no size there is no row to compare against, so the criterion is
+            # met rather than guessed at. No message: naming a $0 limit the
+            # household did not have to clear would misreport why it passed.
+            # Unreachable in production — household_size is a declared
+            # dependency, so can_calc() drops the program first.
+            e.condition(True)
+            return
+
+        income = self._countable_income()
+        e.condition(income <= income_limit, messages.income(income, income_limit))
+
+    def _income_limit(self) -> int | None:
+        """200% of the federal poverty guideline for the household size, or
+        None when no size was entered.
+
+        Read through ``get_limit`` rather than ``as_dict()[household_size]``:
+        the dict holds explicit rows only to size 8, and Kansas publishes its
+        table to 16. The helper extends past 8 by the per-additional-person
+        amount, which is exactly how KHRC's own printed table is built — its
+        sizes 9 through 16 are $122,800 through $202,320, and 200% of the 2026
+        guideline reproduces every one of them.
+        """
+        household_size = self.screen.household_size
+        if household_size is None:
+            return None
+
+        return int(self.fpl_percent * self.program.year.get_limit(household_size))
+
+    def _countable_income(self) -> float:
+        """Annual gross income less WPN 25-3's exclusions, summed across the
+        household as entered.
+
+        Rounded to cents rather than truncated: the boundary is inclusive, so a
+        household $0.50 over its limit must fail, and ``int()`` would floor it
+        back onto the limit and admit it. Rounding at cents also absorbs the
+        float artifacts a Decimal-to-float sum leaves behind, which would
+        otherwise flip an exactly-at-limit household.
+        """
+        total = 0.0
+
+        for member in self.screen.household_members.all():
+            exclude = list(self.excluded_income_types)
+            if self._earned_income_disregarded(member):
+                exclude += list(self.student_excluded_income_types)
+            total += member.calc_gross_income("yearly", ["all"], exclude=exclude)
+
+        return round(total, 2)
+
+    def _earned_income_disregarded(self, member: HouseholdMember) -> bool:
+        """Whether Section D.1 disregards this member's earned income and
+        unemployment compensation.
+
+        Under 18 is the exact test and needs nothing else. The clause's "(or
+        full-time high school students)" half is honoured at any age, because
+        MFB records no level of schooling — `student_full_time` is the same
+        flag a full-time college student sets. Applying it too widely can only
+        lower countable income, so it widens results rather than producing a
+        false negative (Data Gap 6).
+
+        Read as `student and student_full_time`, matching
+        `FullTimeCollegeStudentDependency`. `student_full_time` is only asked
+        once `student` is ticked, but nothing enforces that server-side, so the
+        conjunction keeps a non-student's wages counted.
+
+        A member of unknown age with no student flag is treated as an adult:
+        the disregard is granted on proof, not assumed without it.
+        """
+        if bool(member.student and member.student_full_time):
+            return True
+
+        age = member.calc_age()
+        if age is None:
+            return False
+
+        return age < self.minor_age
+
+    def _categorically_eligible(self) -> bool:
+        """Criterion 3 — whether a non-income route admits the household
+        outright, by either the current-benefit row or the income stream that
+        evidences the same receipt."""
+        for base_program in self.categorical_base_programs:
+            if self.screen.has_base_benefit(base_program):
+                return True
+
+        return self.screen.calc_gross_income("yearly", list(self.categorical_income_types)) > 0

--- a/programs/programs/cross_white_label/weatherization/ks.py
+++ b/programs/programs/cross_white_label/weatherization/ks.py
@@ -19,7 +19,11 @@ class KsWap(ProgramCalculator):
         poverty guideline for the household size. The program row's `year` pin
         selects the guideline edition — 2026, whose 200% figures reproduce the
         table KHRC prints on its own application exactly, at every size from 1
-        to 16 ($31,920 / $43,280 / $54,640 / $66,000 … $202,320).
+        to 16 ($31,920 / $43,280 / $54,640 / $66,000 … $202,320). Only sizes 1
+        through 8 are reachable in practice: the screener caps household size
+        at 8, and that cap is not per-white-label. The threshold arithmetic
+        above 8 is correct and tested, but no Kansas household can currently
+        reach it.
       * Criterion 2 defines what "income" means for criterion 1: gross cash
         receipts less the exclusions the current DOE Weatherization Program
         Notice lists. See `excluded_income_types` and
@@ -176,6 +180,13 @@ class KsWap(ProgramCalculator):
         amount, which is exactly how KHRC's own printed table is built — its
         sizes 9 through 16 are $122,800 through $202,320, and 200% of the 2026
         guideline reproduces every one of them.
+
+        Sizes above 8 are not reachable today: the screener's household-size
+        step caps at 8 for every white label. ``get_limit`` is still the right
+        call rather than clamping to 8 — there is no hardcoded table here to
+        truncate, a clamp would silently understate the limit for a large
+        household if the cap is ever raised, and the extrapolation is already
+        the published Kansas figure.
         """
         household_size = self.screen.household_size
         if household_size is None:

--- a/programs/programs/cross_white_label/weatherization/specs/ks.md
+++ b/programs/programs/cross_white_label/weatherization/specs/ks.md
@@ -214,14 +214,20 @@ Sixteen core scenarios, all executable against the current screener. Location ap
 - Config-level criteria are tested outside this calculator suite: legal status (criterion 4) is the program row's `legal_status_required`, and Kansas routing (criterion 5) is the white label.
 - The committed data gaps have no executable scenarios, because the screener cannot observe them.
 - Section 8 / HCV has no executable Kansas scenario: no Kansas `section_8` program row exists.
-- LIEAP and household sizes 9–16 are covered by the binding implementation regressions below.
+- LIEAP is covered by binding implementation requirement 1 below.
+- **Household sizes 9–16 are not reachable.** The screener caps household size at 8, so no scenario above that size can be entered. Sizes 1–8 are the full testable range; requirement 2 below records what was and was not delivered.
 
 **Binding implementation requirements**
 
-Both are committed build requirements for this program.
+Both were committed build requirements for this program. Requirement 1 is delivered; requirement 2 is delivered on the calculator side only.
 
-1. **LIEAP current-benefit visibility.** Set `ks_lieap.show_in_has_benefits_step = true` and add an energy-assistance category to the Kansas current-benefits step. Until both land, no `CurrentBenefit` row for LIEAP can be written, `has_base_benefit("liheap")` is false on every Kansas screen, and criterion 3's LIEAP route cannot fire. Illinois, Colorado and North Carolina all carry an energy option; Kansas does not. Required regression once the input is enterable: an over-income Kansas household with current `ks_lieap` → **Eligible — $7,475**. It becomes ordinary core scenario coverage at that point.
-2. **Kansas household sizes 1–16.** The Kansas white label must permit household sizes 1–16 in both the household-size entry and the household-member flow; other white labels retain their existing maximum. `KsWap` must read the threshold through `program.year.get_limit(household_size)`. Required regression: ZIP `66603`, Shawnee County, household size 10, countable annual income $134,160 → **Eligible — $7,475**, with no error. Kansas's PolicyEngine-backed programs must also be exercised at sizes 9–16, since raising the cap sends them inputs they have never received.
+1. **LIEAP current-benefit visibility — delivered.** `ks_lieap.show_in_has_benefits_step` is set to `true` (in the program's config and, for rows that already exist, migration `0175_ks_lieap_on_has_benefits_step`). No separate white-label or frontend change was needed: the has-benefits step is data-driven, rendering whatever `/api/has_benefits_programs/{white_label}` returns and grouping it by the program's own category. Until this landed, no `CurrentBenefit` row for LIEAP could be written, `has_base_benefit("liheap")` was false on every Kansas screen, and criterion 3's LIEAP route could not fire. Regression, now ordinary coverage: an over-income Kansas household with current `ks_lieap` → **Eligible — $7,475**.
+
+2. **Kansas household sizes 1–16 — calculator only; the screener still caps at 8.**
+   - **Delivered:** `KsWap` reads the threshold through `program.year.get_limit(household_size)`, never `as_dict()[household_size]`. That extends past size 8 by the per-additional-person amount and reproduces KHRC's printed rows for 9 through 16 exactly ($122,800 … $202,320). Unit-tested at every published size, including 10 and 16.
+   - **Not delivered:** the screener does not accept a household larger than 8. The cap is a hardcoded `.lte(8)` in `benefits-calculator` (`src/Components/Steps/HouseholdSize/HouseholdSize.tsx`), not a per-white-label setting, so Kansas cannot be raised on its own without a frontend change. A Kansas household of 9 or more therefore cannot be screened at all, and this program's sizes 9–16 support is unreachable in production.
+   - **Why it was not done here:** raising the cap is cross-cutting rather than KS-specific. Twelve calculators and urgent needs index `program.year.as_dict()[household_size]` directly and would raise `KeyError` above size 8 — and because `screener/views.py` catches only `DependencyError` around the per-program loop, that would 500 the entire eligibility response rather than dropping one program. HUD publishes AMI only for sizes 1–8 (and the client enforces it), and the SMI service has its own `MAX_HOUSEHOLD_SIZE = 8`, so ~28 programs have no upstream limit to read above 8. Kansas's PolicyEngine-backed programs have also never received a household that large.
+   - **Tracked in MFB-1869**, an investigation into whether and how to raise the cap. Until it concludes, treat size 8 as this program's effective maximum.
 
 ### Scenario 1: Four-person household under the income limit — Eligible, $7,475
 **What we're checking**: the reference case — income comfortably within the limit for the household's size.

--- a/programs/programs/cross_white_label/weatherization/specs/ks.md
+++ b/programs/programs/cross_white_label/weatherization/specs/ks.md
@@ -1,0 +1,459 @@
+# Weatherization Assistance Program (KS) — Program Spec
+
+- **Program key**: `ks_wap` (`programs/programs/cross_white_label/weatherization/ks.py`, class `KsWap`)
+- **Base federal program**: Weatherization Assistance Program for Low-Income Persons (U.S. Department of Energy), 42 U.S.C. §§ 6861–6873 and 10 CFR part 440 — `base_program: wap`
+- **White label**: KS
+- **Engine**: MFB custom
+- **Added to MFB**: not yet added
+- **Policy year**: 2026
+- **Spec last updated**: 2026-09-03
+- **Sources verified as of**: 2026-09-02
+
+## Covered Eligibility Criteria
+
+**(criterion 1 OR criterion 3) AND criterion 4 AND criterion 5.** Categorical receipt substitutes for the income test; it is never ANDed with it. Criterion 2 defines the income criterion 1 measures, and criterion 6 defines the unit both are measured over.
+
+1. **The household's income is at or below 200 percent of the federal poverty level for its size.**
+   - Evaluation scope: `household`
+   - Captured via: countable income as defined by criterion 2, compared against `household_size` (Screen, IntegerField)
+   - Implementation:
+     - `countable_income <= fpl_percent * program.year.get_limit(household_size)`, with `fpl_percent = 2.0` as a class constant.
+     - Read the threshold through `program.year.get_limit(household_size)`. Never index `program.year.as_dict()[household_size]` — that raises `KeyError` above the table's explicit rows, while the helper extrapolates.
+     - The comparison is inclusive (`<=`).
+     - `household_size` is nullable. When absent, treat the criterion as met rather than comparing.
+     - The poverty edition is configuration, not a constant: the program row's `year: "2026"` reproduces Kansas's printed limits exactly — 200 percent of the 2026 one-person guideline of $15,960 is the $31,920 Kansas prints.
+   - Source: 42 U.S.C. § 6862(7)(A) — "is at or below 200 percent of the poverty level determined in accordance with criteria established by the Director of the Office of Management and Budget" — [snapshot `2026-08-26--42-usc-6862`](../../../sources/ks/ks_wap/2026-08-26--42-usc-6862/content.md), accessed 2026-08-26
+   - Source: 10 CFR 440.22(a)(1) — "Whose income is at or below 200 percent of the poverty level determined in accordance with criteria established by the Director of the Office of Management and Budget," — [snapshot `2026-09-02--10-cfr-440-22`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-22/content.md), accessed 2026-09-02
+   - Source: KHRC standardized weatherization application, revised 2026-02-23, p. 1 "PROGRAM ELIGIBILITY", the operative limits — the printed table interleaves two columns, sizes 1–8 on the left and 9–16 on the right: "Maximum Income for Maximum Income for Family Family Weatherization Weatherization Size Size (200% of FPL) (200% of FPL) 1 $31,920 9 $122,800 2 $43,280 10 $134,160 3 $54,640 11 $145,520 4 $66,000 12 $156,880 5 $77,360 13 $168,240 6 $88,720 14 $179,600 7 $100,080 15 $190,960 8 $111,440 16 $202,320" — [snapshot `2026-08-26--khrc-standardized-wx-application-2026-02-23`](../../../sources/ks/ks_wap/2026-08-26--khrc-standardized-wx-application-2026-02-23/content.md), accessed 2026-08-26
+   - Source: HHS ASPE, 2026 poverty guidelines, identifying that table's edition — the one-person figure "15,960.00" doubles to the $31,920 Kansas publishes, under the heading "2026 Poverty Guidelines: 48 Contiguous States (all states except Alaska and Hawaii) Dollars Per Year Household/ Family Size 50% 75% 100" — [snapshot `2026-08-26--hhs-2026-poverty-guidelines`](../../../sources/ks/ks_wap/2026-08-26--hhs-2026-poverty-guidelines/content.md), accessed 2026-08-26
+
+2. **Countable income is gross cash receipts before taxes, less the exclusions the current DOE Weatherization Program Notice lists, and excluding the earned income and unemployment compensation of members under 18 or in full-time high school. Self-employment and rental income count at their *net* amount.**
+   - Evaluation scope: `household`
+   - Captured via: accessor `HouseholdMember.calc_gross_income("yearly", ["all"], exclude=[…])`, summed across members
+   - Implementation, in calculation order:
+     1. For each `HouseholdMember`, start from the base exclusion list: `childSupport`, `gifts`, `selfEmployment`, `rental`, `boarder`, `investment`.
+     2. If that member's `calc_age()` is under 18, or the member is `student` and `student_full_time`, add `wages` and `unemployment` to their exclusions.
+     3. Annualize: `calc_gross_income("yearly", ["all"], exclude=<that member's list>)`.
+     4. Sum across members. No rounding.
+   - The base list has two halves that must not be conflated. **DOE policy exclusions**: `childSupport`, `gifts`. **MFB inclusive proxies**, standing in for figures MFB cannot compute: `selfEmployment`, `rental`, `boarder`, `investment` (Data Gap 7). `alimony` is countable and stays in.
+   - Kansas states no income definition of its own; it defers wholesale to the DOE notice, so the notice's definition *is* the Kansas rule. Income-stream spellings are verbatim from `configuration/white_labels/base.py`; Kansas ships no `income_options_by_category` override. Two further limits on the same definition are Data Gap 8 (the period the income is measured over) and Data Gap 9 (the Medicare deduction on a Social Security benefit letter).
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40), the deferral that makes the DOE notice controlling — "Definition of Income- Income shall be defined by the most recent DOE issued WPN in effect. Income guidance comes in WPNs labeled as WPN “year” - 3." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment "Definition of Income" § A — "Income means Cash Receipts earned and/or received by the applicant before taxes during applicable tax year(s) but not the Income Exclusions listed below in Section C. Gross Income is to be used, not Net Income." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § B.2 and § B.6, the two net-figure categories — "Net receipts from non-farm or farm self-employment (receipts from a person's own business or from an owned or rented farm after deductions for business or farm expenses)." and "Net rental income and net royalties." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § C, the exclusions — "Capital gains." and "Gifts, loans, or lump-sum inheritances." and "Child support, as defined below in Section E." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § E, child support in both directions — "Child Support payments, whether received by the Payee or paid by the Payor, are not considered Sources of Income to be added to the payee income or deducted from the payor income for the purposes of determining applicant eligibility." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § D.1, the minor rule — "Do not count, or enter, earned income or unemployment compensation for minors under the age of 18 (or full-time high school students) at the time of the application." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § B.3, alimony countable — "Regular payments from social security, railroad retirement, unemployment compensation, strike benefits from union funds, worker's compensation, veteran's payments, training stipends, alimony, and military family allotments." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+
+3. **A household containing a member who currently receives SSI, TANF or LIEAP, or whose screen records a Section 8 / Housing Choice Voucher benefit, is income-eligible whatever its income.**
+   - Evaluation scope: `household`
+   - Implementation: `SSI OR TANF OR LIEAP OR Section 8/HCV` → skip the criterion 1 income test.
+     - **SSI** — `Screen.has_base_benefit("ssi")`, or `Screen.calc_gross_income("yearly", ["sSI"]) > 0`. The stream test is a backstop: the single-benefit toggle endpoint does not re-derive the current-benefit row, so a screen can carry the stream without the row.
+     - **TANF** — `Screen.has_base_benefit("tanf")`, or `Screen.calc_gross_income("yearly", ["cashAssistance"]) > 0`. MFB files TANF dollars under `cashAssistance` and never `tanf`, so the stream test is required, not optional. Kansas administers TANF under the name TAF; one program row, `ks_tanf`, backs both names.
+     - **LIEAP** — `Screen.has_base_benefit("liheap")`. Wire it now; it returns false on every Kansas screen until the white-label change in Test Scenarios ships.
+     - **Section 8 / HCV** — `Screen.has_base_benefit("section_8")`. Wired and inert: Kansas has no voucher program row, so it changes no current verdict and activates on its own if one is added. It reaches only Section 8 / HCV; the other HUD means-tested programs are Data Gap 1.
+   - The sourced rule also reaches *past* receipt, which MFB cannot see — Data Gap 3.
+   - Source: KHRC, Weatherization Assistance Program page — "Households that receive Supplemental Security Income (SSI), Temporary Assistance for Needy Families (TANF), or utility assistance from the Low Income Energy Assistance Program (LIEAP) are automatically income-eligible." — [snapshot `2026-08-26--khrc-weatherization-assistance`](../../../sources/ks/ks_wap/2026-08-26--khrc-weatherization-assistance/content.md), accessed 2026-08-26
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40) — "Applicants receiving LIEAP Utility Assistance from Kansas Department of Children and Families (KDCF) during the current program year will automatically income-qualify for weatherization services." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+   - Source: 10 CFR 440.22(a)(3), the election Kansas has taken — "If the State elects, is eligible for assistance under the Low-Income Home Energy Assistance Act of 1981, provided that such basis is at least 200 percent of the poverty level determined in accordance with criteria established by the Director of the Office of Management and Budget." — [snapshot `2026-09-02--10-cfr-440-22`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-22/content.md), accessed 2026-09-02
+   - Source: 10 CFR 440.22(a)(2) — "Which contains a member who has received cash assistance payments under Title IV or XVI of the Social Security Act or applicable State or local law at any time during the 12-month period preceding the determination of eligibility for weatherization assistance; or" — [snapshot `2026-09-02--10-cfr-440-22`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-22/content.md), accessed 2026-09-02
+   - Source: DOE Weatherization Program Notice 22-5 v3, "PURPOSE", the HUD route — "include U.S. Department of Housing and Urban Development’s (HUD) means-tested programs’ income qualifications at or below 80% of Area Median Income." — [snapshot `2026-08-26--doe-wpn-22-5-v3-hud-categorical`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-22-5-v3-hud-categorical/content.md), accessed 2026-08-26
+
+4. **At least one United States citizen or Qualified Alien resides at the address.**
+   - Evaluation scope: `config`
+   - Captured via: the program row's `legal_status_required`, set to `["citizen", "gc_5plus", "gc_5less", "refugee", "otherWithWorkPermission"]`. Not calculator logic.
+   - Implementation: the filter matches a household holding at least one listed status, which is the rule exactly — one qualifying resident satisfies it, so a mixed-status household passes on that member. `non_citizen` is deliberately excluded: including it would extend the program to households in which no resident is a citizen or Qualified Alien, the case Kansas's signed certification rules out. Qualified Alien carries its statutory definition.
+   - Source: Subrecipient Procedure Manual 2025 v3, "Qualified Aliens Eligibility" (manual p. 42) — "All client files will contain the signed Eligibility Certification statement “I certify that there is at least one United States citizen or Qualified Alien who resides at the address listed on this application. Qualified Alien is defined in section 431 of the Personal Responsibility and Work Opportunity Reconciliation Act of 1996.”" — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+5. **The dwelling is in Kansas.**
+   - Evaluation scope: `config`
+   - Captured via: white-label routing — a screen reaching the `ks` white label is in Kansas; `assumed-met` in the calculator
+   - Implementation: service area adds no further restriction. Each subrecipient must cover the whole of its own territory, so no Kansas address is outside the program.
+   - Source: Kansas Weatherization State Plan 2025, § V.1.1 — "shall be eligible for weatherization assistance in Kansas" — [snapshot `2026-08-26--ks-weatherization-state-plan-2025-draft`](../../../sources/ks/ks_wap/2026-08-26--ks-weatherization-state-plan-2025-draft/content.md), accessed 2026-08-26
+   - Source: Subrecipient Procedure Manual 2025 v3, "Priority Groups" (manual p. 42), on coverage being complete — "Local agencies are required to serve their entire geographic area. Each county shall receive, at a minimum, service once every two years." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+6. **The unit measured is the family unit: all persons living together in the dwelling.**
+   - Evaluation scope: `household`
+   - Captured via: `household_size` (Screen, IntegerField) and the entered `HouseholdMember` list, which are what criteria 1 and 2 read
+   - Implementation: use `household_size` and the entered member list **as entered**, for both the poverty-table row and the countable-income sum. Do **not** reconstruct the unit from tax-unit status or relationship fields. This follows the Kansas LIEAP convention, which also treats the unit as everyone living at the address.
+   - The proxy is imperfect in both directions, and neither direction is observable: MFB's household-size step includes a spouse "even if you file taxes separately or live apart" (broader than the family unit), and includes another resident "only ... if you buy and prepare the majority of your food together" (narrower). Residual limitation: Data Gap 4.
+   - Source: 10 CFR 440.3 — "Family Unit means all persons living together in a dwelling unit." — [snapshot `2026-09-02--10-cfr-440-3`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-3/content.md), accessed 2026-09-02
+   - Source: 10 CFR 440.22(a) — "A dwelling unit shall be eligible for weatherization assistance under this part if it is occupied by a family unit:" — [snapshot `2026-09-02--10-cfr-440-22`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-22/content.md), accessed 2026-09-02
+
+## Missing Eligibility Criteria (Data Gaps)
+
+Every gap below carries one committed treatment.
+
+**Shared convention, gaps 1–3.** For an affirmative categorical pathway MFB cannot observe, absence of an MFB record is not treated as proof that the pathway does not apply. The calculator evaluates every observable income and current-benefit route; the unobservable route cannot independently activate eligibility, and it is disclosed to the user. It is not inferred true either — assuming an OR-branch met would resolve the eligibility disjunction for every Kansas household and reduce criterion 1 to dead code.
+
+1. **HUD means-tested categorical route**
+   - Rule: a household qualifying under a HUD means-tested program is income-eligible whatever its income.
+   - MFB handling: shared convention above. The Section 8 / HCV sliver is already wired in criterion 3 and becomes live if a Kansas voucher row lands; public housing, TBRA and the non-housing HUD programs have no MFB representation at all.
+   - Effect: disclosure-only.
+   - User-facing: yes.
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40) — "WPN 22-5 extended categorical income eligibility to HUD means-tested programs." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+   - Source: Subrecipient Procedure Manual 2025 v3, "Eligibility Determined by Outside Agency/Program" (manual p. 40), what Kansas accepts as proof — "such as a copy of the LIEAP list, USDA or HUD eligibility documentation (TBRA, Section 8 or public housing eligibility), will suffice as evidence of client eligibility" — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+2. **USDA means-tested categorical route**
+   - Rule: a household qualifying under a select USDA means-tested program at or below 80 percent of area median income is income-eligible whatever its income.
+   - MFB handling: shared convention above. MFB has no representation of any USDA means-tested program in any white label, so there is nothing to wire.
+   - Effect: disclosure-only.
+   - User-facing: yes.
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40) — "WPN 25-4 extended categorical income eligibility to select U.S. Department of Agriculture (USDA) means-tested programs at 80% AMI or below." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+   - Source: DOE Weatherization Program Notice 25-4, "BACKGROUND" — "USDA’s means-tested low-income programs accept households using 80% AMI or below, depending on specific program parameters." — [snapshot `2026-08-26--doe-wpn-25-4-usda-categorical`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-4-usda-categorical/content.md), accessed 2026-08-26
+
+3. **Cash assistance received in the prior 12 months**
+   - Rule: past receipt qualifies a household, not only present receipt — cash assistance at any point in the preceding twelve months.
+   - MFB handling: shared convention above. The current-benefit table is a screen-to-program join with no dates and no field records a formerly-held benefit, so the lookback cannot be modelled; current receipt is sufficient positive evidence.
+   - Effect: disclosure-only. The affected population is ordinary rather than marginal — leaving TANF or SSI for work is the standard exit path and income at exit routinely lands above the limit — so the description names this route explicitly.
+   - User-facing: yes.
+   - Source: 10 CFR 440.22(a)(2) — "at any time during the 12-month period preceding the determination of eligibility for weatherization assistance" — [snapshot `2026-09-02--10-cfr-440-22`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-22/content.md), accessed 2026-09-02
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40), defining the window — "“During the 12- month period” is defined as having received within the 12-month period but not restricted to the entire period during that program year." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+4. **Family unit vs MFB household**
+   - Rule: WAP counts all persons living together in the dwelling. MFB does not independently observe who lives at the address.
+   - MFB handling: the committed proxy in criterion 6 — `household_size` and the entered member list, used as entered, never reconstructed from tax-unit or relationship fields.
+   - Effect: non-uniform. The mismatch runs in both directions, and a smaller unit means a lower poverty-table row but also less income counted, so the direction of error is not fixed.
+   - User-facing: yes — the description says the provider will confirm who lives in the home.
+   - Source: 10 CFR 440.3 — "Family Unit means all persons living together in a dwelling unit." — [snapshot `2026-09-02--10-cfr-440-3`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-3/content.md), accessed 2026-09-02
+
+5. **Occupancy of the dwelling applied for**
+   - Rule: the household must occupy the dwelling for which it is applying.
+   - MFB handling: `assumed-met`. The screener collects no housing or tenure information — `housing_situation` exists as a column on `Screen` but is not collected, is absent from `ScreenSerializer`, is never assigned by the frontend, and is read by no calculator.
+   - Effect: inclusive — widens results, for households with no dwelling to weatherize.
+   - User-facing: yes — the description must tell the applicant they have to live in the home they are applying for.
+   - Source: 10 CFR 440.22(a) — "A dwelling unit shall be eligible for weatherization assistance under this part if it is occupied by a family unit:" — [snapshot `2026-09-02--10-cfr-440-22`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-22/content.md), accessed 2026-09-02
+   - Source: KHRC standardized weatherization application, revised 2026-02-23, p. 1 "PROGRAM ELIGIBILITY" — "You and your household must occupy the home that you are applying to receive assistance with through this Program." — [snapshot `2026-08-26--khrc-standardized-wx-application-2026-02-23`](../../../sources/ks/ks_wap/2026-08-26--khrc-standardized-wx-application-2026-02-23/content.md), accessed 2026-08-26
+   - Source: Subrecipient Procedure Manual 2025 v3, "Eligible Rental Units" (manual p. 44), tenure being neutral — "Renter occupied housing units are eligible for weatherization services if they meet all other eligibility requirements." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+6. **Full-time high-school student**
+   - Rule: the earned income and unemployment compensation of a full-time high-school student is excluded regardless of age.
+   - MFB handling: inclusive proxy. Criterion 2 implements the under-18 half exactly from `birth_year_month`; for the other half, `student` and `student_full_time` (HouseholdMember, BooleanField) record full-time student status without distinguishing high school from college, so the exclusion applies at any age.
+   - Effect: inclusive — widens results. It over-excludes full-time college students' wages, which lowers countable income and so cannot turn an eligible household ineligible.
+   - Source: DOE WPN 25-3, Attachment § D.1 — "Do not count, or enter, earned income or unemployment compensation for minors under the age of 18 (or full-time high school students) at the time of the application." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+
+7. **Net self-employment and rental income, and capital gains**
+   - Rule: self-employment and rental income count at their net amount, and capital gains are excluded from otherwise-countable dividends and interest.
+   - MFB handling: inclusive proxy. MFB collects no business, farm or rental expense fields, so it cannot derive a net figure from a reported gross one; and its `investment` stream fuses countable dividends and interest with excluded capital gains into one number that cannot be split. `selfEmployment`, `rental`, `boarder` and `investment` are therefore excluded in full. `boarder` is grouped here because MFB files it with `rental` and it carries the same net-figure problem, though the notice does not name it.
+   - Effect: inclusive — widens results, since dropping a whole stream can only lower countable income. This is the one gap whose inclusive direction produces an actionable false positive: a household reporting substantial self-employment, rental or investment income can be shown eligible on income Kansas will in fact count.
+   - User-facing: yes — the description says the provider may count self-employment, rental, or investment income differently.
+   - Source: DOE WPN 25-3, Attachment § B.2 — "Net receipts from non-farm or farm self-employment (receipts from a person's own business or from an owned or rented farm after deductions for business or farm expenses)." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § B.6 — "Net rental income and net royalties." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+   - Source: DOE WPN 25-3, Attachment § B.5 and § C.1, the split MFB cannot make — "Dividends and/or interest." and "Capital gains." — [snapshot `2026-08-26--doe-wpn-25-3-poverty-income-guidelines`](../../../sources/ks/ks_wap/2026-08-26--doe-wpn-25-3-poverty-income-guidelines/content.md), accessed 2026-08-26
+
+8. **Income measurement period**
+   - Rule: income is verified or calculated for the one-year period prior to the certification month, may be annualized from a shorter recent period (Kansas's stated method is the most recent three months × 4), and a household found ineligible on the three-month average may provide twelve months of documentation for re-determination. The choice of method is the subrecipient's.
+   - MFB handling: compare the annualized current recurring figure MFB holds — of Kansas's own accepted methods, the closest to what the screener collects. `IncomeStream` carries `amount` and `frequency` and no dates, so no history exists to use: fabricate none, and make no inference in either direction about the twelve-month route.
+   - Effect: non-uniform. It widens results where income has recently fallen and narrows them where it has recently risen.
+   - User-facing: yes — the description says the provider may look at recent income or a longer income history.
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40) — "Applicant income must be verified or calculated for the one-year period prior to the certification month. Income data for a part of a year may be annualized to determine eligibility. For example, by multiplying by four the amount of income received during the most recent three months. A minimum of three months’ income documentation must be available." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40), the route back from an adverse three-month result — "If the household is determined to be ineligible based on the average income for three months, the applicant should be notified that 12 months of documentation may be provided to re-determine eligibility." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+   - Source: Kansas Weatherization State Plan 2025, § V.1.2, the choice of method belonging to the agency — "The method of calculation is to be determined by the Subrecipient in accordance with WPN 22-3 and the Subrecipient Procedures Manual and should be uniformly applied." — [snapshot `2026-08-26--ks-weatherization-state-plan-2025-draft`](../../../sources/ks/ks_wap/2026-08-26--ks-weatherization-state-plan-2025-draft/content.md), accessed 2026-08-26
+
+9. **Medicare deduction on Social Security**
+   - Rule: when Social Security income is calculated from a benefit letter, the Medicare deduction is not income; Kansas counts the net monthly benefit.
+   - MFB handling: count the Social Security amount as entered and manufacture no deduction. MFB records only whether a member carries Medicare — `medicare` (Insurance, BooleanField, one row per `HouseholdMember`), reached through `has_insurance_types` — never the premium withheld.
+   - Effect: non-uniform. A user who entered their net deposit already matches Kansas; one who entered the gross benefit is over-counted, which is the narrowing direction. MFB cannot tell which was entered.
+   - User-facing: yes — the description says that for Social Security, the provider uses the amount after Medicare is taken out.
+   - Source: Subrecipient Procedure Manual 2025 v3, "Determining Client Income Eligibility" (manual p. 40) — "KWAP has received clarification that when using a Social Security Benefit Letter to calculate income, the deduction for Medicare is not considered income. Use the net value after the Medicare deduction for the monthly benefit." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+## Priority Criteria
+
+Kansas uses these to order a waiting list among households that are already eligible; none affects whether a household qualifies, and none is calculator logic. Entries 2 and 3 are surfaced in the program description; entry 1 and the existence of the waiting list are surfaced in the program config's `warning_message` instead, because both are operational rather than evergreen.
+
+1. **Emergencies outrank every other priority** — life-threatening housing conditions.
+2. **Demographic groups, served first** among ordinary applicants: clients age 60 or over; clients with disabilities; families with children 18 years of age or under.
+3. **Energy tier, reached only by applicants outside those three groups**: high residential energy users — previous 12-month use above 100 MCF of natural gas, 14,000 kWh of electricity or 800 gallons of propane — or a high energy burden, meaning annual energy costs at or above 15 percent of annual household income.
+
+- Source: Subrecipient Procedure Manual 2025 v3, "Priority Groups" (manual p. 42) — "Among eligible clients there are program priorities which the Kansas Weatherization Assistance Program and the weatherization subrecipients observe. Priority is given to:" followed by "Low-income elderly clients (age 60 or over)" and "Low-income families with children 18 years of age or under" — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+- Source: 10 CFR 440.16(b) — "Priority is given to identifying and providing weatherization assistance to:" followed by "Persons with disabilities;" — [snapshot `2026-09-02--10-cfr-440-16`](../../../sources/ks/ks_wap/2026-09-02--10-cfr-440-16/content.md), accessed 2026-09-02
+- Source: Subrecipient Procedure Manual 2025 v3, "Priority Groups" (manual p. 42), the conditional structure — "If applicants are not elderly, disabled, or members of families with children 18 years old or under, they may also be prioritized if they qualify as high residential energy users or a household with a high energy burden." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+- Source: Subrecipient Procedure Manual 2025 v3, "Priority Groups" (manual p. 42), the thresholds — "High energy users are households who’s previous 12-month energy use exceeds 100 MCF of natural gas or 14,000 kWh for electricity or 800 gallons of propane." and "High energy burden households are households where overall annual energy costs are equal to or greater than 15% of the household’s annual income." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+- Source: Subrecipient Procedure Manual 2025 v3, "Priority Groups" (manual p. 42), emergencies — "Emergencies may take precedence over all other priorities. Emergencies are defined as life-threatening housing conditions and shall be documented in the client file." — [snapshot `2026-08-26--khrc-wx-subrecipient-manual-2025v3`](../../../sources/ks/ks_wap/2026-08-26--khrc-wx-subrecipient-manual-2025v3/content.md), accessed 2026-08-26
+
+## Related Programs
+
+- **Kansas Low Income Energy Assistance Program (LIEAP)** — `ks_lieap`, Kansas's LIHEAP program, administered by the Department for Children and Families rather than KHRC. Current LIEAP receipt is a categorical route into KS WAP (criterion 3). It is otherwise a separate program with its own eligibility and its own value, and nothing about it enters this program's calculation.
+  - Source: KEESM 13000, LIEAP's own income standard, which is not this program's — "Combined income of all persons living at the address must not exceed 150% of the federal poverty level;" — [snapshot `2026-08-26--keesm-13000-lieap`](../../../sources/ks/ks_wap/2026-08-26--keesm-13000-lieap/content.md), accessed 2026-08-26
+
+## Benefit Value
+
+- **Estimated value**: **$7,475**, one time
+- **`value_format`**: `lump_sum`. The program installs measures once; it is not recurring, so no annualization applies.
+- **Type**: an MFB estimate of the in-kind weatherization service. Not a payment, not an entitlement, and not a promise of a fixed amount of work — the measures come from an on-site energy audit and vary by home.
+- **Method**: Kansas's most recently published average program-operations cost per dwelling unit, $7,474.93, rounded to the dollar.
+- **Variation axes**: flat. The audit-selected measures, the fuel type and single-family versus multifamily drive the real cost, and none is derivable from anything the screener collects, so the value does not vary by household and no scenario varies it.
+- **Not the ceiling**: the PY2025 average expenditure limit of $8,550 in the same plan caps what the grantee may average statewide, not what a household receives; the plan's own planning figure of $7,500 sits beside the $7,474.93. Kansas publishes no energy-savings estimate, so a cost-per-unit figure is the only Kansas-specific option.
+- Source: Kansas Weatherization State Plan 2025, § IV.2 WAP Production Schedule — "Average Program Operations Costs per Unit (F divided by G) ..............................................                       $ 7,474.93" and "Total Average Cost per Dwelling Unit (H plus I) ..................................................................              $7,474.93" — [snapshot `2026-08-26--ks-weatherization-state-plan-2025-draft`](../../../sources/ks/ks_wap/2026-08-26--ks-weatherization-state-plan-2025-draft/content.md), accessed 2026-08-26
+- Source: Kansas Weatherization State Plan 2025, § IV.2, the ceiling distinguished — "The PY 2025 average expenditure limit is $8,550 per Weatherization Program Notice 23-1, effective date of December 20, 2024, and shall be the maximum average expenditure allowed. For planning purposes an average of $7,500 will be used which is closer to historical state averages." — [snapshot `2026-08-26--ks-weatherization-state-plan-2025-draft`](../../../sources/ks/ks_wap/2026-08-26--ks-weatherization-state-plan-2025-draft/content.md), accessed 2026-08-26
+
+## Test Scenarios
+
+Sixteen core scenarios, all executable against the current screener. Location appears in every scenario because the screener collects it, but it never discriminates: criterion 5 is satisfied by the white label and coverage is statewide. Every eligible scenario expects the flat $7,475; no scenario varies the value.
+
+**Coverage map**
+
+| Modelable branch | Scenarios |
+|---|---|
+| Income at or below 200% FPL, inclusive boundary (criterion 1) | 1, 2, 3 |
+| Limit indexed to household size (criterion 1) | 4, 5, 16 |
+| Income summed across members; monthly converted to yearly (criterion 1) | 2 |
+| Zero income is $0, not missing data (criterion 1) | 10 |
+| DOE policy exclusions — child support received, gifts (criterion 2) | 11 |
+| Child support *paid* is not a deduction (criterion 2) | 15 |
+| Minor's wages and unemployment excluded (criterion 2) | 12 |
+| Alimony countable (criterion 2) | 13 |
+| Categorical route — SSI, current benefit and income stream (criterion 3) | 6, 7 |
+| Categorical route — TANF, current benefit and `cashAssistance` stream (criterion 3) | 8, 14 |
+| Categorical route — LIEAP (criterion 3) | none yet; see the binding implementation requirements below |
+| SNAP is not a categorical route (criterion 3) | 9 |
+| Value | flat $7,475 in every eligible scenario |
+
+**Known scenario gaps**
+
+- Config-level criteria are tested outside this calculator suite: legal status (criterion 4) is the program row's `legal_status_required`, and Kansas routing (criterion 5) is the white label.
+- The committed data gaps have no executable scenarios, because the screener cannot observe them.
+- Section 8 / HCV has no executable Kansas scenario: no Kansas `section_8` program row exists.
+- LIEAP and household sizes 9–16 are covered by the binding implementation regressions below.
+
+**Binding implementation requirements**
+
+Both are committed build requirements for this program.
+
+1. **LIEAP current-benefit visibility.** Set `ks_lieap.show_in_has_benefits_step = true` and add an energy-assistance category to the Kansas current-benefits step. Until both land, no `CurrentBenefit` row for LIEAP can be written, `has_base_benefit("liheap")` is false on every Kansas screen, and criterion 3's LIEAP route cannot fire. Illinois, Colorado and North Carolina all carry an energy option; Kansas does not. Required regression once the input is enterable: an over-income Kansas household with current `ks_lieap` → **Eligible — $7,475**. It becomes ordinary core scenario coverage at that point.
+2. **Kansas household sizes 1–16.** The Kansas white label must permit household sizes 1–16 in both the household-size entry and the household-member flow; other white labels retain their existing maximum. `KsWap` must read the threshold through `program.year.get_limit(household_size)`. Required regression: ZIP `66603`, Shawnee County, household size 10, countable annual income $134,160 → **Eligible — $7,475**, with no error. Kansas's PolicyEngine-backed programs must also be exercised at sizes 9–16, since raising the cap sends them inputs they have never received.
+
+### Scenario 1: Four-person household under the income limit — Eligible, $7,475
+**What we're checking**: the reference case — income comfortably within the limit for the household's size.
+**Expected**: Eligible — $7,475
+**Household size**: `4`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1988, `birth_month` 3, income `wages` $60,000/yearly
+* Person 2 — `spouse`: `birth_year` 1990, `birth_month` 7, no income
+* Person 3 — `child`: `birth_year` 2016, `birth_month` 1, no income
+* Person 4 — `child`: `birth_year` 2019, `birth_month` 5, no income
+* Current benefits: none
+**Calculation**: $60,000 ≤ $66,000, the four-person limit.
+**Why this matters**: Confirms the income comparison runs and is neither inverted nor dropped.
+
+### Scenario 2: Four-person household exactly at the income limit — Eligible, $7,475
+**What we're checking**: the boundary is inclusive, income is summed across earners, and monthly income is annualized first.
+**Expected**: Eligible — $7,475
+**Household size**: `4`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1988, `birth_month` 3, income `wages` $4,000/monthly
+* Person 2 — `spouse`: `birth_year` 1990, `birth_month` 7, income `wages` $1,500/monthly
+* Person 3 — `child`: `birth_year` 2016, `birth_month` 1, no income
+* Person 4 — `child`: `birth_year` 2019, `birth_month` 5, no income
+* Current benefits: none
+**Calculation**: ($4,000 + $1,500) × 12 = $66,000, exactly the four-person limit, and the comparison is `<=`.
+**Why this matters**: Confirms the inclusive boundary, multi-member summation and monthly-to-yearly conversion all hold at once.
+
+### Scenario 3: Four-person household one dollar over the income limit — Ineligible
+**What we're checking**: the limit actually excludes, with no observable categorical route in play.
+**Expected**: Ineligible
+**Household size**: `4`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1988, `birth_month` 3, income `wages` $66,001/yearly
+* Person 2 — `spouse`: `birth_year` 1990, `birth_month` 7, no income
+* Person 3 — `child`: `birth_year` 2016, `birth_month` 1, no income
+* Person 4 — `child`: `birth_year` 2019, `birth_month` 5, no income
+* Current benefits: none
+**Calculation**: $66,001 > $66,000, the four-person limit.
+**Why this matters**: Confirms the income limit excludes when no categorical route applies.
+
+### Scenario 4: One-person household at the one-person limit — Eligible, $7,475
+**What we're checking**: the one-person entry of the poverty table, at its exact value.
+**Expected**: Eligible — $7,475
+**Household size**: `1`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1975, `birth_month` 2, income `wages` $31,920/yearly
+* Current benefits: none
+**Calculation**: $31,920 = $31,920, the one-person limit, and the comparison is `<=`.
+**Why this matters**: Pins the one-person poverty-table entry at $31,920.
+
+### Scenario 5: One-person household at a four-person income — Ineligible
+**What we're checking**: the limit is indexed to the household's own size, in the failing direction.
+**Expected**: Ineligible
+**Household size**: `1`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1975, `birth_month` 2, income `wages` $66,000/yearly
+* Current benefits: none
+**Calculation**: $66,000 > $31,920, the one-person limit. The same income is eligible at four people (scenario 2).
+**Why this matters**: Confirms the limit is indexed to `household_size` rather than to a constant.
+
+### Scenario 6: Household above the income limit receiving SSI — Eligible, $7,475
+**What we're checking**: categorical receipt substitutes for the income test rather than adding to it.
+**Expected**: Eligible — $7,475
+**Household size**: `2`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1962, `birth_month` 11, income `wages` $90,000/yearly
+* Person 2 — `spouse`: `birth_year` 1966, `birth_month` 11, no income
+* Current benefits: SSI (`ks_ssi`)
+**Calculation**: $90,000 > $43,280, the two-person limit; SSI receipt qualifies the household regardless.
+**Why this matters**: Confirms categorical SSI receipt bypasses the income test rather than being ANDed with it.
+
+### Scenario 7: Household above the income limit reporting SSI only as income — Eligible, $7,475
+**What we're checking**: SSI reported as an income stream counts, and the stream is found on any member rather than only the head.
+**Expected**: Eligible — $7,475
+**Household size**: `2`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1958, `birth_month` 11, income `wages` $39,000/yearly
+* Person 2 — `spouse`: `birth_year` 1960, `birth_month` 11, income `sSI` $11,000/yearly
+* Current benefits: none
+**Calculation**: $39,000 + $11,000 = $50,000 > $43,280, the two-person limit; the `sSI` stream qualifies the household regardless.
+**Why this matters**: Confirms the `sSI` income-stream route is checked on every member, not only the head of household.
+
+### Scenario 8: Household above the income limit receiving TANF — Eligible, $7,475
+**What we're checking**: the TANF route, which Kansas administers under the name TAF.
+**Expected**: Eligible — $7,475
+**Household size**: `3`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1992, `birth_month` 7, income `wages` $70,000/yearly
+* Person 2 — `child`: `birth_year` 2014, `birth_month` 12, no income
+* Person 3 — `child`: `birth_year` 2021, `birth_month` 2, no income
+* Current benefits: TANF (`ks_tanf`)
+**Calculation**: $70,000 > $54,640, the three-person limit; TANF receipt qualifies the household regardless.
+**Why this matters**: Confirms TANF is implemented as a categorical route alongside SSI, not instead of it.
+
+### Scenario 9: Household above the income limit receiving only SNAP — Ineligible
+**What we're checking**: SNAP is not a categorical route; other benefits do not bypass the income test.
+**Expected**: Ineligible
+**Household size**: `2`
+**Steps**:
+* Location: ZIP `67202`, county `Sedgwick County`
+* Person 1 — `headOfHousehold`: `birth_year` 1970, `birth_month` 5, income `wages` $55,000/yearly
+* Person 2 — `spouse`: `birth_year` 1972, `birth_month` 1, no income
+* Current benefits: SNAP (`ks_snap`)
+**Calculation**: $55,000 > $43,280, the two-person limit, and SNAP is not a Kansas categorical route.
+**Why this matters**: Prevents SNAP from being mistakenly included in Kansas's categorical-benefit list.
+
+### Scenario 10: Household with no income — Eligible, $7,475
+**What we're checking**: zero income is under the limit, not missing data.
+**Expected**: Eligible — $7,475
+**Household size**: `1`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1968, `birth_month` 7, no income
+* Current benefits: none
+**Calculation**: $0 ≤ $31,920, the one-person limit.
+**Why this matters**: Confirms absent income is treated as $0 rather than as missing data or an error.
+
+### Scenario 11: Household at the limit on wages, with child support and gifts received — Eligible, $7,475
+**What we're checking**: the two income types the DOE notice itself excludes are excluded.
+**Expected**: Eligible — $7,475
+**Household size**: `2`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1985, `birth_month` 3, income `wages` $43,280/yearly
+* Person 2 — `spouse`: `birth_year` 1987, `birth_month` 7, income `childSupport` $6,000/yearly, `gifts` $2,000/yearly
+* Current benefits: none
+**Calculation**: Countable income = $43,280, exactly the two-person limit; the $6,000 and $2,000 are excluded. Summing `["all"]` gives $51,280 and fails.
+**Why this matters**: Confirms the DOE policy exclusions for child support received and gifts are applied.
+
+### Scenario 12: Household at the limit with a working 16-year-old — Eligible, $7,475
+**What we're checking**: a minor's earned income and unemployment compensation are excluded.
+**Expected**: Eligible — $7,475
+**Household size**: `3`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1982, `birth_month` 6, income `wages` $54,640/yearly
+* Person 2 — `spouse`: `birth_year` 1984, `birth_month` 4, no income
+* Person 3 — `child`: `birth_year` 2010, `birth_month` 3, income `wages` $8,000/yearly, `unemployment` $2,000/yearly
+* Current benefits: none
+**Calculation**: Countable income = $54,640, exactly the three-person limit; the minor's $10,000 is excluded. Counting it gives $64,640 and fails.
+**Why this matters**: Confirms wages and unemployment are excluded by member age, not by stream type.
+
+### Scenario 13: Household one dollar over the limit on wages plus alimony — Ineligible
+**What we're checking**: alimony is countable — the exclusion list does not over-reach into the rest of its income category.
+**Expected**: Ineligible
+**Household size**: `2`
+**Steps**:
+* Location: ZIP `67202`, county `Sedgwick County`
+* Person 1 — `headOfHousehold`: `birth_year` 1979, `birth_month` 1, income `wages` $30,000/yearly
+* Person 2 — `spouse`: `birth_year` 1981, `birth_month` 8, income `alimony` $13,281/yearly
+* Current benefits: none
+**Calculation**: $30,000 + $13,281 = $43,281 > $43,280, the two-person limit. Excluding `alimony` leaves $30,000 and wrongly returns Eligible.
+**Why this matters**: Confirms `alimony` stays countable and is not excluded alongside the other `support` types.
+
+### Scenario 14: Household above the income limit reporting TANF as a `cashAssistance` income stream — Eligible, $7,475
+**What we're checking**: the TANF categorical route is found through the income stream, not only through the current-benefit tile.
+**Expected**: Eligible — $7,475
+**Household size**: `3`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1990, `birth_month` 5, income `wages` $70,000/yearly, `cashAssistance` $4,800/yearly
+* Person 2 — `child`: `birth_year` 2013, `birth_month` 2, no income
+* Person 3 — `child`: `birth_year` 2018, `birth_month` 11, no income
+* Current benefits: none
+**Calculation**: $70,000 + $4,800 = $74,800 > $54,640, the three-person limit; the `cashAssistance` stream qualifies the household regardless.
+**Why this matters**: Confirms TANF is detected through the `cashAssistance` stream, not only through the current-benefit tile.
+
+### Scenario 15: Household one dollar over the limit paying child support — Ineligible
+**What we're checking**: child support *paid* is not deducted from countable income.
+**Expected**: Ineligible
+**Household size**: `2`
+**Steps**:
+* Location: ZIP `67202`, county `Sedgwick County`
+* Person 1 — `headOfHousehold`: `birth_year` 1983, `birth_month` 2, income `wages` $43,281/yearly
+* Person 2 — `spouse`: `birth_year` 1985, `birth_month` 6, no income
+* Expenses: `childSupport` $9,000/yearly
+* Current benefits: none
+**Calculation**: Countable income = $43,281 > $43,280, the two-person limit. Deducting the $9,000 expense gives $34,281 and wrongly returns Eligible.
+**Why this matters**: Confirms paid child support is not deducted from countable income.
+
+### Scenario 16: Eight-person household at the eight-person limit — Eligible, $7,475
+**What we're checking**: the largest household the current screener can accept, at its exact limit.
+**Expected**: Eligible — $7,475
+**Household size**: `8`
+**Steps**:
+* Location: ZIP `66603`, county `Shawnee County`
+* Person 1 — `headOfHousehold`: `birth_year` 1981, `birth_month` 1, income `wages` $111,440/yearly
+* Person 2 — `spouse`: `birth_year` 1983, `birth_month` 3, no income
+* Person 3 — `child`: `birth_year` 2009, `birth_month` 1, no income
+* Person 4 — `child`: `birth_year` 2011, `birth_month` 1, no income
+* Person 5 — `child`: `birth_year` 2013, `birth_month` 1, no income
+* Person 6 — `child`: `birth_year` 2015, `birth_month` 1, no income
+* Person 7 — `child`: `birth_year` 2017, `birth_month` 1, no income
+* Person 8 — `child`: `birth_year` 2019, `birth_month` 1, no income
+* Current benefits: none
+**Calculation**: $111,440 = $111,440, the eight-person limit.
+**Why this matters**: Pins the eight-person poverty-table row at the top of the currently enterable range.
+
+---
+
+## Research Sources
+
+| Snapshot | Tier | Title | URL | Retrieved |
+|---|---|---|---|---|
+| `2026-08-26--42-usc-6862` | 1 | 42 U.S.C. 6862 — Definitions (Weatherization Assistance Program) | https://www.govinfo.gov/content/pkg/USCODE-2023-title42/html/USCODE-2023-title42-chap81-subchapIII-partA-sec6862.htm | 2026-08-26 |
+| `2026-08-26--doe-wap-poverty-income-guidelines-index` | 2 | DOE — WAP Poverty Income Guidelines (index) | https://www.energy.gov/cmei/scep/wap/poverty-income-guidelines | 2026-08-26 |
+| `2026-08-26--doe-wpn-22-5-v3-hud-categorical` | 2 | DOE WPN 22-5 v3 — Categorical eligibility for HUD means-tested programs | https://www.energy.gov/sites/default/files/2022-09/wpn-22-5_v3.pdf | 2026-08-26 |
+| `2026-08-26--doe-wpn-25-3-poverty-income-guidelines` | 2 | DOE WPN 25-3 — 2025 Federal Poverty Guidelines and Definition of Income | https://www.energy.gov/sites/default/files/2025-04/wap-wpn-25-3_041625_0.pdf | 2026-08-26 |
+| `2026-08-26--doe-wpn-25-4-usda-categorical` | 2 | DOE WPN 25-4 — Categorical eligibility for select USDA means-tested programs (effective 2024-12-30) | https://www.energy.gov/sites/default/files/2024-12/wap-wpn-25-4.pdf | 2026-08-26 |
+| `2026-08-26--doe-wpn-index` | 2 | DOE — Weatherization Program Notices and Memorandums (index) | https://www.energy.gov/cmei/scep/wap/weatherization-program-notices-and-memorandums | 2026-08-26 |
+| `2026-08-26--hhs-2026-poverty-guidelines` | 2 | HHS ASPE — 2026 Poverty Guidelines (detailed) | https://aspe.hhs.gov/sites/default/files/documents/b1bfa16b20ae9b89d525bc35de7c1643/detailed-guidelines-2026.pdf | 2026-08-26 |
+| `2026-08-26--kcc-utility-weatherization-north-central` | 2 | Kansas Corporation Commission — Utility & Weatherization Related Assistance Programs in North Central Kansas | https://www.kcc.ks.gov/public-affairs-and-consumer-protection/utility-weatherization-related-assistance-programs-in-north-central-kansas | 2026-08-26 |
+| `2026-08-26--keesm-13000-lieap` | 2 | KS DCF KEESM 13000 — Low Income Energy Assistance Program (LIEAP) | https://content.dcf.ks.gov/ees/keesm/current/keesm13000.htm | 2026-08-26 |
+| `2026-08-26--keesm-13500-k-wap` | 2 | KS DCF KEESM 13500 — The Kansas Weatherization Assistance Program (K-WAP) | https://content.dcf.ks.gov/ees/keesm/current/keesm13500.htm | 2026-08-26 |
+| `2026-08-26--khrc-online-weatherization-application` | 2 | Kansas Weatherization Assistance Program — online application form | https://kansasepp.formstack.com/forms/weatherization_application_ps | 2026-08-26 |
+| `2026-08-26--khrc-public-hearing-2026-state-plan` | 2 | KHRC — Public Hearing: 2026 Weatherization State Plan | https://kshousingcorp.org/events/public-hearing-2026-weatherization-state-plan/ | 2026-08-26 |
+| `2026-08-26--khrc-standardized-wx-application-2026-02-23` | 2 | KHRC Standardized Weatherization Application (2026-02-23) | https://kshousingcorp.org/wp-content/uploads/2024/06/Standardized-Weatherization-Application-2.23.26.pdf | 2026-08-26 |
+| `2026-08-26--khrc-weatherization-assistance` | 2 | KHRC — Weatherization Assistance | https://kshousingcorp.org/weatherization-assistance/ | 2026-08-26 |
+| `2026-08-26--khrc-weatherization-flyer-2026-02-24` | 2 | KHRC Weatherization flyer (2026-02-24) | https://kshousingcorp.org/wp-content/uploads/2025/08/Weatherization-Flyer-2.24.2026.pdf | 2026-08-26 |
+| `2026-08-26--khrc-wx-subrecipient-manual-2025v3` | 2 | KHRC Kansas WAP Subrecipient Procedure Manual 2025 v3 | https://kshousingcorp.org/wp-content/uploads/2025/09/final-2025v3-Wx-Subrecipient-Procedure-Manual.pdf | 2026-08-26 |
+| `2026-08-26--ks-weatherization-state-plan-2025-draft` | 2 | Kansas Weatherization State Plan 2025 (Draft) | https://kshousingcorp.org/wp-content/uploads/2025/03/2025-Weatherization-State-Plan-Draft.pdf | 2026-08-26 |
+| `2026-08-26--sckedd-kwap-application-2026` | 3 | SCKEDD — Kansas Weatherization Assistance Program application (2026) | https://www.sckedd.org/wp-content/uploads/2026/04/2026-KWAP-Application.pdf | 2026-08-26 |
+| `2026-09-02--10-cfr-440-14` | 1 | 10 CFR 440.14 | https://www.govinfo.gov/content/pkg/CFR-2025-title10-vol4/xml/CFR-2025-title10-vol4-sec440-14.xml | 2026-09-02 |
+| `2026-09-02--10-cfr-440-16` | 1 | 10 CFR 440.16 | https://www.govinfo.gov/content/pkg/CFR-2025-title10-vol4/xml/CFR-2025-title10-vol4-sec440-16.xml | 2026-09-02 |
+| `2026-09-02--10-cfr-440-18` | 1 | 10 CFR 440.18 | https://www.govinfo.gov/content/pkg/CFR-2025-title10-vol4/xml/CFR-2025-title10-vol4-sec440-18.xml | 2026-09-02 |
+| `2026-09-02--10-cfr-440-22` | 1 | 10 CFR 440.22 | https://www.govinfo.gov/content/pkg/CFR-2025-title10-vol4/xml/CFR-2025-title10-vol4-sec440-22.xml | 2026-09-02 |
+| `2026-09-02--10-cfr-440-3` | 1 | 10 CFR 440.3 — Definitions (Weatherization Assistance Program) | https://www.govinfo.gov/content/pkg/CFR-2025-title10-vol4/xml/CFR-2025-title10-vol4-sec440-3.xml | 2026-09-02 |

--- a/programs/programs/cross_white_label/weatherization/tests/test_ks.py
+++ b/programs/programs/cross_white_label/weatherization/tests/test_ks.py
@@ -173,7 +173,9 @@ class TestKsWapClassAttributes(KsWapTestCase):
         this calculator's configuration — Kansas's categorical list names SSI,
         TANF and LIEAP, and the DOE expansions reach HUD and USDA."""
         configured = (
-            set(KsWap.excluded_income_types) | set(KsWap.categorical_income_types) | set(KsWap.categorical_base_programs)
+            set(KsWap.excluded_income_types)
+            | set(KsWap.categorical_income_types)
+            | set(KsWap.categorical_base_programs)
         )
         self.assertNotIn("snap", {name.lower() for name in configured})
 

--- a/programs/programs/cross_white_label/weatherization/tests/test_ks.py
+++ b/programs/programs/cross_white_label/weatherization/tests/test_ks.py
@@ -758,10 +758,14 @@ class TestKsWapSpecScenarios(KsWapTestCase):
 class TestKsWapBindingImplementationRequirements(KsWapTestCase):
     """The two regressions specs/ks.md commits to as build requirements.
 
-    Both depend on inputs the screener cannot yet produce — the Kansas
-    has-benefits step has no energy-assistance tile, and the household-size
-    step caps at 8. The calculator side of each is implemented and pinned here;
-    the screener side is tracked separately."""
+    Requirement 1 is fully delivered: flipping `ks_lieap`'s has-benefits flag
+    made the input enterable, so its regression is reachable end to end.
+
+    Requirement 2 is delivered on the calculator side only. The screener caps
+    household size at 8 for every white label, so sizes 9 and up cannot be
+    entered and the two tests below them assert arithmetic no Kansas household
+    can currently reach. They stay because the arithmetic is this calculator's
+    to get right and is cheap to pin — not because the sizes are supported."""
 
     def test_lieap_route_admits_an_over_income_kansas_household(self):
         """Requirement 1. `ks_lieap.show_in_has_benefits_step` is flipped to

--- a/programs/programs/cross_white_label/weatherization/tests/test_ks.py
+++ b/programs/programs/cross_white_label/weatherization/tests/test_ks.py
@@ -1,0 +1,802 @@
+"""
+Unit tests for the KsWap calculator.
+
+Coverage maps to ``specs/ks.md`` — its four calculator-implemented criteria
+(1 income, 2 countable income, 3 categorical routes, 6 the household unit),
+its Benefit Value section, and one test per entry in its sixteen-scenario Test
+Scenarios list.
+
+Built on real ``Screen`` / ``HouseholdMember`` / ``IncomeStream`` / ``Expense`` /
+``CurrentBenefit`` rows rather than mocks. Almost every rule here is a question
+about income-type filtering (``calc_gross_income`` with ``exclude``, the ``all``
+aggregation, monthly-to-yearly conversion) or about an accessor (``calc_age``,
+``has_base_benefit``), so a mock standing in for those would assert the mock's
+own semantics rather than the calculator's.
+
+Ages are fixed integers rather than birth dates: the spec's scenarios state
+birth years and months, but deriving an age from ``timezone.now()`` would break
+the suite on a calendar boundary, and no rule here turns on the month.
+
+The income limits every scenario is measured against come from the program
+row's 2026 FPL pin, whose 200% figures reproduce KHRC's printed table exactly
+at every size from 1 to 16 — ``TestKsWapIncomeLimit`` pins that table directly.
+
+Not tested here, because the calculator does not implement them (see the class
+docstring):
+- Criterion 4 (at least one citizen or Qualified Alien) — the program's
+  ``legal_status_required`` config.
+- Criterion 5 (the dwelling is in Kansas) — white-label routing.
+- The HUD and USDA routes beyond Section 8, and cash assistance received
+  earlier in the preceding twelve months — all unscreenable, all recorded as
+  disclosure-only data gaps.
+- Priority order, occupancy, dwelling type, and the 15-year re-weatherization
+  bar — none affect eligibility or value.
+
+Every eligible household is worth a flat $7,475.
+"""
+
+from django.test import TestCase
+
+from programs.framework.base import Eligibility, ProgramCalculator
+from programs.framework.registry import build
+from programs.models import Program
+from programs.programs.cross_white_label.weatherization.ks import KsWap
+from programs.programs.testing_fixtures.pe_integration import (
+    add_income,
+    add_member,
+    make_program,
+    make_screen,
+)
+from screener.models import CurrentBenefit, Expense
+from screener.tests.helpers import seed_program
+
+YEAR = "2026"
+VALUE = 7_475
+
+#: 200% of the 2026 federal poverty guideline — the table KHRC prints on its
+#: own application. Every scenario below is positioned against one of these.
+LIMIT = {1: 31_920, 2: 43_280, 3: 54_640, 4: 66_000, 8: 111_440, 10: 134_160, 16: 202_320}
+
+
+class KsWapTestCase(TestCase):
+    """Household builder shared by every test below."""
+
+    # Distinct ids per household keep the members of one screen from colliding
+    # with another's when a test builds more than one.
+    next_screen_id = 1
+
+    def build(self, household_size, zipcode="66603", county="Shawnee County"):
+        screen = make_screen(
+            self.next_screen_id,
+            white_label_code="ks",
+            state_code="KS",
+            household_size=household_size,
+            zipcode=zipcode,
+            county=county,
+        )
+        # Reused rather than recreated: a test that builds more than one
+        # household (every subTest loop below) would otherwise collide on the
+        # program row's unique external_name.
+        existing = Program.objects.filter(white_label=screen.white_label, name_abbreviated="ks_wap").first()
+        self.program = existing or make_program("ks", "ks_wap", YEAR)
+        self.member_id = self.next_screen_id * 100
+        KsWapTestCase.next_screen_id += 1
+        return screen
+
+    def add_person(self, screen, relationship="headOfHousehold", age=40, **kwargs):
+        self.member_id += 1
+        return add_member(screen, self.member_id, relationship, age, **kwargs)
+
+    def add_yearly_income(self, member, income_type, amount):
+        return add_income(member, amount, income_type, "yearly")
+
+    def add_monthly_income(self, member, income_type, amount):
+        return add_income(member, amount, income_type, "monthly")
+
+    def add_expense(self, screen, expense_type, yearly_amount):
+        return Expense.objects.create(
+            screen=screen,
+            type=expense_type,
+            amount=yearly_amount,
+            frequency="yearly",
+        )
+
+    def receive_benefit(self, screen, name_abbreviated, base_program):
+        """Record `screen` as already receiving a benefit, the way the
+        has-benefits step does — a real Program row plus a CurrentBenefit link,
+        so `has_base_benefit` resolves it structurally."""
+        seed_program(screen.white_label, name_abbreviated, base_program=base_program)
+        program = Program.objects.get(white_label=screen.white_label, name_abbreviated=name_abbreviated)
+        CurrentBenefit.objects.create(screen=screen, program=program)
+        screen.invalidate_current_benefits_cache()
+
+    def calculator(self, screen):
+        return KsWap(screen, self.program, {}, screen.missing_fields())
+
+    def household_eligible(self, screen):
+        e = Eligibility()
+        self.calculator(screen).household_eligible(e)
+        return e
+
+    def result(self, screen):
+        return self.calculator(screen).calc()
+
+    def countable_income(self, screen):
+        return self.calculator(screen)._countable_income()
+
+    def single_earner(self, household_size=1, income_type="wages", amount=0, **screen_kwargs):
+        """The commonest shape: one adult with one yearly income stream."""
+        screen = self.build(household_size, **screen_kwargs)
+        member = self.add_person(screen)
+        if amount:
+            self.add_yearly_income(member, income_type, amount)
+        return screen, member
+
+
+class TestKsWapClassAttributes(KsWapTestCase):
+    def test_is_subclass_of_program_calculator(self):
+        self.assertTrue(issubclass(KsWap, ProgramCalculator))
+
+    def test_registered_under_ks_wap(self):
+        self.assertIs(build("programs.programs", ProgramCalculator).get("ks_wap"), KsWap)
+
+    def test_amount_is_7475_lump_sum(self):
+        # Kansas's published average program-operations cost per dwelling unit,
+        # $7,474.93 in the 2025 state plan, rounded to the dollar.
+        self.assertEqual(KsWap.amount, VALUE)
+
+    def test_fpl_percent_is_200(self):
+        self.assertEqual(KsWap.fpl_percent, 2)
+
+    def test_excluded_income_types(self):
+        self.assertEqual(
+            set(KsWap.excluded_income_types),
+            {"childSupport", "gifts", "selfEmployment", "rental", "boarder", "investment"},
+        )
+
+    def test_student_excluded_income_types_cover_earned_and_unemployment(self):
+        # `selfEmployment` is the third earned stream and is already excluded
+        # for every member, so it does not repeat here.
+        self.assertEqual(set(KsWap.student_excluded_income_types), {"wages", "unemployment"})
+
+    def test_minor_age_is_18(self):
+        self.assertEqual(KsWap.minor_age, 18)
+
+    def test_categorical_base_programs_cover_all_four_routes(self):
+        self.assertEqual(set(KsWap.categorical_base_programs), {"ssi", "tanf", "liheap", "section_8"})
+
+    def test_categorical_income_types_back_the_ssi_and_tanf_routes(self):
+        self.assertEqual(set(KsWap.categorical_income_types), {"sSI", "cashAssistance"})
+
+    def test_snap_is_not_a_pathway(self):
+        """Unlike tx_wap, cowap and wa_wap, no SNAP name appears anywhere in
+        this calculator's configuration — Kansas's categorical list names SSI,
+        TANF and LIEAP, and the DOE expansions reach HUD and USDA."""
+        configured = (
+            set(KsWap.excluded_income_types) | set(KsWap.categorical_income_types) | set(KsWap.categorical_base_programs)
+        )
+        self.assertNotIn("snap", {name.lower() for name in configured})
+
+    def test_income_fields_in_dependencies(self):
+        self.assertIn("household_size", KsWap.dependencies)
+        self.assertIn("income_amount", KsWap.dependencies)
+        self.assertIn("income_frequency", KsWap.dependencies)
+
+
+class TestKsWapIncomeLimit(KsWapTestCase):
+    """Criterion 1's table — 200% of the 2026 federal poverty guideline, which
+    is the table KHRC prints on its standardized application (revised
+    2026-02-23) at every size it publishes."""
+
+    #: KHRC's printed table verbatim, both of its interleaved columns.
+    KHRC_TABLE = {
+        1: 31_920,
+        2: 43_280,
+        3: 54_640,
+        4: 66_000,
+        5: 77_360,
+        6: 88_720,
+        7: 100_080,
+        8: 111_440,
+        9: 122_800,
+        10: 134_160,
+        11: 145_520,
+        12: 156_880,
+        13: 168_240,
+        14: 179_600,
+        15: 190_960,
+        16: 202_320,
+    }
+
+    def limit_for(self, household_size):
+        screen = self.build(household_size)
+        return self.calculator(screen)._income_limit()
+
+    def test_every_published_row(self):
+        """Sizes 9 and up are the reason the calculator reads `get_limit` rather
+        than indexing `as_dict()`: the dict holds explicit rows only to 8, and
+        the helper's per-additional-person extension reproduces KHRC's printed
+        figures for 9 through 16 exactly."""
+        for household_size, expected in self.KHRC_TABLE.items():
+            with self.subTest(household_size=household_size):
+                self.assertEqual(self.limit_for(household_size), expected)
+
+    def test_size_above_the_published_table_still_extends(self):
+        self.assertEqual(self.limit_for(17), self.KHRC_TABLE[16] + 2 * 5_680)
+
+    def test_null_household_size_yields_no_limit(self):
+        # Unreachable in production: household_size is a declared dependency,
+        # so can_calc() drops the program first. Pinned so the guard stays
+        # honest rather than raising or comparing against a fabricated row.
+        screen = self.build(1)
+        screen.household_size = None
+        self.assertIsNone(self.calculator(screen)._income_limit())
+
+
+class TestKsWapIncomeBoundary(KsWapTestCase):
+    """Criterion 1's comparator is inclusive of the exact limit."""
+
+    def eligible_at(self, amount, household_size=1):
+        screen, _ = self.single_earner(household_size=household_size, amount=amount)
+        return self.household_eligible(screen).eligible
+
+    def test_below_limit_eligible(self):
+        self.assertTrue(self.eligible_at(20_000))
+
+    def test_zero_income_eligible(self):
+        self.assertTrue(self.eligible_at(0))
+
+    def test_exactly_at_limit_eligible(self):
+        self.assertTrue(self.eligible_at(LIMIT[1]))
+
+    def test_one_dollar_over_limit_ineligible(self):
+        self.assertFalse(self.eligible_at(LIMIT[1] + 1))
+
+    def test_fractional_amount_over_limit_ineligible(self):
+        # Countable income is rounded to cents, not truncated — $0.50 over the
+        # limit must fail rather than being floored back onto it.
+        screen, member = self.single_earner(amount=LIMIT[1])
+        self.add_yearly_income(member, "pension", "0.50")
+        self.assertFalse(self.household_eligible(screen).eligible)
+
+    def test_income_failure_reports_the_limit(self):
+        screen, _ = self.single_earner(amount=LIMIT[1] + 1)
+        e = self.household_eligible(screen)
+        self.assertFalse(e.eligible)
+        self.assertIn(f" ${LIMIT[1]}", "".join(part for part in e.fail_messages[0] if isinstance(part, str)))
+
+    def test_null_household_size_passes_the_income_criterion_unmeasured(self):
+        # The limit is indexed to the size; with no size there is no row to
+        # compare against, so the criterion is met rather than guessed at — and
+        # no pass message claims a limit the household did not have to clear.
+        screen, _ = self.single_earner(amount=500_000)
+        screen.household_size = None
+        e = self.household_eligible(screen)
+        self.assertTrue(e.eligible)
+        self.assertEqual(e.pass_messages, [])
+
+
+class TestKsWapIncomeAggregation(KsWapTestCase):
+    """Criterion 6 — income is summed over the family unit as entered."""
+
+    def test_two_members_incomes_are_summed(self):
+        screen = self.build(2)
+        head = self.add_person(screen)
+        spouse = self.add_person(screen, "spouse")
+        self.add_yearly_income(head, "wages", 24_000)
+        self.add_yearly_income(spouse, "wages", 20_000)
+        self.assertEqual(self.countable_income(screen), 44_000)
+
+    def test_one_members_multiple_streams_are_summed(self):
+        screen, member = self.single_earner(amount=20_000)
+        self.add_yearly_income(member, "alimony", 5_000)
+        self.add_yearly_income(member, "sSRetirement", 3_000)
+        self.assertEqual(self.countable_income(screen), 28_000)
+
+
+class TestKsWapCountableIncomeExclusions(KsWapTestCase):
+    """Criterion 2 — DOE WPN 25-3's "Definition of Income" attachment, which
+    Kansas adopts wholesale rather than defining an income rule of its own."""
+
+    BASE = 20_000
+    ADDED = 5_000
+
+    def countable_with(self, income_type, member_kwargs=None):
+        screen = self.build(1)
+        member = self.add_person(screen, **(member_kwargs or {}))
+        self.add_yearly_income(member, "wages", self.BASE)
+        self.add_yearly_income(member, income_type, self.ADDED)
+        return self.countable_income(screen)
+
+    def test_excluded_types_do_not_count(self):
+        for income_type in KsWap.excluded_income_types:
+            with self.subTest(income_type=income_type):
+                self.assertEqual(self.countable_with(income_type), self.BASE)
+
+    def test_counted_types_do_count(self):
+        # Everything WPN 25-3 leaves countable at gross. `alimony` is the one
+        # the notice names explicitly (B.3, no netting question).
+        for income_type in (
+            "wages",
+            "alimony",
+            "unemployment",
+            "sSI",
+            "sSDisability",
+            "sSRetirement",
+            "sSSurvivor",
+            "sSDependent",
+            "cashAssistance",
+            "workersComp",
+            "veteran",
+            "pension",
+            "deferredComp",
+        ):
+            with self.subTest(income_type=income_type):
+                self.assertEqual(self.countable_with(income_type), self.BASE + self.ADDED)
+
+    def test_child_support_paid_is_not_deducted(self):
+        # Section E bars the deduction; the calculator reads no expenses at all.
+        screen, _ = self.single_earner(amount=self.BASE)
+        self.add_expense(screen, "childSupport", 12_000)
+        self.assertEqual(self.countable_income(screen), self.BASE)
+
+    def test_housing_expenses_are_not_deducted(self):
+        screen, _ = self.single_earner(amount=self.BASE)
+        self.add_expense(screen, "rent", 12_000)
+        self.assertEqual(self.countable_income(screen), self.BASE)
+
+    def test_monthly_streams_are_annualized(self):
+        screen = self.build(1)
+        member = self.add_person(screen)
+        self.add_monthly_income(member, "wages", 1_000)
+        self.assertEqual(self.countable_income(screen), 12_000)
+
+
+class TestKsWapStudentIncomeExclusion(KsWapTestCase):
+    """Criterion 2 / WPN 25-3 Section D.1 — earned income and unemployment
+    compensation come out for a member under 18, or for a full-time student of
+    any age. Their unearned income stays in."""
+
+    ADULT_WAGES = 20_000
+
+    def household_with_second_member(self, member_kwargs, streams):
+        screen = self.build(2)
+        head = self.add_person(screen)
+        self.add_yearly_income(head, "wages", self.ADULT_WAGES)
+        other = self.add_person(screen, "child", **member_kwargs)
+        for income_type, amount in streams:
+            self.add_yearly_income(other, income_type, amount)
+        return screen
+
+    def test_minor_wages_excluded(self):
+        screen = self.household_with_second_member({"age": 15}, [("wages", 1_800)])
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES)
+
+    def test_minor_unemployment_excluded(self):
+        screen = self.household_with_second_member({"age": 15}, [("unemployment", 600)])
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES)
+
+    def test_minor_unearned_income_still_counts(self):
+        # Section D.1 names earned income and unemployment compensation only.
+        screen = self.household_with_second_member({"age": 15}, [("sSI", 4_000)])
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES + 4_000)
+
+    def test_seventeen_year_old_is_a_minor(self):
+        screen = self.household_with_second_member({"age": 17}, [("wages", 9_000)])
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES)
+
+    def test_eighteen_year_old_who_is_not_a_student_counts(self):
+        # The age half of Section D.1 is "under the age of 18", exclusive.
+        screen = self.household_with_second_member({"age": 18}, [("wages", 9_000)])
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES + 9_000)
+
+    def test_full_time_student_is_excluded_at_any_age(self):
+        """Data Gap 6. Section D.1's "(or full-time high school students)"
+        clause is honoured for any full-time student, because MFB records no
+        level of schooling to distinguish high school from college. Excluding
+        too widely only lowers countable income, so it can only widen results
+        — never turn an eligible household ineligible."""
+        for age in (18, 19, 22, 45):
+            with self.subTest(age=age):
+                screen = self.household_with_second_member(
+                    {"age": age, "student": True, "student_full_time": True},
+                    [("wages", 9_000)],
+                )
+                self.assertEqual(self.countable_income(screen), self.ADULT_WAGES)
+
+    def test_part_time_student_counts(self):
+        screen = self.household_with_second_member(
+            {"age": 20, "student": True, "student_full_time": False},
+            [("wages", 9_000)],
+        )
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES + 9_000)
+
+    def test_full_time_flag_without_student_does_not_exclude(self):
+        """`student_full_time` is only meaningful alongside `student`. Nothing
+        enforces that server-side, so a direct API write can set the flag on a
+        non-student — whose wages Section D.1 still counts."""
+        for student in (False, None):
+            with self.subTest(student=student):
+                screen = self.household_with_second_member(
+                    {"age": 30, "student": student, "student_full_time": True},
+                    [("wages", 9_000)],
+                )
+                self.assertEqual(self.countable_income(screen), self.ADULT_WAGES + 9_000)
+
+    def test_unknown_age_counts_as_an_adult(self):
+        # The age disregard is granted on proof of age; an unproven one is not
+        # assumed.
+        screen = self.household_with_second_member({"age": None}, [("wages", 9_000)])
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES + 9_000)
+
+    def test_unknown_age_full_time_student_is_still_excluded(self):
+        # The student half of the clause does not depend on age at all.
+        screen = self.household_with_second_member(
+            {"age": None, "student": True, "student_full_time": True},
+            [("wages", 9_000)],
+        )
+        self.assertEqual(self.countable_income(screen), self.ADULT_WAGES)
+
+
+class TestKsWapCategoricalEligibility(KsWapTestCase):
+    """Criterion 3 — the routes that bypass the income test outright."""
+
+    OVER_LIMIT = 80_000
+
+    def over_income_household(self):
+        screen, member = self.single_earner(amount=self.OVER_LIMIT)
+        return screen, member
+
+    def test_over_income_alone_is_ineligible(self):
+        screen, _ = self.over_income_household()
+        self.assertFalse(self.household_eligible(screen).eligible)
+
+    def test_ssi_receipt_bypasses_the_income_test(self):
+        screen, _ = self.over_income_household()
+        self.receive_benefit(screen, "ks_ssi", "ssi")
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_ssi_income_stream_bypasses_the_income_test(self):
+        # The stream is a backstop to the current-benefit row: the
+        # single-benefit toggle endpoint does not re-derive the row, so a
+        # screen can carry the stream without it.
+        screen, member = self.over_income_household()
+        self.add_monthly_income(member, "sSI", 900)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_tanf_receipt_bypasses_the_income_test(self):
+        # Kansas administers TANF as TAF; one program row, `ks_tanf`, backs both.
+        screen, _ = self.over_income_household()
+        self.receive_benefit(screen, "ks_tanf", "tanf")
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_cash_assistance_income_stream_bypasses_the_income_test(self):
+        # MFB files TANF dollars under `cashAssistance` and never under `tanf`,
+        # so for TANF the stream test is required rather than a backstop.
+        screen, member = self.over_income_household()
+        self.add_monthly_income(member, "cashAssistance", 400)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_lieap_receipt_bypasses_the_income_test(self):
+        screen, _ = self.over_income_household()
+        self.receive_benefit(screen, "ks_lieap", "liheap")
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_section_8_receipt_bypasses_the_income_test(self):
+        # Wired ahead of the data: Kansas has no voucher row yet, so this
+        # pathway activates the day one is added.
+        screen, _ = self.over_income_household()
+        self.receive_benefit(screen, "ks_hcv", "section_8")
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_routes_are_matched_structurally_not_by_exact_name(self):
+        for name_abbreviated, base_program in (
+            ("ks_ssi", "ssi"),
+            ("ks_tanf", "tanf"),
+            ("ks_lieap", "liheap"),
+            ("ks_hcv", "section_8"),
+        ):
+            with self.subTest(base_program=base_program):
+                screen, _ = self.over_income_household()
+                self.receive_benefit(screen, name_abbreviated, base_program)
+                self.assertFalse(screen.has_benefit(base_program))
+                self.assertTrue(screen.has_base_benefit(base_program))
+
+    def test_another_members_ssi_stream_qualifies_the_household(self):
+        screen = self.build(2)
+        head = self.add_person(screen)
+        self.add_yearly_income(head, "wages", self.OVER_LIMIT)
+        child = self.add_person(screen, "child", age=10)
+        self.add_monthly_income(child, "sSI", 900)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_zero_amount_cash_assistance_stream_is_not_a_pathway(self):
+        screen, member = self.over_income_household()
+        self.add_yearly_income(member, "cashAssistance", 0)
+        self.assertFalse(self.household_eligible(screen).eligible)
+
+    def test_categorical_pathway_reports_presumed_eligibility(self):
+        screen, member = self.over_income_household()
+        self.add_monthly_income(member, "sSI", 900)
+        e = self.household_eligible(screen)
+        self.assertTrue(e.eligible)
+        self.assertEqual(e.pass_messages[0][0]["label"], "eligibility_message.presumptive_eligibility-0")
+
+    def test_snap_receipt_alone_is_not_a_pathway(self):
+        # True for tx_wap, cowap and wa_wap; deliberately false here.
+        screen, _ = self.over_income_household()
+        self.receive_benefit(screen, "ks_snap", "snap")
+        self.assertFalse(self.household_eligible(screen).eligible)
+
+    def test_categorical_route_does_not_require_the_income_test_too(self):
+        # The disjunction is OR, never AND: an under-income household with no
+        # benefit is eligible, and an over-income one with a benefit is too.
+        screen, _ = self.single_earner(amount=20_000)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+
+class TestKsWapValue(KsWapTestCase):
+    """Benefit Value — a flat $7,475 for every eligible household, and no
+    eligible-but-$0 result."""
+
+    def test_eligible_household_is_worth_7475(self):
+        screen, _ = self.single_earner(amount=20_000)
+        result = self.result(screen)
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, VALUE)
+
+    def test_ineligible_household_is_worth_nothing(self):
+        screen, _ = self.single_earner(amount=80_000)
+        result = self.result(screen)
+        self.assertFalse(result.eligible)
+        self.assertEqual(result.value, 0)
+
+    def test_categorically_eligible_household_is_worth_7475(self):
+        screen, member = self.single_earner(amount=80_000)
+        self.add_monthly_income(member, "sSI", 900)
+        result = self.result(screen)
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, VALUE)
+
+    def test_value_does_not_scale_with_household_size(self):
+        screen = self.build(4)
+        self.add_person(screen)
+        self.add_person(screen, "spouse")
+        self.add_person(screen, "child", age=8)
+        self.add_person(screen, "child", age=5)
+        result = self.result(screen)
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, VALUE)
+
+    def test_no_member_level_value(self):
+        self.assertEqual(KsWap.member_amount, 0)
+
+
+class TestKsWapNotGatedOn(KsWapTestCase):
+    """The calculator does not exclude a household on tenure, occupancy,
+    dwelling type, prior-weatherization history or priority status — none of
+    which it reads. Asserted as behaviour: a household with no housing expense,
+    no elderly/disabled/child member and no assets still passes."""
+
+    def test_bare_household_with_low_income_is_eligible(self):
+        screen = self.build(1)
+        self.add_person(screen, age=40, disabled=False, long_term_disability=False, visually_impaired=False)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+    def test_no_housing_or_utility_expense_required(self):
+        screen, _ = self.single_earner(amount=20_000)
+        self.assertEqual(screen.expenses.count(), 0)
+        self.assertTrue(self.household_eligible(screen).eligible)
+
+
+class TestKsWapSpecScenarios(KsWapTestCase):
+    """One test per entry in specs/ks.md's sixteen-scenario Test Scenarios
+    list. Location appears in each because the screener collects it, but it
+    never discriminates — criterion 5 is satisfied by the white label and
+    Kansas's coverage is statewide."""
+
+    def assert_eligible(self, screen):
+        result = self.result(screen)
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, VALUE)
+
+    def assert_ineligible(self, screen):
+        result = self.result(screen)
+        self.assertFalse(result.eligible)
+        self.assertEqual(result.value, 0)
+
+    def four_person_household(self, head_streams):
+        screen = self.build(4)
+        head = self.add_person(screen, age=38)
+        for income_type, amount, frequency in head_streams:
+            add_income(head, amount, income_type, frequency)
+        spouse = self.add_person(screen, "spouse", age=36)
+        self.add_person(screen, "child", age=10)
+        self.add_person(screen, "child", age=7)
+        return screen, head, spouse
+
+    def test_scenario_1_four_person_household_under_the_income_limit(self):
+        screen, _, _ = self.four_person_household([("wages", 60_000, "yearly")])
+        self.assertEqual(self.countable_income(screen), 60_000)
+        self.assert_eligible(screen)
+
+    def test_scenario_2_four_person_household_exactly_at_the_income_limit(self):
+        # Inclusive boundary, multi-member summation and monthly-to-yearly
+        # conversion, all at once.
+        screen, _, spouse = self.four_person_household([("wages", 4_000, "monthly")])
+        self.add_monthly_income(spouse, "wages", 1_500)
+        self.assertEqual(self.countable_income(screen), LIMIT[4])
+        self.assert_eligible(screen)
+
+    def test_scenario_3_four_person_household_one_dollar_over_the_income_limit(self):
+        screen, _, _ = self.four_person_household([("wages", LIMIT[4] + 1, "yearly")])
+        self.assert_ineligible(screen)
+
+    def test_scenario_4_one_person_household_at_the_one_person_limit(self):
+        screen, _ = self.single_earner(household_size=1, amount=LIMIT[1])
+        self.assertEqual(self.countable_income(screen), LIMIT[1])
+        self.assert_eligible(screen)
+
+    def test_scenario_5_one_person_household_at_a_four_person_income(self):
+        # The same income is eligible at four people (scenario 2), so the limit
+        # is indexed to household_size rather than to a constant.
+        screen, _ = self.single_earner(household_size=1, amount=LIMIT[4])
+        self.assert_ineligible(screen)
+
+    def test_scenario_6_household_above_the_income_limit_receiving_ssi(self):
+        screen = self.build(2)
+        head = self.add_person(screen, age=64)
+        self.add_yearly_income(head, "wages", 90_000)
+        self.add_person(screen, "spouse", age=60)
+        self.receive_benefit(screen, "ks_ssi", "ssi")
+        self.assertGreater(self.countable_income(screen), LIMIT[2])
+        self.assert_eligible(screen)
+
+    def test_scenario_7_household_above_the_income_limit_reporting_ssi_only_as_income(self):
+        # The stream is checked on every member, not only the head.
+        screen = self.build(2)
+        head = self.add_person(screen, age=68)
+        self.add_yearly_income(head, "wages", 39_000)
+        spouse = self.add_person(screen, "spouse", age=66)
+        self.add_yearly_income(spouse, "sSI", 11_000)
+        self.assertEqual(self.countable_income(screen), 50_000)
+        self.assertGreater(self.countable_income(screen), LIMIT[2])
+        self.assert_eligible(screen)
+
+    def test_scenario_8_household_above_the_income_limit_receiving_tanf(self):
+        screen = self.build(3)
+        head = self.add_person(screen, age=34)
+        self.add_yearly_income(head, "wages", 70_000)
+        self.add_person(screen, "child", age=12)
+        self.add_person(screen, "child", age=5)
+        self.receive_benefit(screen, "ks_tanf", "tanf")
+        self.assertGreater(self.countable_income(screen), LIMIT[3])
+        self.assert_eligible(screen)
+
+    def test_scenario_9_household_above_the_income_limit_receiving_only_snap(self):
+        screen = self.build(2, zipcode="67202", county="Sedgwick County")
+        head = self.add_person(screen, age=56)
+        self.add_yearly_income(head, "wages", 55_000)
+        self.add_person(screen, "spouse", age=54)
+        self.receive_benefit(screen, "ks_snap", "snap")
+        self.assertGreater(self.countable_income(screen), LIMIT[2])
+        self.assert_ineligible(screen)
+
+    def test_scenario_10_household_with_no_income(self):
+        # Absent income is $0, not missing data.
+        screen = self.build(1)
+        self.add_person(screen, age=58)
+        self.assertEqual(self.countable_income(screen), 0)
+        self.assert_eligible(screen)
+
+    def test_scenario_11_child_support_received_and_gifts_are_excluded(self):
+        screen = self.build(2)
+        head = self.add_person(screen, age=41)
+        self.add_yearly_income(head, "wages", LIMIT[2])
+        spouse = self.add_person(screen, "spouse", age=39)
+        self.add_yearly_income(spouse, "childSupport", 6_000)
+        self.add_yearly_income(spouse, "gifts", 2_000)
+        # Summing ["all"] gives $51,280 and fails.
+        self.assertEqual(self.countable_income(screen), LIMIT[2])
+        self.assert_eligible(screen)
+
+    def test_scenario_12_working_sixteen_year_olds_wages_and_unemployment_are_excluded(self):
+        screen = self.build(3)
+        head = self.add_person(screen, age=44)
+        self.add_yearly_income(head, "wages", LIMIT[3])
+        self.add_person(screen, "spouse", age=42)
+        child = self.add_person(screen, "child", age=16)
+        self.add_yearly_income(child, "wages", 8_000)
+        self.add_yearly_income(child, "unemployment", 2_000)
+        # Counting the minor's $10,000 gives $64,640 and fails.
+        self.assertEqual(self.countable_income(screen), LIMIT[3])
+        self.assert_eligible(screen)
+
+    def test_scenario_13_alimony_is_counted_and_flips_the_household_over(self):
+        screen = self.build(2, zipcode="67202", county="Sedgwick County")
+        head = self.add_person(screen, age=47)
+        self.add_yearly_income(head, "wages", 30_000)
+        spouse = self.add_person(screen, "spouse", age=45)
+        self.add_yearly_income(spouse, "alimony", 13_281)
+        # Excluding alimony leaves $30,000 and wrongly returns eligible.
+        self.assertEqual(self.countable_income(screen), LIMIT[2] + 1)
+        self.assert_ineligible(screen)
+
+    def test_scenario_14_tanf_reported_as_a_cash_assistance_income_stream(self):
+        screen = self.build(3)
+        head = self.add_person(screen, age=36)
+        self.add_yearly_income(head, "wages", 70_000)
+        self.add_yearly_income(head, "cashAssistance", 4_800)
+        self.add_person(screen, "child", age=13)
+        self.add_person(screen, "child", age=8)
+        self.assertGreater(self.countable_income(screen), LIMIT[3])
+        self.assert_eligible(screen)
+
+    def test_scenario_15_child_support_paid_is_not_deducted(self):
+        screen = self.build(2, zipcode="67202", county="Sedgwick County")
+        head = self.add_person(screen, age=43)
+        self.add_yearly_income(head, "wages", LIMIT[2] + 1)
+        self.add_person(screen, "spouse", age=41)
+        self.add_expense(screen, "childSupport", 9_000)
+        # Deducting the $9,000 expense gives $34,281 and wrongly returns eligible.
+        self.assertEqual(self.countable_income(screen), LIMIT[2] + 1)
+        self.assert_ineligible(screen)
+
+    def test_scenario_16_eight_person_household_at_the_eight_person_limit(self):
+        screen = self.build(8)
+        head = self.add_person(screen, age=45)
+        self.add_yearly_income(head, "wages", LIMIT[8])
+        self.add_person(screen, "spouse", age=43)
+        for age in (17, 15, 13, 11, 9, 7):
+            self.add_person(screen, "child", age=age)
+        self.assertEqual(self.countable_income(screen), LIMIT[8])
+        self.assert_eligible(screen)
+
+
+class TestKsWapBindingImplementationRequirements(KsWapTestCase):
+    """The two regressions specs/ks.md commits to as build requirements.
+
+    Both depend on inputs the screener cannot yet produce — the Kansas
+    has-benefits step has no energy-assistance tile, and the household-size
+    step caps at 8. The calculator side of each is implemented and pinned here;
+    the screener side is tracked separately."""
+
+    def test_lieap_route_admits_an_over_income_kansas_household(self):
+        """Requirement 1. `ks_lieap.show_in_has_benefits_step` is flipped to
+        true in this program's config import, which is what lets a Kansas
+        screen carry the CurrentBenefit row this reads."""
+        screen, _ = self.single_earner(household_size=1, amount=45_000)
+        self.receive_benefit(screen, "ks_lieap", "liheap")
+        self.assertGreater(self.countable_income(screen), LIMIT[1])
+        self.assert_eligible_at_full_value(screen)
+
+    def test_ten_person_household_at_the_ten_person_limit(self):
+        """Requirement 2, the calculator half. The screener caps household size
+        at 8 today, so this is unreachable through the UI until that cap is
+        raised for Kansas — but the threshold arithmetic is this calculator's
+        and is correct now."""
+        screen = self.build(10)
+        head = self.add_person(screen, age=45)
+        self.add_yearly_income(head, "wages", LIMIT[10])
+        self.add_person(screen, "spouse", age=44)
+        for age in (19, 17, 15, 13, 11, 9, 7, 5):
+            self.add_person(screen, "child", age=age)
+        self.assertEqual(self.calculator(screen)._income_limit(), LIMIT[10])
+        self.assert_eligible_at_full_value(screen)
+
+    def test_sixteen_person_household_at_the_sixteen_person_limit(self):
+        """The top of KHRC's printed table, which is the top of the range
+        requirement 2 asks Kansas to accept."""
+        screen = self.build(16)
+        head = self.add_person(screen, age=50)
+        self.add_yearly_income(head, "wages", LIMIT[16])
+        self.add_person(screen, "spouse", age=48)
+        for index in range(14):
+            self.add_person(screen, "child", age=20 + index)
+        self.assertEqual(self.calculator(screen)._income_limit(), LIMIT[16])
+        self.assert_eligible_at_full_value(screen)
+
+    def assert_eligible_at_full_value(self, screen):
+        result = self.result(screen)
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, VALUE)


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Implements [MFB-1067](https://linear.app/myfriendben/issue/MFB-1067/program-ks-weatherization-assistance-program) — KS Weatherization Assistance Program (`ks_wap`), part of the KS Launch.
- Discovery: [MFB-1298](https://linear.app/myfriendben/issue/MFB-1298/discovery-ks-weatherization-assistance-program). **The engine is MFB custom, not PolicyEngine.** The ticket body says to reuse PE's `il_ihwap`; discovery corrected that — `il_ihwap` is hard-scoped `defined_for = StateCode.IL` with Illinois-only parameters, PolicyEngine has no Kansas weatherization variable, and nothing in benefits-api references it. A PE route would need an upstream contribution.
- Follow-up filed: [MFB-1869](https://linear.app/myfriendben/issue/MFB-1869/investigation-should-the-screener-support-household-sizes-above-8) (household sizes above 8 — see Known limitations).

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- **`programs/programs/cross_white_label/weatherization/ks.py`** — new `KsWap`, `program_code = "ks_wap"`. Registration is automatic via the registry walk; no registry edit.
  - Eligibility is `(income ≤ 200% FPL) OR categorical`, never ANDed.
  - Income read through `program.year.get_limit(household_size)`, **not** `as_dict()[household_size]` — the dict holds explicit rows only to size 8 and Kansas publishes to 16. The 2026 FPL pin × 2 reproduces KHRC's printed table exactly at all 16 sizes ($31,920 … $202,320).
  - Countable income per DOE WPN 25-3: `childSupport` and `gifts` out as the notice's own policy exclusions; `selfEmployment`, `rental`, `boarder`, `investment` out as inclusive proxies for net figures MFB can't compute; `alimony` stays in. Earned income and unemployment disregarded for members under 18 and for full-time students at any age.
  - Categorical routes: `has_base_benefit` on `ssi` / `tanf` / `liheap` / `section_8`, plus the `sSI` and `cashAssistance` income streams as a backstop (MFB files TANF dollars under `cashAssistance` and never `tanf`, so for TANF the stream test is doing the whole job).
  - **SNAP is deliberately absent.** `tx_wap`, `cowap` and `wa_wap` all list it; Kansas's categorical set is SSI / TANF / LIEAP plus the DOE expansions to HUD and USDA. Copying a sibling would have silently over-admitted.
  - Flat **$7,475** (`lump_sum`) — Kansas's published average program-operations cost per dwelling unit, $7,474.93 in the 2025 state plan.
- **`programs/programs/cross_white_label/weatherization/specs/ks.md`** — the finalized discovery spec, verbatim.
- **`programs/programs/cross_white_label/weatherization/tests/test_ks.py`** — 77 tests.
- **`.../data/ks_wap_initial_config.json`** — the finalized discovery config, plus `"active": true`. The importer only sets `active` when the key is present, so the artifact as delivered would have imported the program **inactive**.
- **`.../data/ks_lieap_initial_config.json`** — `show_in_has_benefits_step` flipped to `true`.
- **`programs/migrations/0175_ks_lieap_on_has_benefits_step.py`** — flips the same flag on rows that already exist, since `--reconcile` is additive-only and can't change program fields.

### Why the `ks_lieap` change is in this PR

Criterion 3 admits a LIEAP household regardless of income — the route KHRC advertises most prominently. Kansas had no energy-assistance tile on the has-benefits step, so no `CurrentBenefit` row for LIEAP could ever be written and `has_base_benefit("liheap")` was false on every Kansas screen. Without the flag that route is dead code. Discovery made it a binding requirement of this program rather than a deferred follow-up.

No frontend work is needed: `AlreadyHasBenefits.tsx` groups whatever `/has_benefits_programs` returns by category, and the endpoint filters on `active=True, show_in_has_benefits_step=True`. Every other white label with a LIHEAP program (co, il, ma, nc, mo) already has its tile.

### Not on the has-benefits step

`ks_wap` stays `show_in_has_benefits_step: false`. No calculator keys off WAP receipt, and the categorical direction runs LIEAP/SSI/TANF → WAP, never the reverse (confirmed against current KHRC and KDCF policy, not training data).

## Testing

<!-- Steps needed to test this PR locally -->

- **Migrations to run:** `0175_ks_lieap_on_has_benefits_step` (data-only, idempotent, no-ops if the `ks_lieap` row is absent; reversible).
- **Configuration updates needed:** `python manage.py import_program_config programs/management/commands/import_program_config_data/data/ks_wap_initial_config.json` — run **after** this branch is deployed, since nothing at import time checks that a calculator exists for `has_calculator: true`. Dry-run is clean against current `main`.
- **Environment variables/settings to add:** none.
- **Manual testing steps:**
  - `venv/bin/python -m pytest programs/programs/cross_white_label/weatherization/tests/test_ks.py` → **77 passed**.
  - Verified end-to-end against the real imported `Program` row locally: 4-person household at $66,000 → eligible, $7,475; one dollar over → ineligible, $0.
  - Full suite: 4,108 passed, 80 failed. **All 80 pre-exist on `main`** (`test_assistant_context.py` 50, `test_nps.py` 30) — confirmed by stashing this branch and re-running. Unrelated to this work, but they're red on main and worth someone's attention.

### QA

API QA run against local on this branch: **18/18 pass** — all 16 spec scenarios on both eligibility and value ($7,475 flat), plus the two binding-requirement regressions. Results in `qa/MFB-1067-ks-wap-api-results.md` and summarised on the ticket. Negatives were verified to fail on the income condition with the exact expected figures rather than being dropped from the response, and every `current_benefits` name was confirmed to have persisted (scenario 9's SNAP in particular, which would otherwise pass for the wrong reason).

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- **Post-deployment scripts needed:** run `import_program_config` for `ks_wap_initial_config.json` on staging, then prod. Order matters — calculator first, config second.
- **Production config updates:** the migration flips `ks_lieap.show_in_has_benefits_step` automatically in every environment; no admin edit needed.
- **Admin updates needed:** none.
- **Notify team/users of:** the Kansas has-benefits step gains an energy-assistance (LIEAP) tile. Worth a heads-up to whoever QAs that step.

### Household size: what is and isn't supported

`get_limit()` extrapolates past size 8 correctly and is unit-tested at 10 and 16, but **8 is this program's effective maximum** because the screener will not accept more. The two oversized tests are kept as arithmetic guards, labelled as unreachable — they are not a claim of support.

I deliberately did **not** clamp to `min(household_size, 8)`. There is no hardcoded table here to truncate (unlike `ks_ccap`, which implements 2–8 from a source publishing 2–11), the extrapolation already reproduces KHRC's own printed rows, and a clamp would silently understate the limit for a large household the day the cap is raised.

Raising the cap is cross-cutting rather than KS-specific, which is why it is its own investigation: 12 calculators index `as_dict()[household_size]` and would `KeyError` above 8 — and since `screener/views.py` catches only `DependencyError`, that would 500 the **entire** eligibility response rather than dropping one program. HUD publishes AMI only for sizes 1–8 and the SMI service has its own `MAX_HOUSEHOLD_SIZE = 8`, so ~28 programs have no upstream limit to read above 8.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- **Known limitations:**
  - **Household sizes above 8 are not reachable, and the spec is amended to say so.** Discovery made "the KS white label must accept sizes 1–16" a binding requirement; only the calculator half ships here. The cap is a hardcoded `.lte(8)` in `benefits-calculator` (`HouseholdSize.tsx:48`) and is **not** per-white-label, so Kansas cannot be raised on its own — a Kansas household of 9+ cannot be screened at all. `specs/ks.md`, the `KsWap` docstring and the test class now record that explicitly rather than implying the range is live. Tracked in [MFB-1869](https://linear.app/myfriendben/issue/MFB-1869/investigation-should-the-screener-support-household-sizes-above-8).
  - The HUD, USDA and prior-12-months cash-assistance categorical routes are unobservable. Per the committed treatment, absence is not read as disproving eligibility, but neither is it inferred true — inferring it would resolve the disjunction for every Kansas household and make the income test dead code. They're disclosed in the program description instead.
  - `selfEmployment` / `rental` / `boarder` / `investment` being dropped in full is the one inclusive proxy that can produce an actionable false positive.
- **Future considerations:**
  - The `section_8` route is wired and inert — Kansas has no voucher row, so it activates on its own when `ks_hcv` ([MFB-1056](https://linear.app/myfriendben/issue/MFB-1056/program-ks-housing-choice-voucher-section-8)) lands.
  - Worth reviewing carefully: the **student income disregard applies at any age**, which differs from `mo_wap` (capped at 18). That's the KS spec's committed reading of WPN 25-3 D.1 — over-excluding only lowers countable income, so it widens results rather than producing a false negative.
  - The suite is mutation-checked: removing the student clause, flipping `<=` to `<`, and adding SNAP to the categorical list each break the tests that should break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

