### PR TITLE
MFB-1868: add Kansas and Missouri to the public state dropdown

### DIFF
--- a/configuration/tests.py
+++ b/configuration/tests.py
@@ -201,9 +201,9 @@ class TestStateOptionsConfiguration(SimpleTestCase):
     EXPECTED_CATALOG = {
         "co": True,
         "il": True,
-        "ks": False,
+        "ks": True,
         "ma": True,
-        "mo": False,
+        "mo": True,
         "nc": True,
         "tx": True,
         "wa": True,

--- a/configuration/white_labels/ks.py
+++ b/configuration/white_labels/ks.py
@@ -11,8 +11,8 @@ class KsConfigurationData(ConfigurationData):
     # BASIC INFORMATION
     # ==========================================================================================
 
-    # Reachable at /ks and offered to the 2-1-1 referrers, but not yet in the public dropdown.
-    publicly_launched = False
+    # Offered in the public state dropdown.
+    publicly_launched = True
 
     state = {"name": "Kansas"}
 

--- a/configuration/white_labels/mo.py
+++ b/configuration/white_labels/mo.py
@@ -11,8 +11,8 @@ class MoConfigurationData(ConfigurationData):
     # BASIC INFORMATION
     # ==========================================================================================
 
-    # Reachable at /mo and offered to the 2-1-1 referrers, but not yet in the public dropdown.
-    publicly_launched = False
+    # Offered in the public state dropdown.
+    publicly_launched = True
 
     state = {"name": "Missouri"}
 


### PR DESCRIPTION
## What

Adds Kansas and Missouri to the screener's "What is your state?" dropdown by flipping `publicly_launched` on their white label configs.

Resolves [MFB-1868](https://linear.app/myfriendben/issue/MFB-1868/add-ksmo-to-state-dropdown).

## Why this is the only change needed

The dropdown used to be a hardcoded frontend list, but #2187 made it data-driven: the frontend reads the `state_options` config, which `configuration/white_labels/__init__.py` derives from the white label registry, flagging each state with its `publicly_launched` value. The frontend keeps only a routability filter against `ALL_VALID_WHITE_LABELS`, which already contains `ks` and `mo`.

So there is no frontend PR to pair with this one, and no new config key.

The flag is opt-in on purpose — a state under construction can't reach the public dropdown by omission. KS and MO were previously reachable at `/ks` and `/mo` and offered to the KS/MO 2-1-1 referrers that name them explicitly; those referrers select from the whole catalog, not the public subset, so their scoped dropdowns are unaffected.

## Testing

- `configuration.tests` passes (12 tests). `TestStateOptionsConfiguration.EXPECTED_CATALOG` is pinned rather than re-derived from the flags, so updating it is the intended, deliberate edit that accompanies a launch.
- Verified the derived catalog directly — `state_options()` now returns Kansas and Missouri with `public: True`, in the existing alphabetical display order.
- `black` clean.

## Deploy note

`state_options` is written by `add_config`, which the release process runs, so the dropdown picks this up on deploy with no manual command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kansas and Missouri are now available for selection in the public state dropdown.
  * Missouri can now be accessed directly through the public state selection flow, in addition to existing access paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->